### PR TITLE
Add valid check for AddJEIEventJS

### DIFF
--- a/forge/src/main/java/dev/latvian/kubejs/integration/jei/AddJEIEventJS.java
+++ b/forge/src/main/java/dev/latvian/kubejs/integration/jei/AddJEIEventJS.java
@@ -7,7 +7,10 @@ import mezz.jei.api.runtime.IJeiRuntime;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 /**
  * @author LatvianModder
@@ -17,12 +20,14 @@ public class AddJEIEventJS<T> extends EventJS {
 	private final IIngredientType<T> type;
 	private final Function<Object, T> function;
 	private final Collection<T> added;
+	private final Predicate<T> isValid;
 
-	public AddJEIEventJS(IJeiRuntime r, IIngredientType<T> t, Function<Object, T> f) {
+	public AddJEIEventJS(IJeiRuntime r, IIngredientType<T> t, Function<Object, T> f, Predicate<T> i) {
 		runtime = r;
 		type = t;
 		function = f;
 		added = new ArrayList<>();
+		isValid = i;
 	}
 
 	public void add(Object o) {
@@ -38,7 +43,8 @@ public class AddJEIEventJS<T> extends EventJS {
 	@Override
 	protected void afterPosted(boolean result) {
 		if (!added.isEmpty()) {
-			runtime.getIngredientManager().addIngredientsAtRuntime(type, added);
+			List<T> items = added.stream().filter(isValid).collect(Collectors.toList());
+			runtime.getIngredientManager().addIngredientsAtRuntime(type, items);
 		}
 	}
 }

--- a/forge/src/main/java/dev/latvian/kubejs/integration/jei/JEIPlugin.java
+++ b/forge/src/main/java/dev/latvian/kubejs/integration/jei/JEIPlugin.java
@@ -52,8 +52,8 @@ public class JEIPlugin implements IModPlugin {
 		new YeetJEICategoriesEvent(runtime).post(ScriptType.CLIENT, JEIIntegration.JEI_YEET_CATEGORIES);
 		new YeetJEIRecipesEvent(runtime).post(ScriptType.CLIENT, JEIIntegration.JEI_YEET_RECIPES);
 
-		new AddJEIEventJS<>(runtime, VanillaTypes.ITEM, object -> ItemStackJS.of(object).getItemStack()).post(ScriptType.CLIENT, JEIIntegration.JEI_ADD_ITEMS);
-		new AddJEIEventJS<>(runtime, VanillaTypes.FLUID, object -> fromArchitectury(FluidStackJS.of(object).getFluidStack())).post(ScriptType.CLIENT, JEIIntegration.JEI_ADD_FLUIDS);
+		new AddJEIEventJS<>(runtime, VanillaTypes.ITEM, object -> ItemStackJS.of(object).getItemStack(), stack -> !stack.isEmpty()).post(ScriptType.CLIENT, JEIIntegration.JEI_ADD_ITEMS);
+		new AddJEIEventJS<>(runtime, VanillaTypes.FLUID, object -> fromArchitectury(FluidStackJS.of(object).getFluidStack()), stack -> !stack.isEmpty()).post(ScriptType.CLIENT, JEIIntegration.JEI_ADD_FLUIDS);
 	}
 
 	private FluidStack fromArchitectury(me.shedaniel.architectury.fluid.FluidStack stack) {


### PR DESCRIPTION
Reason: passing `minecraft:air` to the JEIRuntime kills the runtime

`HideJEIEventJS` already use a predicate to check if the stack is empty before passing it to JEI. This is missing in `AddJEIEventJS`