### PR TITLE
add mode annotation

### DIFF
--- a/common/src/main/java/dev/latvian/kubejs/CommonProperties.java
+++ b/common/src/main/java/dev/latvian/kubejs/CommonProperties.java
@@ -27,6 +27,7 @@ public class CommonProperties {
 	public boolean serverOnly;
 	public boolean announceReload;
 	public boolean invertClassLoader;
+	public String mode;
 
 	private CommonProperties() {
 		properties = new Properties();
@@ -46,6 +47,7 @@ public class CommonProperties {
 			hideServerScriptErrors = get("hideServerScriptErrors", false);
 			serverOnly = get("serverOnly", false);
 			announceReload = get("announceReload", true);
+			mode = get("mode", "default");
 			invertClassLoader = "true".equals(properties.getProperty("invertClassLoader")); // Advanced option, not recommended to be set to true
 
 			if (writeProperties) {

--- a/common/src/main/java/dev/latvian/kubejs/CommonProperties.java
+++ b/common/src/main/java/dev/latvian/kubejs/CommonProperties.java
@@ -27,7 +27,7 @@ public class CommonProperties {
 	public boolean serverOnly;
 	public boolean announceReload;
 	public boolean invertClassLoader;
-	public String mode;
+	public String packMode;
 
 	private CommonProperties() {
 		properties = new Properties();
@@ -47,7 +47,7 @@ public class CommonProperties {
 			hideServerScriptErrors = get("hideServerScriptErrors", false);
 			serverOnly = get("serverOnly", false);
 			announceReload = get("announceReload", true);
-			mode = get("mode", "default");
+			packMode = get("packmode", "default");
 			invertClassLoader = "true".equals(properties.getProperty("invertClassLoader")); // Advanced option, not recommended to be set to true
 
 			if (writeProperties) {

--- a/common/src/main/java/dev/latvian/kubejs/script/ScriptFileInfo.java
+++ b/common/src/main/java/dev/latvian/kubejs/script/ScriptFileInfo.java
@@ -24,6 +24,7 @@ public class ScriptFileInfo {
 	private final Map<String, String> properties;
 	private int priority;
 	private boolean ignored;
+	private String mode;
 
 	public ScriptFileInfo(ScriptPackInfo p, String f) {
 		pack = p;
@@ -33,6 +34,7 @@ public class ScriptFileInfo {
 		properties = new HashMap<>();
 		priority = 0;
 		ignored = false;
+		mode = "default";
 	}
 
 	@Nullable
@@ -60,6 +62,7 @@ public class ScriptFileInfo {
 
 			priority = Integer.parseInt(getProperty("priority", "0"));
 			ignored = getProperty("ignored", "false").equals("true");
+			mode = getProperty("mode", "default");
 			return null;
 		} catch (Throwable ex) {
 			return ex;
@@ -76,5 +79,9 @@ public class ScriptFileInfo {
 
 	public boolean isIgnored() {
 		return ignored;
+	}
+
+	public String getMode() {
+		return mode;
 	}
 }

--- a/common/src/main/java/dev/latvian/kubejs/script/ScriptFileInfo.java
+++ b/common/src/main/java/dev/latvian/kubejs/script/ScriptFileInfo.java
@@ -24,7 +24,7 @@ public class ScriptFileInfo {
 	private final Map<String, String> properties;
 	private int priority;
 	private boolean ignored;
-	private String mode;
+	private String packMode;
 
 	public ScriptFileInfo(ScriptPackInfo p, String f) {
 		pack = p;
@@ -34,7 +34,7 @@ public class ScriptFileInfo {
 		properties = new HashMap<>();
 		priority = 0;
 		ignored = false;
-		mode = "default";
+		packMode = "default";
 	}
 
 	@Nullable
@@ -62,7 +62,7 @@ public class ScriptFileInfo {
 
 			priority = Integer.parseInt(getProperty("priority", "0"));
 			ignored = getProperty("ignored", "false").equals("true");
-			mode = getProperty("mode", "default");
+			packMode = getProperty("packmode", "default");
 			return null;
 		} catch (Throwable ex) {
 			return ex;
@@ -81,7 +81,7 @@ public class ScriptFileInfo {
 		return ignored;
 	}
 
-	public String getMode() {
-		return mode;
+	public String getPackMode() {
+		return packMode;
 	}
 }

--- a/common/src/main/java/dev/latvian/kubejs/script/ScriptManager.java
+++ b/common/src/main/java/dev/latvian/kubejs/script/ScriptManager.java
@@ -1,5 +1,6 @@
 package dev.latvian.kubejs.script;
 
+import dev.latvian.kubejs.CommonProperties;
 import dev.latvian.kubejs.KubeJS;
 import dev.latvian.kubejs.KubeJSEvents;
 import dev.latvian.kubejs.KubeJSPlugin;
@@ -77,7 +78,8 @@ public class ScriptManager {
 
 			Throwable error = fileInfo.preload(scriptSource);
 
-			if (fileInfo.isIgnored()) {
+			String mode = fileInfo.getMode();
+			if (fileInfo.isIgnored() || (!mode.equals("default") && !mode.equals(CommonProperties.get().mode))) {
 				continue;
 			}
 

--- a/common/src/main/java/dev/latvian/kubejs/script/ScriptManager.java
+++ b/common/src/main/java/dev/latvian/kubejs/script/ScriptManager.java
@@ -78,8 +78,8 @@ public class ScriptManager {
 
 			Throwable error = fileInfo.preload(scriptSource);
 
-			String mode = fileInfo.getMode();
-			if (fileInfo.isIgnored() || (!mode.equals("default") && !mode.equals(CommonProperties.get().mode))) {
+			String packMode = fileInfo.getPackMode();
+			if (fileInfo.isIgnored() || (!packMode.equals("default") && !packMode.equals(CommonProperties.get().packMode))) {
 				continue;
 			}
 


### PR DESCRIPTION
As mentioned on discord [here](https://discord.com/channels/303440391124942858/615627049637380144/837630095174139905), I added a "annotation" for modes.
That way, you can set a mode to a script. If the mode does not match, it will be ignored. If no mode is set, the script will load anyways. 