### PR TITLE
Fix for issue #218

### DIFF
--- a/common/src/main/java/dev/latvian/kubejs/entity/LivingEntityJS.java
+++ b/common/src/main/java/dev/latvian/kubejs/entity/LivingEntityJS.java
@@ -110,7 +110,7 @@ public class LivingEntityJS extends EntityJS {
 	}
 
 	public void swingArm(InteractionHand hand) {
-		minecraftLivingEntity.swing(hand);
+		minecraftLivingEntity.swing(hand,true);
 	}
 
 	public ItemStackJS getEquipment(EquipmentSlot slot) {


### PR DESCRIPTION
In regards to Issue https://github.com/KubeJS-Mods/KubeJS/issues/218
The animation for swingArm called from the server doesn't play for the client when LivingEntity.swing is false for the second parameter.
Changing it to true, makes it update on the client's side.
The swing seems to be "fake", as in if it doesn't act as if the client right/left click, but nearly swung the object in the main or off-hand.