### PR TITLE
Add ItemPropertiesEventJS

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/KubeJSEvents.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/KubeJSEvents.java
@@ -82,6 +82,7 @@ public interface KubeJSEvents {
 	String ITEM_FOOD_EATEN = "item.food_eaten";
 	String ITEM_TOOLTIP = "item.tooltip";
 	String ITEM_MODIFICATION = "item.modification";
+	String ITEM_PROPERTIES = "item.properties";
 
 	String SOUND_REGISTRY = "sound.registry";
 }

--- a/common/src/main/java/dev/latvian/mods/kubejs/KubeJSEvents.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/KubeJSEvents.java
@@ -82,7 +82,7 @@ public interface KubeJSEvents {
 	String ITEM_FOOD_EATEN = "item.food_eaten";
 	String ITEM_TOOLTIP = "item.tooltip";
 	String ITEM_MODIFICATION = "item.modification";
-	String ITEM_PROPERTIES = "item.properties";
+	String ITEM_MODEL_PROPERTIES = "item.model_properties";
 
 	String SOUND_REGISTRY = "sound.registry";
 }

--- a/common/src/main/java/dev/latvian/mods/kubejs/client/KubeJSClientEventHandler.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/client/KubeJSClientEventHandler.java
@@ -17,6 +17,7 @@ import dev.latvian.mods.kubejs.client.painter.screen.ScreenPaintEventJS;
 import dev.latvian.mods.kubejs.client.painter.world.WorldPaintEventJS;
 import dev.latvian.mods.kubejs.core.ImageButtonKJS;
 import dev.latvian.mods.kubejs.fluid.FluidPlatformHelper;
+import dev.latvian.mods.kubejs.item.ItemPropertiesEventJS;
 import dev.latvian.mods.kubejs.item.ItemTooltipEventJS;
 import dev.latvian.mods.kubejs.level.ClientLevelJS;
 import dev.latvian.mods.kubejs.script.AttachDataEvent;
