### PR TITLE
Added more functions for ItemBuilder

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/item/ItemBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/item/ItemBuilder.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.ToIntFunction;
 
 /**
  * @author LatvianModder
@@ -63,6 +64,8 @@ public abstract class ItemBuilder extends BuilderBase<Item> {
 	public String texture;
 	public String parentModel;
 	public transient FoodBuilder foodBuilder;
+	public transient Function<ItemStackJS, Color> barColor;
+	public transient ToIntFunction<ItemStackJS> barWidth;
 
 	public JsonObject modelJson;
 
@@ -194,6 +197,16 @@ public abstract class ItemBuilder extends BuilderBase<Item> {
 		return this;
 	}
 
+	public ItemBuilder barColor(Function<ItemStackJS, Color> barColor) {
+		this.barColor = barColor;
+		return this;
+	}
+
+	public ItemBuilder barWidth(ToIntFunction<ItemStackJS> barWidth) {
+		this.barWidth = barWidth;
+		return this;
+	}
+
 	public ItemBuilder food(Consumer<FoodBuilder> b) {
 		foodBuilder = new FoodBuilder();
 		b.accept(foodBuilder);
@@ -225,4 +238,5 @@ public abstract class ItemBuilder extends BuilderBase<Item> {
 
 		return properties;
 	}
+
 }

--- a/common/src/main/java/dev/latvian/mods/kubejs/mixin/common/ItemMixin.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/mixin/common/ItemMixin.java
@@ -4,6 +4,7 @@ import dev.architectury.registry.fuel.FuelRegistry;
 import dev.latvian.mods.kubejs.KubeJSRegistries;
 import dev.latvian.mods.kubejs.core.ItemKJS;
 import dev.latvian.mods.kubejs.item.ItemBuilder;
+import dev.latvian.mods.kubejs.item.ItemStackJS;
 import dev.latvian.mods.rhino.util.RemapForJS;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.food.FoodProperties;
@@ -13,8 +14,10 @@ import net.minecraft.world.item.Rarity;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.gen.Accessor;
 import org.spongepowered.asm.mixin.injection.At;
@@ -29,6 +32,9 @@ import java.util.List;
  */
 @Mixin(value = Item.class, priority = 1001)
 public abstract class ItemMixin implements ItemKJS {
+	@Shadow
+	@Final
+	public static int MAX_BAR_WIDTH;
 	@Unique
 	private ItemBuilder itemBuilderKJS;
 
@@ -95,6 +101,27 @@ public abstract class ItemMixin implements ItemKJS {
 	private void appendHoverText(ItemStack stack, @Nullable Level level, List<Component> tooltip, TooltipFlag flagIn, CallbackInfo ci) {
 		if (itemBuilderKJS != null && !itemBuilderKJS.tooltip.isEmpty()) {
 			tooltip.addAll(itemBuilderKJS.tooltip);
+		}
+	}
+
+	@Inject(method = "isBarVisible", at = @At("HEAD"), cancellable = true)
+	private void isBarVisible(ItemStack stack, CallbackInfoReturnable<Boolean> ci) {
+		if (itemBuilderKJS != null && itemBuilderKJS.barWidth != null && itemBuilderKJS.barWidth.applyAsInt(ItemStackJS.of(stack)) <= MAX_BAR_WIDTH) {
+			ci.setReturnValue(true);
+		}
+	}
+
+	@Inject(method = "getBarWidth", at = @At("HEAD"), cancellable = true)
+	private void getBarWidth(ItemStack stack, CallbackInfoReturnable<Integer> ci) {
+		if (itemBuilderKJS != null && itemBuilderKJS.barWidth != null) {
+			ci.setReturnValue(itemBuilderKJS.barWidth.applyAsInt(ItemStackJS.of(stack)));
+		}
+	}
+
+	@Inject(method = "getBarColor", at = @At("HEAD"), cancellable = true)
+	private void getBarColor(ItemStack stack, CallbackInfoReturnable<Integer> ci) {
+		if (itemBuilderKJS != null && itemBuilderKJS.barColor != null) {
+			ci.setReturnValue(itemBuilderKJS.barColor.apply(ItemStackJS.of(stack)).getRgbKJS());
 		}
 	}
 }


### PR DESCRIPTION
Added support to change the behavior of durability bar:

```javascript
event.create("hammer")
        //Determine how long the bar is, should be an integer between 0 (empty) and 13 (full)
        //If the value is below 0, it will be treated as 0.
        //The value is capped at 13, any value over 13 will be considered "full", thus making it not shown
        .barWidth(i => i.nbt.contains("hit_count") ? i.nbt.getInt("hit_count") / 13.0 : 0)
        //Determine what color should the bar be.
        .barColor(i => Color.AQUA)
```

The "default ItemStack" support was removed as `.getDefaultInstance()` actually has no usage currently.