### PR TITLE
Implement getOriginalRecipeResult & getOriginalRecipeIngredients

### DIFF
--- a/common/src/main/java/dev/latvian/kubejs/recipe/RecipeJS.java
+++ b/common/src/main/java/dev/latvian/kubejs/recipe/RecipeJS.java
@@ -462,6 +462,24 @@ public abstract class RecipeJS {
 		return resultRecipe;
 	}
 
+	public ItemStackJS getOriginalRecipeResult() {
+		if(this.originalRecipe == null) {
+			ConsoleJS.SERVER.warn("Original recipe is null - could not get result");
+			return ItemStackJS.EMPTY;
+		}
+
+		return ItemStackJS.of(this.originalRecipe.getResultItem());
+	}
+
+	public List<IngredientJS> getOriginalRecipeIngredients() {
+		if(this.originalRecipe == null) {
+			ConsoleJS.SERVER.warn("Original recipe is null - could not get ingredients");
+			return new ArrayList<>();
+		}
+
+		return this.originalRecipe.getIngredients().stream().map(IngredientJS::of).collect(Collectors.toList());
+	}
+
 	/**
 	 * Only used when a recipe has sub-recipes, e.g. create:sequenced_assembly
 	 */


### PR DESCRIPTION
Based on this: https://discord.com/channels/303440391124942858/901216585434411069/901229239909625878

`inputItems` in `RecipeJS` returns a distinct list of ingredients. So a `stone_brick_stair` returns one input item.
```java
	public final List<IngredientJS> inputItems = new ArrayList<>(1);
```

`getOriginalRecipeIngredients` returns a list of non distinct ingredients by just returning the ingredient list of the original recipe. 