@@ -80,6 +81,7 @@ public class KubeJSClientEventHandler {
 		for (var builder : RegistryObjectBuilderTypes.ALL_BUILDERS) {
 			builder.clientRegistry(minecraft);
 		}
+		new ItemPropertiesEventJS().post(KubeJSEvents.ITEM_PROPERTIES);
 	}
 
 	private void debugInfoLeft(List<String> lines) {

--- a/common/src/main/java/dev/latvian/mods/kubejs/client/KubeJSClientEventHandler.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/client/KubeJSClientEventHandler.java
@@ -17,7 +17,7 @@ import dev.latvian.mods.kubejs.client.painter.screen.ScreenPaintEventJS;
 import dev.latvian.mods.kubejs.client.painter.world.WorldPaintEventJS;
 import dev.latvian.mods.kubejs.core.ImageButtonKJS;
 import dev.latvian.mods.kubejs.fluid.FluidPlatformHelper;
-import dev.latvian.mods.kubejs.item.ItemPropertiesEventJS;
+import dev.latvian.mods.kubejs.item.ItemModelPropertiesEventJS;
 import dev.latvian.mods.kubejs.item.ItemTooltipEventJS;
 import dev.latvian.mods.kubejs.level.ClientLevelJS;
 import dev.latvian.mods.kubejs.script.AttachDataEvent;
@@ -81,7 +81,7 @@ public class KubeJSClientEventHandler {
 		for (var builder : RegistryObjectBuilderTypes.ALL_BUILDERS) {
 			builder.clientRegistry(minecraft);
 		}
-		new ItemPropertiesEventJS().post(KubeJSEvents.ITEM_PROPERTIES);
+		new ItemModelPropertiesEventJS().post(KubeJSEvents.ITEM_MODEL_PROPERTIES);
 	}
 
 	private void debugInfoLeft(List<String> lines) {

--- a/common/src/main/java/dev/latvian/mods/kubejs/item/ItemModelPropertiesEventJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/item/ItemModelPropertiesEventJS.java
@@ -13,7 +13,7 @@ import net.minecraft.resources.ResourceLocation;
 
 import javax.annotation.Nullable;
 
-public class ItemPropertiesEventJS extends StartupEventJS {
+public class ItemModelPropertiesEventJS extends StartupEventJS {
 	public void register(IngredientJS ingredient, String overwriteId, ItemPropertiesCallback callback) {
 		if (ingredient instanceof MatchAllIngredientJS) {
 			registerAll(overwriteId, callback);

--- a/common/src/main/java/dev/latvian/mods/kubejs/item/ItemPropertiesEventJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/item/ItemPropertiesEventJS.java
@@ -1,0 +1,43 @@
+package dev.latvian.mods.kubejs.item;
+
+import dev.architectury.registry.item.ItemPropertiesRegistry;
+import dev.latvian.mods.kubejs.KubeJS;
+import dev.latvian.mods.kubejs.core.EntityKJS;
+import dev.latvian.mods.kubejs.entity.EntityJS;
+import dev.latvian.mods.kubejs.event.StartupEventJS;
+import dev.latvian.mods.kubejs.item.ingredient.IngredientJS;
+import dev.latvian.mods.kubejs.item.ingredient.MatchAllIngredientJS;
+import dev.latvian.mods.kubejs.level.LevelJS;
+import net.minecraft.client.renderer.item.ClampedItemPropertyFunction;
+import net.minecraft.resources.ResourceLocation;
+
+import javax.annotation.Nullable;
+
+public class ItemPropertiesEventJS extends StartupEventJS {
+	public void register(IngredientJS ingredient, String overwriteId, ItemPropertiesCallback callback) {
+		if (ingredient instanceof MatchAllIngredientJS) {
+			registerAll(overwriteId, callback);
+		} else {
+			ingredient.getStacks().forEach(stack -> {
+				ItemPropertiesRegistry.register(stack.getItem(), new ResourceLocation(KubeJS.appendModId(overwriteId)), wrap(callback));
+			});
+		}
+	}
+
+	public void registerAll(String overwriteId, ItemPropertiesCallback callback) {
+		ItemPropertiesRegistry.registerGeneric(new ResourceLocation(KubeJS.appendModId(overwriteId)), wrap(callback));
+	}
+
+	private ClampedItemPropertyFunction wrap(ItemPropertiesCallback callback) {
+		return (itemStack, level, entity, id) -> {
+			LevelJS levelJS = level == null ? null : KubeJS.PROXY.getLevel(level);
+			EntityJS entityJS = entity == null ? null : (EntityJS) ((EntityKJS) entity).asKJS();
+			return callback.accept(ItemStackJS.of(itemStack), levelJS, entityJS, id);
+		};
+	}
+
+	@FunctionalInterface
+	public interface ItemPropertiesCallback {
+		float accept(ItemStackJS stack, @Nullable LevelJS level, @Nullable EntityJS entity, int id);
+	}
+}


### PR DESCRIPTION
Add the ability to declare item properties which can be used in your item models.

Into `startup_scripts`:
```js
onEvent("item.model_properties", (event) => {
	/**
         * You can use every notation for item like `Ingredient.of()` or `Item.of()`, 
         * which makes it possible too also use multiple items at once.
         * 
	 * Register item property for diamonds with the name "kubejs:hidden_emerald".
	 * level and entity can be null!
	 */
	event.register("minecraft:diamond", "hidden_emerald", (stack, level, entity, id) => {
		// example which checks if the nbt contains "is_emerald"
		if(stack.nbt && stack.nbt.is_emerald) {
			return 1;
		}
		return 0;
	});

	/**
	 * Register item property for all items with the name "kubejs:hidden_paper".
	 * level and entity can be null!
	 */
	event.registerAll("hidden_paper", (stack, level, entity, id) => {
		// example which checks if the nbt contains "is_hidden"
		if(stack.nbt && stack.nbt.is_hidden) {
			return 1;
		}
		return 0;
	})
});
```

Example to use in your model, in our example `diamond.json`. 
You can learn more about models and properties here: https://minecraft.fandom.com/wiki/Model#Item_predicates
```json
{
	"parent": "minecraft:item/generated",
	"textures": {
		"layer0": "minecraft:item/diamond"
	},
	"overrides": [
		{
			"predicate": {
				"kubejs:hidden_emerald": 1
			},
			"model": "minecraft:item/emerald"
		},
		{
			"predicate": {
				"kubejs:hidden_paper": 1
			},
			"model": "minecraft:item/paper"
		}
	]
}
```

![image](https://user-images.githubusercontent.com/29131229/164538045-164666e6-9dd2-458f-9fed-191742ca9a4b.png)
