### PR TITLE
Implement LivingEntityDropsExperienceEventJS for forge

### DIFF
--- a/common/src/main/java/dev/latvian/kubejs/KubeJSEvents.java
+++ b/common/src/main/java/dev/latvian/kubejs/KubeJSEvents.java
@@ -52,6 +52,7 @@ public class KubeJSEvents {
 	public static final String ENTITY_DEATH = "entity.death";
 	public static final String ENTITY_ATTACK = "entity.attack";
 	public static final String ENTITY_DROPS = "entity.drops";
+	public static final String ENTITY_DROPS_EXPERIENCE = "entity.drops.experience";
 	public static final String ENTITY_CHECK_SPAWN = "entity.check_spawn";
 	public static final String ENTITY_SPAWNED = "entity.spawned";
 

--- a/forge/src/main/java/dev/latvian/kubejs/entity/forge/LivingEntityDropsExperienceEventJS.java
+++ b/forge/src/main/java/dev/latvian/kubejs/entity/forge/LivingEntityDropsExperienceEventJS.java
@@ -1,0 +1,42 @@
+package dev.latvian.kubejs.entity.forge;
+
+import dev.latvian.kubejs.entity.EntityJS;
+import dev.latvian.kubejs.entity.LivingEntityEventJS;
+import dev.latvian.kubejs.player.PlayerJS;
+import net.minecraftforge.event.entity.living.LivingExperienceDropEvent;
+import org.jetbrains.annotations.Nullable;
+
+public class LivingEntityDropsExperienceEventJS extends LivingEntityEventJS {
+	private final LivingExperienceDropEvent event;
+
+	public LivingEntityDropsExperienceEventJS(LivingExperienceDropEvent event) {
+		this.event = event;
+	}
+
+	@Override
+	public boolean canCancel() {
+		return true;
+	}
+
+	@Override
+	public EntityJS getEntity() {
+		return entityOf(event.getEntity());
+	}
+
+	@Nullable
+	public PlayerJS<?> getAttacker() {
+		return getWorld().getPlayer(event.getAttackingPlayer());
+	}
+
+	public int getVanillaXp() {
+		return event.getOriginalExperience();
+	}
+
+	public int getXp() {
+		return event.getDroppedExperience();
+	}
+
+	public void setXp(int xp) {
+		event.setDroppedExperience(xp);
+	}
+}

--- a/forge/src/main/java/dev/latvian/kubejs/forge/KubeJSForge.java
+++ b/forge/src/main/java/dev/latvian/kubejs/forge/KubeJSForge.java
@@ -7,6 +7,7 @@ import dev.latvian.kubejs.block.forge.MissingMappingEventJS;
 import dev.latvian.kubejs.entity.ItemEntityJS;
 import dev.latvian.kubejs.entity.forge.CheckLivingEntitySpawnEventJS;
 import dev.latvian.kubejs.entity.forge.LivingEntityDropsEventJS;
+import dev.latvian.kubejs.entity.forge.LivingEntityDropsExperienceEventJS;
 import dev.latvian.kubejs.integration.IntegrationManager;
 import dev.latvian.kubejs.item.forge.ItemDestroyedEventJS;
 import dev.latvian.kubejs.script.ScriptType;
@@ -20,6 +21,7 @@ import net.minecraftforge.common.ForgeMod;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.event.entity.living.LivingDropsEvent;
+import net.minecraftforge.event.entity.living.LivingExperienceDropEvent;
 import net.minecraftforge.event.entity.living.LivingSpawnEvent;
 import net.minecraftforge.event.entity.player.PlayerDestroyItemEvent;
 import net.minecraftforge.eventbus.api.Event;
@@ -47,6 +49,7 @@ public class KubeJSForge {
 		MinecraftForge.EVENT_BUS.addListener(KubeJSForge::itemDestroyed);
 
 		MinecraftForge.EVENT_BUS.addListener(KubeJSForge::livingDrops);
+		MinecraftForge.EVENT_BUS.addListener(KubeJSForge::livingDropsExperience);
 		MinecraftForge.EVENT_BUS.addListener(KubeJSForge::checkLivingSpawn);
 
 		if (!CommonProperties.get().serverOnly) {
@@ -92,6 +95,18 @@ public class KubeJSForge {
 			for (ItemEntityJS ie : e.eventDrops) {
 				event.getDrops().add((ItemEntity) ie.minecraftEntity);
 			}
+		}
+	}
+
+	private static void livingDropsExperience(LivingExperienceDropEvent event) {
+		if(event.getEntity().level.isClientSide()) {
+			return;
+		}
+
+		LivingEntityDropsExperienceEventJS e = new LivingEntityDropsExperienceEventJS(event);
+		boolean result = e.post(KubeJSEvents.ENTITY_DROPS_EXPERIENCE);
+		if(result) {
+			event.setCanceled(true);
 		}
 	}
 


### PR DESCRIPTION
Using `LivingExperienceDropEvent` from forge to implement the event. 

Event is cancel able which will drop no experience for the player.
`getXp()` can return a different xp value if its modified before through other mods or events. 
`getVanillaXp()` will return the experience the mod will normally drop. 
