### PR TITLE
Make PropertyObject public in BlockIDPredicate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,10 @@ name: Java CI
 
 on:
   push:
-    branches: [ main, dev ]
+    branches:
+      # main and dev versions for each mc ver here
+      - "1.16/main"
+      - "1.16/dev"
   workflow_dispatch:
     inputs:
       norelease:
@@ -27,6 +30,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 30 # Gets the last 30 commits so the changelog might work
+      # Always run on Java 16, Loom needs it
       - name: Set up JDK 16
         uses: actions/setup-java@v2
         with:
@@ -41,11 +45,11 @@ jobs:
           ./gradlew build publish --stacktrace --no-daemon
       - name: Release to CurseForge
         if: |
-          github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, '[norelease]') && github.event.inputs.norelease != 'true'
+          contains(github.ref, 'main') && !contains(github.event.head_commit.message, '[norelease]') && github.event.inputs.norelease != 'true'
         env:
           GIT_COMMIT: ${{ github.event.after }}
           GIT_PREVIOUS_COMMIT: ${{ github.event.before }}
           CURSEFORGE_KEY: ${{ secrets.CURSEFORGE_KEY }}
         run: |
           chmod +x ./gradlew
-          ./gradlew build curseforgePublish --stacktrace --no-daemon
+          ./gradlew build curseforge --stacktrace --no-daemon

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ repositories {
 
     maven {
         // saps.dev Maven (KubeJS and Rhino)
-        // you can also use Lat's Maven @ https://maven.latvian.dev/
         url = "https://maven.saps.dev/minecraft"
         content {
             includeGroup "dev.latvian.mods"
@@ -57,17 +56,17 @@ modImplementation("dev.latvian.mods:kubejs-<loader>:${kubejs_version}")
 implementation fg.deobf("dev.latvian.mods:kubejs-forge:${kubejs_version}")
 
 // these two are unfortunately needed since fg.deobf doesn't respect transitive dependencies as of yet
-implementation "dev.latvian.mods:rhino:${rhino_version}"
+implementation fg.deobf("dev.latvian.mods:rhino:${rhino_version}")
 implementation fg.deobf("me.shedaniel:architectury-forge:${architectury_version}")
 ```
 
 Just set the versions with most up-to-date version of the required mod(s), which you also find using these badges:
 
 <p align="center">
-    <a href="https://maven.saps.dev/versions">
+    <a href="https://vers.saps.dev">
         <img src="https://flat.badgen.net/maven/v/metadata-url/https/mvn.saps.dev/minecraft/dev/latvian/mods/kubejs/maven-metadata.xml?color=C186E6&label=KubeJS" alt="KubeJS Latest Version">
     </a>
-	<a href="https://maven.saps.dev/versions">
+	<a href="https://vers.saps.dev">
         <img src="https://flat.badgen.net/maven/v/metadata-url/https/mvn.saps.dev/minecraft/dev/latvian/mods/rhino/maven-metadata.xml?color=3498DB&label=Rhino" alt="Rhino Latest Version">
     </a>
 		<a href="https://niceme.me">

--- a/common/src/main/java/dev/latvian/kubejs/block/BlockBuilder.java
+++ b/common/src/main/java/dev/latvian/kubejs/block/BlockBuilder.java
@@ -4,6 +4,7 @@ import com.google.gson.JsonObject;
 import dev.latvian.kubejs.block.custom.BasicBlockType;
 import dev.latvian.kubejs.block.custom.BlockType;
 import dev.latvian.kubejs.loot.LootBuilder;
+import dev.latvian.kubejs.script.ScriptType;
 import dev.latvian.kubejs.util.BuilderBase;
 import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
 import me.shedaniel.architectury.registry.BlockProperties;
@@ -79,7 +80,7 @@ public class BlockBuilder extends BuilderBase {
 		color = new Int2IntOpenHashMap();
 		color.defaultReturnValue(0xFFFFFFFF);
 		textures = new JsonObject();
-		texture(id.getNamespace() + ":block/" + id.getPath());
+		textureAll(id.getNamespace() + ":block/" + id.getPath());
 		model = "";
 		itemBuilder = new BlockItemBuilder(i);
 		itemBuilder.blockBuilder = this;
@@ -172,22 +173,28 @@ public class BlockBuilder extends BuilderBase {
 		return this;
 	}
 
+	@Deprecated
 	public BlockBuilder texture(String tex) {
+		ScriptType.STARTUP.console.warn("Using 'texture(tex)' in block builders is deprecated! Please use 'textureAll(tex)' instead!");
+		return textureAll(tex);
+	}
+
+	public BlockBuilder textureAll(String tex) {
 		for (Direction direction : Direction.values()) {
-			textures.addProperty(direction.getSerializedName(), tex);
+			textureSide(direction, tex);
 		}
 
 		textures.addProperty("particle", tex);
 		return this;
 	}
 
+	public BlockBuilder textureSide(Direction direction, String tex) {
+		return texture(direction.getSerializedName(), tex);
+	}
+
 	public BlockBuilder texture(String id, String tex) {
 		textures.addProperty(id, tex);
 		return this;
-	}
-
-	public BlockBuilder texture(Direction direction, String tex) {
-		return texture(direction.getSerializedName(), tex);
 	}
 
 	public BlockBuilder model(String m) {

--- a/common/src/main/java/dev/latvian/kubejs/block/predicate/BlockIDPredicate.java
+++ b/common/src/main/java/dev/latvian/kubejs/block/predicate/BlockIDPredicate.java
@@ -19,9 +19,17 @@ import java.util.Optional;
  * @author LatvianModder
  */
 public class BlockIDPredicate implements BlockPredicate {
-	private static class PropertyObject {
+	public static class PropertyObject {
 		private Property<?> property;
 		private Object value;
+
+		public Property<?> getProperty() {
+			return property;
+		}
+
+		public Object getValue() {
+			return value;
+		}
 	}
 
 	private final ResourceLocation id;

--- a/common/src/main/java/dev/latvian/kubejs/core/TagCollectionKJS.java
+++ b/common/src/main/java/dev/latvian/kubejs/core/TagCollectionKJS.java
@@ -18,6 +18,7 @@ public interface TagCollectionKJS<T> {
 		String c = getResourceLocationPrefixKJS().substring(5);
 		String t = getItemTypeNameKJS();
 		new TagEventJS<T>(c, map, getRegistryKJS()).post(t + ".tags");
+		new TagEventJS<T>(c, map, getRegistryKJS()).post("tags." + c);
 	}
 
 	Function<ResourceLocation, Optional<T>> getRegistryKJS();

--- a/common/src/main/java/dev/latvian/kubejs/item/ModifiedArmorTier.java
+++ b/common/src/main/java/dev/latvian/kubejs/item/ModifiedArmorTier.java
@@ -9,7 +9,7 @@ import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.item.ArmorMaterial;
 import net.minecraft.world.item.crafting.Ingredient;
 
-import java.util.Optional;
+import java.util.function.Supplier;
 
 /**
  * @author LatvianModder
@@ -24,14 +24,14 @@ public class ModifiedArmorTier implements ArmorMaterial {
 	private SoundEvent sound;
 	private float toughness;
 	private float knockbackResistance;
-	private Optional<Ingredient> repairIngredient;
+	private Supplier<Ingredient> repairIngredient;
 	private String name;
 
 	public ModifiedArmorTier(String id, ArmorMaterial p) {
 		parent = p;
 		enchantmentValue = p.getEnchantmentValue();
 		sound = p.getEquipSound();
-		repairIngredient = Optional.empty();
+		repairIngredient = parent::getRepairIngredient;
 		toughness = p.getToughness();
 		knockbackResistance = p.getKnockbackResistance();
 		name = id;
@@ -78,11 +78,11 @@ public class ModifiedArmorTier implements ArmorMaterial {
 	@Override
 	@RemapForJS("getVanillaRepairIngredient")
 	public Ingredient getRepairIngredient() {
-		return repairIngredient.orElse(parent.getRepairIngredient());
+		return repairIngredient.get();
 	}
 
 	public void setRepairIngredient(IngredientJS in) {
-		repairIngredient = Optional.of(in.createVanillaIngredient());
+		repairIngredient = in::createVanillaIngredient;
 	}
 
 	@Override

--- a/common/src/main/java/dev/latvian/kubejs/item/ModifiedToolTier.java
+++ b/common/src/main/java/dev/latvian/kubejs/item/ModifiedToolTier.java
@@ -5,7 +5,7 @@ import dev.latvian.mods.rhino.util.RemapForJS;
 import net.minecraft.world.item.Tier;
 import net.minecraft.world.item.crafting.Ingredient;
 
-import java.util.Optional;
+import java.util.function.Supplier;
 
 /**
  * @author LatvianModder
@@ -17,7 +17,7 @@ public class ModifiedToolTier implements Tier {
 	private float attackDamageBonus;
 	private int level;
 	private int enchantmentValue;
-	private Optional<Ingredient> repairIngredient;
+	private Supplier<Ingredient> repairIngredient;
 
 	public ModifiedToolTier(Tier p) {
 		parent = p;
@@ -26,7 +26,7 @@ public class ModifiedToolTier implements Tier {
 		attackDamageBonus = parent.getAttackDamageBonus();
 		level = parent.getLevel();
 		enchantmentValue = parent.getEnchantmentValue();
-		repairIngredient = Optional.empty();
+		repairIngredient = parent::getRepairIngredient;
 	}
 
 	@Override
@@ -82,10 +82,10 @@ public class ModifiedToolTier implements Tier {
 	@Override
 	@RemapForJS("getVanillaRepairIngredient")
 	public Ingredient getRepairIngredient() {
-		return repairIngredient.orElse(parent.getRepairIngredient());
+		return repairIngredient.get();
 	}
 
 	public void setRepairIngredient(IngredientJS in) {
-		repairIngredient = Optional.of(in.createVanillaIngredient());
+		repairIngredient = in::createVanillaIngredient;
 	}
 }

--- a/common/src/main/java/dev/latvian/kubejs/item/custom/ArmorItemType.java
+++ b/common/src/main/java/dev/latvian/kubejs/item/custom/ArmorItemType.java
@@ -26,6 +26,5 @@ public class ArmorItemType extends ItemType {
 	public void applyDefaults(ItemBuilder builder) {
 		super.applyDefaults(builder);
 		builder.unstackable();
-		builder.maxDamage(300);
 	}
 }

--- a/common/src/main/java/dev/latvian/kubejs/item/custom/ToolItemType.java
+++ b/common/src/main/java/dev/latvian/kubejs/item/custom/ToolItemType.java
@@ -36,7 +36,6 @@ public class ToolItemType extends ItemType {
 		builder.attackDamageBaseline = attackDamageBaseline;
 		builder.attackSpeedBaseline = attackSpeedBaseline;
 		builder.unstackable();
-		builder.maxDamage(300);
 	}
 
 	@Override

--- a/common/src/main/java/dev/latvian/kubejs/item/ingredient/IgnoreNBTIngredientJS.java
+++ b/common/src/main/java/dev/latvian/kubejs/item/ingredient/IgnoreNBTIngredientJS.java
@@ -61,4 +61,10 @@ public final class IgnoreNBTIngredientJS implements IngredientJS {
 
 		return json;
 	}
+
+	@Override
+	public String toString() {
+		String stack = item.toString().replaceAll("^'(.*)'$", "Item.of($1)");
+		return stack + ".ignoreNBT()";
+	}
 }

--- a/common/src/main/java/dev/latvian/kubejs/item/ingredient/IngredientWithCustomPredicateJS.java
+++ b/common/src/main/java/dev/latvian/kubejs/item/ingredient/IngredientWithCustomPredicateJS.java
@@ -90,6 +90,6 @@ public class IngredientWithCustomPredicateJS implements IngredientJS {
 
 	@Override
 	public String toString() {
-		return ingredient.toString();
+		return ingredient + " (with custom predicate)";
 	}
 }

--- a/common/src/main/java/dev/latvian/kubejs/item/ingredient/NotIngredientJS.java
+++ b/common/src/main/java/dev/latvian/kubejs/item/ingredient/NotIngredientJS.java
@@ -37,4 +37,9 @@ public final class NotIngredientJS implements IngredientJS {
 	public boolean isInvalidRecipeIngredient() {
 		return ingredientJS.isInvalidRecipeIngredient();
 	}
+
+	@Override
+	public String toString() {
+		return "!" + ingredientJS;
+	}
 }

--- a/common/src/main/java/dev/latvian/kubejs/item/ingredient/WeakNBTIngredientJS.java
+++ b/common/src/main/java/dev/latvian/kubejs/item/ingredient/WeakNBTIngredientJS.java
@@ -101,4 +101,11 @@ public final class WeakNBTIngredientJS implements IngredientJS {
 
 		return json;
 	}
+
+	@Override
+	public String toString() {
+		String stack = item.toString().replaceAll("^'(.*)'$", "Item.of($1)");
+		return stack + ".weakNBT()";
+
+	}
 }

--- a/common/src/main/java/dev/latvian/kubejs/script/data/KubeJSResourcePack.java
+++ b/common/src/main/java/dev/latvian/kubejs/script/data/KubeJSResourcePack.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -41,6 +42,7 @@ public abstract class KubeJSResourcePack implements PackResources {
 
 	public KubeJSResourcePack(PackType t) {
 		packType = t;
+		Objects.requireNonNull(KubeJS.instance, "KubeJS has not been initialized, this won't happen unless some OTHER mod failed to load first! Check your latest.log!");
 	}
 
 	private static String getFullPath(PackType type, ResourceLocation location) {

--- a/common/src/main/java/dev/latvian/kubejs/server/KubeJSServerEventHandler.java
+++ b/common/src/main/java/dev/latvian/kubejs/server/KubeJSServerEventHandler.java
@@ -95,8 +95,8 @@ public class KubeJSServerEventHandler {
 		new ServerEventJS().post(ScriptType.SERVER, KubeJSEvents.SERVER_LOAD);
 
 		for (ServerWorldJS world : ServerJS.instance.worlds) {
-			new AttachWorldDataEvent(ServerJS.instance.getOverworld()).invoke();
-			new SimpleWorldEventJS(ServerJS.instance.getOverworld()).post(KubeJSEvents.WORLD_LOAD);
+			new AttachWorldDataEvent(world).invoke();
+			new SimpleWorldEventJS(world).post(KubeJSEvents.WORLD_LOAD);
 		}
 	}
 

--- a/common/src/main/java/dev/latvian/kubejs/util/ConsoleJS.java
+++ b/common/src/main/java/dev/latvian/kubejs/util/ConsoleJS.java
@@ -62,7 +62,7 @@ public class ConsoleJS {
 			if (x != null && skipString != null && skipString.matcher(x).find()) {
 				skip = true;
 			} else {
-				console.log(console.logger::error, "ERR ", x);
+				console.log(console.logger::error, "ERR  ", x);
 			}
 		}
 	}
@@ -229,11 +229,11 @@ public class ConsoleJS {
 	}
 
 	public void info(Object message) {
-		log(logger::info, "INFO", message);
+		log(logger::info, "INFO ", message);
 	}
 
 	public void infof(Object message, Object... args) {
-		logf(logger::info, "INFO", message, args);
+		logf(logger::info, "INFO ", message, args);
 	}
 
 	public void log(Object message) {
@@ -244,7 +244,7 @@ public class ConsoleJS {
 		log(s -> {
 			logger.warn(s);
 			type.warnings.add(s);
-		}, "WARN", message);
+		}, "WARN ", message);
 	}
 
 	public void warn(String message, Throwable throwable, @Nullable Pattern skip) {
@@ -268,14 +268,14 @@ public class ConsoleJS {
 		logf(s -> {
 			logger.warn(s);
 			type.warnings.add(s);
-		}, "WARN", message, args);
+		}, "WARN ", message, args);
 	}
 
 	public void error(Object message) {
 		log(s -> {
 			logger.error(s);
 			type.errors.add(s);
-		}, "ERR ", message);
+		}, "ERR  ", message);
 	}
 
 	public void error(String message, Throwable throwable, @Nullable Pattern skip) {
@@ -299,7 +299,7 @@ public class ConsoleJS {
 		logf(s -> {
 			logger.error(s);
 			type.errors.add(s);
-		}, "ERR ", message, args);
+		}, "ERR  ", message, args);
 	}
 
 	public boolean shouldPrintDebug() {


### PR DESCRIPTION
As `BlockIDPredicate::getBlockProperties` is public and returns a list of `PropertyObject` it would be nice if it's public too to have access to it from the outside. For an example a plugin. 