### PR TITLE
Fix RecipeManager#byName not being populated by KubeJS

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/core/RecipeManagerKJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/core/RecipeManagerKJS.java
@@ -20,6 +20,10 @@ public interface RecipeManagerKJS {
 
 	void setRecipesKJS(Map<RecipeType<?>, Map<ResourceLocation, Recipe<?>>> map);
 
+	Map<ResourceLocation, Recipe<?>> getByNameKJS();
+
+	void setByNameKJS(Map<ResourceLocation, Recipe<?>> map);
+
 	default void customRecipesKJS(Map<ResourceLocation, JsonObject> jsonMap) {
 		if (RecipeEventJS.instance != null) {
 			RecipeEventJS.instance.post((RecipeManager) this, jsonMap);

--- a/common/src/main/java/dev/latvian/mods/kubejs/mixin/common/RecipeManagerMixin.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/mixin/common/RecipeManagerMixin.java
@@ -34,4 +34,12 @@ public abstract class RecipeManagerMixin implements RecipeManagerKJS {
 	@Override
 	@Accessor("recipes")
 	public abstract void setRecipesKJS(Map<RecipeType<?>, Map<ResourceLocation, Recipe<?>>> map);
+
+	@Override
+	@Accessor("byName")
+	public abstract Map<ResourceLocation, Recipe<?>> getByNameKJS();
+
+	@Override
+	@Accessor("byName")
+	public abstract void setByNameKJS(Map<ResourceLocation, Recipe<?>> map);
 }

--- a/common/src/main/java/dev/latvian/mods/kubejs/recipe/RecipeEventJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/recipe/RecipeEventJS.java
@@ -363,6 +363,15 @@ public class RecipeEventJS extends EventJS {
 
 		ConsoleJS.SERVER.info("Added recipes in " + timer.stop());
 		pingNewRecipes(newRecipeMap);
+		((RecipeManagerKJS) recipeManager).setByNameKJS(newRecipeMap.values().stream().flatMap(e -> e.entrySet().stream())
+				.collect(Collectors.toMap(
+						Map.Entry::getKey,
+						Map.Entry::getValue,
+						(a, b) -> {
+							ConsoleJS.SERVER.warn("Duplicate recipe id: " + a.getId());
+							return b;
+						}
+				)));
 		((RecipeManagerKJS) recipeManager).setRecipesKJS(newRecipeMap);
 		ConsoleJS.SERVER.info("Added " + added.getValue() + " recipes, removed " + removed.getValue() + " recipes, modified " + modifiedRecipesCount.get() + " recipes, with " + failed.getValue() + " failed recipes and " + fallbacked.getValue() + " fall-backed recipes");
 		RecipeJS.itemErrors = false;

--- a/common/src/main/java/dev/latvian/mods/kubejs/recipe/RecipesAfterLoadEventJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/recipe/RecipesAfterLoadEventJS.java
@@ -107,12 +107,15 @@ public class RecipesAfterLoadEventJS extends EventJS {
 			e.originalRecipes.removeAll(e.removedRecipes);
 
 			Map<RecipeType<?>, Map<ResourceLocation, Recipe<?>>> newMap = new HashMap<>();
+			Map<ResourceLocation, Recipe<?>> newByName = new HashMap<>();
 
 			for (var r : e.originalRecipes) {
 				newMap.computeIfAbsent(r.originalRecipe.getType(), t -> new HashMap<>()).put(r.id, r.originalRecipe);
+				newByName.put(r.id, r.originalRecipe);
 			}
 
 			recipeManager.setRecipesKJS(newMap);
+			recipeManager.setByNameKJS(newByName);
 		}
 	}
 }


### PR DESCRIPTION
Populate the byName map (new since 1.16) alongside the recipe map in RecipeManager.

Fixes the incompatibilities with other mods caused by this map being empty if KubeJS is installed.