### PR TITLE
Add function to set the name for ArmorMaterials

### DIFF
--- a/common/src/main/java/dev/latvian/kubejs/item/ModifiedArmorTier.java
+++ b/common/src/main/java/dev/latvian/kubejs/item/ModifiedArmorTier.java
@@ -25,6 +25,7 @@ public class ModifiedArmorTier implements ArmorMaterial {
 	private float toughness;
 	private float knockbackResistance;
 	private Optional<Ingredient> repairIngredient;
+	private String name;
 
 	public ModifiedArmorTier(ArmorMaterial p) {
 		parent = p;
@@ -33,6 +34,7 @@ public class ModifiedArmorTier implements ArmorMaterial {
 		repairIngredient = Optional.empty();
 		toughness = p.getToughness();
 		knockbackResistance = p.getKnockbackResistance();
+		name = p.getName();
 	}
 
 	@Override
@@ -86,7 +88,11 @@ public class ModifiedArmorTier implements ArmorMaterial {
 	@Override
 	@Environment(EnvType.CLIENT)
 	public String getName() {
-		return parent.getName();
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
 	}
 
 	@Override

--- a/common/src/main/java/dev/latvian/kubejs/item/ModifiedArmorTier.java
+++ b/common/src/main/java/dev/latvian/kubejs/item/ModifiedArmorTier.java
@@ -27,14 +27,14 @@ public class ModifiedArmorTier implements ArmorMaterial {
 	private Optional<Ingredient> repairIngredient;
 	private String name;
 
-	public ModifiedArmorTier(ArmorMaterial p) {
+	public ModifiedArmorTier(String id, ArmorMaterial p) {
 		parent = p;
 		enchantmentValue = p.getEnchantmentValue();
 		sound = p.getEquipSound();
 		repairIngredient = Optional.empty();
 		toughness = p.getToughness();
 		knockbackResistance = p.getKnockbackResistance();
-		name = p.getName();
+		name = id;
 	}
 
 	@Override

--- a/common/src/main/java/dev/latvian/kubejs/item/custom/ItemArmorTierEventJS.java
+++ b/common/src/main/java/dev/latvian/kubejs/item/custom/ItemArmorTierEventJS.java
@@ -14,7 +14,7 @@ import java.util.function.Consumer;
 public class ItemArmorTierEventJS extends EventJS {
 	public void add(String id, String parent, Consumer<ModifiedArmorTier> tier) {
 		ArmorMaterial material = ItemBuilder.ARMOR_TIERS.getOrDefault(parent, ArmorMaterials.IRON);
-		ModifiedArmorTier t = new ModifiedArmorTier(material);
+		ModifiedArmorTier t = new ModifiedArmorTier(id, material);
 		tier.accept(t);
 		ItemBuilder.ARMOR_TIERS.put(id, t);
 	}

--- a/common/src/main/java/dev/latvian/kubejs/item/custom/ItemArmorTierEventJS.java
+++ b/common/src/main/java/dev/latvian/kubejs/item/custom/ItemArmorTierEventJS.java
@@ -3,6 +3,7 @@ package dev.latvian.kubejs.item.custom;
 import dev.latvian.kubejs.event.EventJS;
 import dev.latvian.kubejs.item.ItemBuilder;
 import dev.latvian.kubejs.item.ModifiedArmorTier;
+import net.minecraft.world.item.ArmorMaterial;
 import net.minecraft.world.item.ArmorMaterials;
 
 import java.util.function.Consumer;
@@ -11,9 +12,14 @@ import java.util.function.Consumer;
  * @author LatvianModder
  */
 public class ItemArmorTierEventJS extends EventJS {
-	public void add(String id, Consumer<ModifiedArmorTier> tier) {
-		ModifiedArmorTier t = new ModifiedArmorTier(ArmorMaterials.IRON);
+	public void add(String id, String parent, Consumer<ModifiedArmorTier> tier) {
+		ArmorMaterial material = ItemBuilder.ARMOR_TIERS.getOrDefault(parent, ArmorMaterials.IRON);
+		ModifiedArmorTier t = new ModifiedArmorTier(material);
 		tier.accept(t);
 		ItemBuilder.ARMOR_TIERS.put(id, t);
+	}
+
+	public void add(String id, Consumer<ModifiedArmorTier> tier) {
+		add(id, "iron", tier);
 	}
 }


### PR DESCRIPTION
Hey,

`HumanoidArmorLayer.java` applies the texture based on the name of the material
Snippet from  `HumanoidArmorLayer.java`
```java
   @Deprecated
   private ResourceLocation getArmorLocation(ArmorItem p_241737_1_, boolean p_241737_2_, @Nullable String p_241737_3_) {
      String s = "textures/models/armor/" + p_241737_1_.getMaterial().getName() + "_layer_" + (p_241737_2_ ? 2 : 1) + (p_241737_3_ == null ? "" : "_" + p_241737_3_) + ".png";
      return (ResourceLocation)ARMOR_LOCATION_CACHE.computeIfAbsent(s, ResourceLocation::new);
   }
```

- Add `setName` so its possible to give the material a custom name. Default is the name of the given parent.
- Additional to this I added an option to pass a parent to the `ItemArmorTierEventJS` event. 

The textures for the armor needs to be in `./assets/minecraft/textures/models/armor/*.png` 

Result:
![image](https://user-images.githubusercontent.com/29131229/123121239-4aefe600-d445-11eb-9e22-a077e395be23.png)


Examples for a new material **conquest**:
```js
onEvent('item.registry.armor_tiers', event => {
	event.add("conquest", "netherite", (tier) => { });
});

// or
onEvent('item.registry.armor_tiers', event => {
	event.add("conquest", (tier) => { });
});
```