### PR TITLE
Fix for anonymous class mixin in RegistryReadOps

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/core/RegistryGetterKJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/core/RegistryGetterKJS.java
@@ -3,7 +3,9 @@ package dev.latvian.mods.kubejs.core;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceLocation;
 
-public interface RegistryGetterKJS<E> {
+import java.util.function.Supplier;
+
+public interface RegistryGetterKJS<E> extends Supplier<E> {
 	Registry<E> getRegistry();
 
 	ResourceLocation getId();

--- a/common/src/main/java/dev/latvian/mods/kubejs/mixin/common/RegistryGetterSupplierMixin.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/mixin/common/RegistryGetterSupplierMixin.java
@@ -2,30 +2,42 @@ package dev.latvian.mods.kubejs.mixin.common;
 
 import dev.latvian.mods.kubejs.core.RegistryGetterKJS;
 import net.minecraft.core.Registry;
+import net.minecraft.resources.RegistryReadOps;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
-import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-// FIXME: THISISTERRIBLETHISISTERRIBLETHISISTERRIBLETHISISTERRIBLETHISISTERRIBLE
-@Mixin(targets = "net.minecraft.resources.RegistryReadOps$1")
+import java.util.function.Supplier;
+
+@Mixin(RegistryReadOps.class)
 public abstract class RegistryGetterSupplierMixin<E> implements RegistryGetterKJS<E> {
-	@Shadow
-	@Final
-	Registry<E> val$registry;
+	@Inject(method = "createRegistryGetter", at = @At(value = "RETURN"), cancellable = true)
+	private static <E> void delegateRegistryGetter(Registry<E> registry, ResourceKey<E> resourceKey, CallbackInfoReturnable<Supplier<E>> cir) {
+		Supplier<E> delegate = cir.getReturnValue();
+		RegistryGetterKJS<E> registryGetter = new RegistryGetterKJS<>() {
+			@Override
+			public E get() {
+				return delegate.get();
+			}
 
-	@Shadow
-	@Final
-	ResourceKey<E> val$elementKey;
+			@Override
+			public Registry<E> getRegistry() {
+				return registry;
+			}
 
-	@Override
-	public Registry<E> getRegistry() {
-		return val$registry;
-	}
+			@Override
+			public ResourceLocation getId() {
+				return resourceKey.location();
+			}
 
-	@Override
-	public ResourceLocation getId() {
-		return val$elementKey.location();
+			@Override
+			public String toString() {
+				return delegate.toString();
+			}
+		};
+		cir.setReturnValue(registryGetter);
 	}
 }


### PR DESCRIPTION
Hey,

short fix for the `RegistryReadOps`. Instead of mixin the anonymous class it injects into `createRegistryGetter` and creates a new custom `Supplier<T>`. 
Fix needed because the mixin could not be applied in a dev environment when having kubejs as dependency. 

Tested just on fabric rn with https://pste.ch/oyecewefic.js as the forge build just don't want to run based on the dependency error. 

`event.removeFeatureById('underground_ores', ['minecraft:ore_coal_upper', 'minecraft:ore_coal_lower'])` still removes the ore as intended.