### PR TITLE
Recipes with NBT yeets previous recipes

### DIFF
--- a/common/src/main/java/dev/latvian/kubejs/item/ItemStackJS.java
+++ b/common/src/main/java/dev/latvian/kubejs/item/ItemStackJS.java
@@ -694,7 +694,7 @@ public abstract class ItemStackJS implements IngredientJS, NBTSerializable, Wrap
 		MapJS nbt = getNbt();
 
 		if (!nbt.isEmpty()) {
-			if (RecipeJS.currentRecipe != null && RecipeJS.currentRecipe.id != null && RecipeJS.currentRecipe.getMod().equals("techreborn")) {
+			if (RecipeJS.currentRecipe != null && RecipeJS.currentRecipe.type != null && RecipeJS.currentRecipe.type.getIdRL().getNamespace().equals("techreborn")) {
 				json.add("nbt", nbt.toJson());
 			} else {
 				json.addProperty("nbt", nbt.toNBT().toString());

--- a/common/src/main/java/dev/latvian/kubejs/item/ItemStackJS.java
+++ b/common/src/main/java/dev/latvian/kubejs/item/ItemStackJS.java
@@ -694,7 +694,7 @@ public abstract class ItemStackJS implements IngredientJS, NBTSerializable, Wrap
 		MapJS nbt = getNbt();
 
 		if (!nbt.isEmpty()) {
-			if (RecipeJS.currentRecipe != null && RecipeJS.currentRecipe.getMod().equals("techreborn")) {
+			if (RecipeJS.currentRecipe != null && RecipeJS.currentRecipe.id != null && RecipeJS.currentRecipe.getMod().equals("techreborn")) {
 				json.add("nbt", nbt.toJson());
 			} else {
 				json.addProperty("nbt", nbt.toNBT().toString());


### PR DESCRIPTION
If the NBT tag exists the code runs into the if statement and calls `RecipeJS.currentRecipe.getMod().equals("techreborn")` were `getMod()` creates a new id for the recipe. At this point the `json` of the recipe is just the type. With this every recipe create the same id and override the previous one. 

I added a null check for the id. The ID of the recipe should already exist at the moment we trying to check for a specific mod id. If I understand correct. 

Example code to reproduce: 
```js
onEvent("recipes", event => {
  event.shaped(Item.of('minecraft:potion', { Potion: "minecraft:water_breathing" }),
    ['FGF', 'GGG', 'FWF'],
    {
      F: 'minecraft:magma_cream',
      W: Item.of('minecraft:potion', { Potion: "minecraft:water" }),
      G: 'minecraft:stick'
    })

  event.shaped(Item.of('minecraft:diamond_sword', { Damage: 200 }),
    ['FFF', 'GWG', 'FGG'],
    {
      F: 'minecraft:carrot',
      W: Item.of('minecraft:potion', { Potion: "minecraft:water" }),
      G: 'minecraft:magma_cream'
    })

  event.shaped(Item.of('minecraft:diamond_sword', { Damage: 1000 }),
    ['FGF', 'GWG', 'FGF'],
    {
      F: 'minecraft:magma_cream',
      W: Item.of('minecraft:potion', { Potion: "minecraft:water" }),
      G: 'minecraft:iron_ingot'
    })

  event.shaped(Item.of('minecraft:potion', { Potion: 'minecraft:night_vision' }),
    ['FGF', 'GWG', 'FGF'],
    {
      F: 'minecraft:diamond',
      W: Item.of('minecraft:potion', { Potion: "minecraft:water" }),
      G: 'minecraft:magma_cream'
    })
})
```

Result before:
![image](https://user-images.githubusercontent.com/29131229/125964907-7817a2a8-9ff5-469c-b402-727cd79c681f.png)

After:
![image](https://user-images.githubusercontent.com/29131229/125965375-99fce27a-7301-4327-bcd6-7bf07ed27e99.png)
