### PR TITLE
Added support for adding attributes to items or entities

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/BuiltinKubeJSPlugin.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/BuiltinKubeJSPlugin.java
@@ -118,6 +118,7 @@ import net.minecraft.util.valueproviders.IntProvider;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.MobCategory;
+import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraft.world.item.ArmorMaterial;
 import net.minecraft.world.item.ArmorMaterials;
 import net.minecraft.world.item.Item;

--- a/common/src/main/java/dev/latvian/mods/kubejs/entity/LivingEntityJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/entity/LivingEntityJS.java
@@ -9,6 +9,7 @@ import net.minecraft.world.InteractionHand;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraft.world.entity.ai.attributes.AttributeInstance;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
@@ -290,6 +291,45 @@ public class LivingEntityJS extends EntityJS {
 
 	public RayTraceResultJS rayTrace() {
 		return rayTrace(getReachDistance());
+	}
+
+	public double getAttributeTotalValue(Attribute attribute) {
+		AttributeInstance instance = minecraftLivingEntity.getAttribute(attribute);
+		if (instance != null) {
+			return instance.getValue();
+		}
+		return 0.0;
+	}
+
+	public double getAttributeBaseValue(Attribute attribute) {
+		AttributeInstance instance = minecraftLivingEntity.getAttribute(attribute);
+		if (instance != null) {
+			return instance.getBaseValue();
+		}
+		return 0.0;
+	}
+
+	public void setAttributeBaseValue(Attribute attribute, double value) {
+		AttributeInstance instance = minecraftLivingEntity.getAttribute(attribute);
+		if (instance != null) {
+			instance.setBaseValue(value);
+		}
+	}
+
+	public void modifyAttribute(Attribute attribute, String identifier, double d, AttributeModifier.Operation operation) {
+		AttributeInstance instance = minecraftLivingEntity.getAttribute(attribute);
+		if (instance != null) {
+			UUID uuid = new UUID(identifier.hashCode(), identifier.hashCode());
+			instance.removeModifier(uuid);
+			instance.addTransientModifier(new AttributeModifier(uuid, identifier, d, operation));
+		}
+	}
+
+	public void removeAttribute(Attribute attribute, String identifier) {
+		AttributeInstance instance = minecraftLivingEntity.getAttribute(attribute);
+		if (instance != null) {
+			instance.removeModifier(new UUID(identifier.hashCode(), identifier.hashCode()));
+		}
 	}
 
 	private AttributeModifier createSpeedModifier(double speed, AttributeModifier.Operation operation) {

--- a/common/src/main/java/dev/latvian/mods/kubejs/item/ItemBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/item/ItemBuilder.java
@@ -1,5 +1,7 @@
 package dev.latvian.mods.kubejs.item;
 
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
 import com.google.gson.JsonObject;
 import dev.architectury.registry.client.rendering.ColorHandlerRegistry;
 import dev.latvian.mods.kubejs.BuilderBase;
@@ -16,6 +18,8 @@ import net.fabricmc.api.Environment;
 import net.minecraft.client.Minecraft;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.item.ArmorMaterial;
 import net.minecraft.world.item.ArmorMaterials;
 import net.minecraft.world.item.CreativeModeTab;
@@ -30,6 +34,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.ToIntFunction;
@@ -66,6 +71,7 @@ public abstract class ItemBuilder extends BuilderBase<Item> {
 	public transient FoodBuilder foodBuilder;
 	public transient Function<ItemStackJS, Color> barColor;
 	public transient ToIntFunction<ItemStackJS> barWidth;
+	public transient Multimap<ResourceLocation, AttributeModifier> attributes;
 
 	public JsonObject modelJson;
 
@@ -86,6 +92,7 @@ public abstract class ItemBuilder extends BuilderBase<Item> {
 		parentModel = "";
 		foodBuilder = null;
 		modelJson = null;
+		attributes = ArrayListMultimap.create();
 	}
 
 	@Override
@@ -239,4 +246,8 @@ public abstract class ItemBuilder extends BuilderBase<Item> {
 		return properties;
 	}
 
+	public ItemBuilder modifyAttribute(ResourceLocation attribute, String identifier, double d, AttributeModifier.Operation operation) {
+		attributes.put(attribute, new AttributeModifier(new UUID(identifier.hashCode(), identifier.hashCode()), identifier, d, operation));
+		return this;
+	}
 }

--- a/common/src/main/java/dev/latvian/mods/kubejs/item/custom/ArmorItemBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/item/custom/ArmorItemBuilder.java
@@ -1,9 +1,15 @@
 package dev.latvian.mods.kubejs.item.custom;
 
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
+import dev.latvian.mods.kubejs.KubeJSRegistries;
 import dev.latvian.mods.kubejs.item.ItemBuilder;
 import dev.latvian.mods.kubejs.item.MutableArmorTier;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.item.ArmorItem;
 import net.minecraft.world.item.ArmorMaterial;
 import net.minecraft.world.item.ArmorMaterials;
@@ -51,7 +57,23 @@ public class ArmorItemBuilder extends ItemBuilder {
 
 	@Override
 	public Item createObject() {
-		return new ArmorItem(armorTier, equipmentSlot, createItemProperties());
+		return new ArmorItem(armorTier, equipmentSlot, createItemProperties()) {
+			private boolean modified = false;
+
+			{
+				defaultModifiers = ArrayListMultimap.<Attribute, AttributeModifier>create();
+				defaultModifiers.putAll(defaultModifiers);
+			}
+
+			@Override
+			public Multimap<Attribute, AttributeModifier> getDefaultAttributeModifiers(EquipmentSlot equipmentSlot) {
+				if (!modified) {
+					modified = true;
+					attributes.forEach((r, m) -> defaultModifiers.put(KubeJSRegistries.attributes().get(r), m));
+				}
+				return super.getDefaultAttributeModifiers(equipmentSlot);
+			}
+		};
 	}
 
 	public ArmorItemBuilder tier(ArmorMaterial t) {

--- a/common/src/main/java/dev/latvian/mods/kubejs/item/custom/ArmorItemBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/item/custom/ArmorItemBuilder.java
@@ -61,8 +61,7 @@ public class ArmorItemBuilder extends ItemBuilder {
 			private boolean modified = false;
 
 			{
-				defaultModifiers = ArrayListMultimap.<Attribute, AttributeModifier>create();
-				defaultModifiers.putAll(defaultModifiers);
+				defaultModifiers = ArrayListMultimap.create(defaultModifiers);
 			}
 
 			@Override

--- a/common/src/main/java/dev/latvian/mods/kubejs/item/custom/AxeItemBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/item/custom/AxeItemBuilder.java
@@ -1,6 +1,13 @@
 package dev.latvian.mods.kubejs.item.custom;
 
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
+import dev.latvian.mods.kubejs.KubeJSRegistries;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.item.AxeItem;
 import net.minecraft.world.item.Item;
 
@@ -11,6 +18,22 @@ public class AxeItemBuilder extends HandheldItemBuilder {
 
 	@Override
 	public Item createObject() {
-		return new AxeItem(toolTier, attackDamageBaseline, speedBaseline, createItemProperties());
+		return new AxeItem(toolTier, attackDamageBaseline, speedBaseline, createItemProperties()) {
+			private boolean modified = false;
+
+			{
+				defaultModifiers = ArrayListMultimap.<Attribute, AttributeModifier>create();
+				defaultModifiers.putAll(defaultModifiers);
+			}
+
+			@Override
+			public Multimap<Attribute, AttributeModifier> getDefaultAttributeModifiers(EquipmentSlot equipmentSlot) {
+				if (!modified) {
+					modified = true;
+					attributes.forEach((r, m) -> defaultModifiers.put(KubeJSRegistries.attributes().get(r), m));
+				}
+				return super.getDefaultAttributeModifiers(equipmentSlot);
+			}
+		};
 	}
 }

--- a/common/src/main/java/dev/latvian/mods/kubejs/item/custom/AxeItemBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/item/custom/AxeItemBuilder.java
@@ -22,8 +22,7 @@ public class AxeItemBuilder extends HandheldItemBuilder {
 			private boolean modified = false;
 
 			{
-				defaultModifiers = ArrayListMultimap.<Attribute, AttributeModifier>create();
-				defaultModifiers.putAll(defaultModifiers);
+				defaultModifiers = ArrayListMultimap.create(defaultModifiers);
 			}
 
 			@Override

--- a/common/src/main/java/dev/latvian/mods/kubejs/item/custom/BasicItemJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/item/custom/BasicItemJS.java
@@ -1,8 +1,10 @@
 package dev.latvian.mods.kubejs.item.custom;
 
+import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
 import dev.architectury.registry.fuel.FuelRegistry;
+import dev.latvian.mods.kubejs.KubeJSRegistries;
 import dev.latvian.mods.kubejs.item.ItemBuilder;
 import dev.latvian.mods.kubejs.item.ItemStackJS;
 import net.minecraft.core.NonNullList;
@@ -32,33 +34,20 @@ public class BasicItemJS extends Item {
 		}
 	}
 
-	private final ImmutableMultimap<Attribute, AttributeModifier> attributes;
+	private final Multimap<Attribute, AttributeModifier> attributes;
+	private final Multimap<ResourceLocation, AttributeModifier> modifiers;
+	private boolean modified = false;
 	private final Function<ItemStackJS, Collection<ItemStackJS>> subtypes;
 
 	public BasicItemJS(ItemBuilder p) {
 		super(p.createItemProperties());
-		// var attackDamage = p.getAttackDamage();
-		// var attackSpeed = p.getAttackSpeed();
-
 		if (p.burnTime > 0) {
 			FuelRegistry.register(p.burnTime, this);
 		}
 
 		subtypes = p.subtypes;
-
-		ImmutableMultimap.Builder<Attribute, AttributeModifier> builder = ImmutableMultimap.builder();
-
-		/*
-		if (attackDamage != null) {
-			builder.put(Attributes.ATTACK_DAMAGE, new AttributeModifier(BASE_ATTACK_DAMAGE_UUID, "Weapon modifier", attackDamage.doubleValue(), AttributeModifier.Operation.ADDITION));
-		}
-
-		if (attackSpeed != null) {
-			builder.put(Attributes.ATTACK_SPEED, new AttributeModifier(BASE_ATTACK_SPEED_UUID, "Weapon modifier", attackSpeed.doubleValue(), AttributeModifier.Operation.ADDITION));
-		}
-		*/
-
-		attributes = builder.build();
+		attributes = ArrayListMultimap.create();
+		modifiers = p.attributes;
 	}
 
 	@Override
@@ -74,6 +63,10 @@ public class BasicItemJS extends Item {
 
 	@Override
 	public Multimap<Attribute, AttributeModifier> getDefaultAttributeModifiers(EquipmentSlot slot) {
+		if (!modified) {
+			modifiers.forEach((r, m) -> attributes.put(KubeJSRegistries.attributes().get(r), m));
+			modified = true;
+		}
 		return slot == EquipmentSlot.MAINHAND ? attributes : super.getDefaultAttributeModifiers(slot);
 	}
 }

--- a/common/src/main/java/dev/latvian/mods/kubejs/item/custom/HoeItemBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/item/custom/HoeItemBuilder.java
@@ -1,6 +1,12 @@
 package dev.latvian.mods.kubejs.item.custom;
 
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import dev.latvian.mods.kubejs.KubeJSRegistries;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.item.HoeItem;
 import net.minecraft.world.item.Item;
 
@@ -11,6 +17,22 @@ public class HoeItemBuilder extends HandheldItemBuilder {
 
 	@Override
 	public Item createObject() {
-		return new HoeItem(toolTier, (int) attackDamageBaseline, speedBaseline, createItemProperties());
+		return new HoeItem(toolTier, (int) attackDamageBaseline, speedBaseline, createItemProperties()) {
+			private boolean modified = false;
+
+			{
+				defaultModifiers = ArrayListMultimap.<Attribute, AttributeModifier>create();
+				defaultModifiers.putAll(defaultModifiers);
+			}
+
+			@Override
+			public Multimap<Attribute, AttributeModifier> getDefaultAttributeModifiers(EquipmentSlot equipmentSlot) {
+				if (!modified) {
+					modified = true;
+					attributes.forEach((r, m) -> defaultModifiers.put(KubeJSRegistries.attributes().get(r), m));
+				}
+				return super.getDefaultAttributeModifiers(equipmentSlot);
+			}
+		};
 	}
 }

--- a/common/src/main/java/dev/latvian/mods/kubejs/item/custom/HoeItemBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/item/custom/HoeItemBuilder.java
@@ -21,8 +21,7 @@ public class HoeItemBuilder extends HandheldItemBuilder {
 			private boolean modified = false;
 
 			{
-				defaultModifiers = ArrayListMultimap.<Attribute, AttributeModifier>create();
-				defaultModifiers.putAll(defaultModifiers);
+				defaultModifiers = ArrayListMultimap.create(defaultModifiers);
 			}
 
 			@Override

--- a/common/src/main/java/dev/latvian/mods/kubejs/item/custom/PickaxeItemBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/item/custom/PickaxeItemBuilder.java
@@ -1,6 +1,12 @@
 package dev.latvian.mods.kubejs.item.custom;
 
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import dev.latvian.mods.kubejs.KubeJSRegistries;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.PickaxeItem;
 
@@ -11,6 +17,22 @@ public class PickaxeItemBuilder extends HandheldItemBuilder {
 
 	@Override
 	public Item createObject() {
-		return new PickaxeItem(toolTier, (int) attackDamageBaseline, speedBaseline, createItemProperties());
+		return new PickaxeItem(toolTier, (int) attackDamageBaseline, speedBaseline, createItemProperties()) {
+			private boolean modified = false;
+
+			{
+				defaultModifiers = ArrayListMultimap.<Attribute, AttributeModifier>create();
+				defaultModifiers.putAll(defaultModifiers);
+			}
+
+			@Override
+			public Multimap<Attribute, AttributeModifier> getDefaultAttributeModifiers(EquipmentSlot equipmentSlot) {
+				if (!modified) {
+					modified = true;
+					attributes.forEach((r, m) -> defaultModifiers.put(KubeJSRegistries.attributes().get(r), m));
+				}
+				return super.getDefaultAttributeModifiers(equipmentSlot);
+			}
+		};
 	}
 }

--- a/common/src/main/java/dev/latvian/mods/kubejs/item/custom/PickaxeItemBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/item/custom/PickaxeItemBuilder.java
@@ -21,8 +21,7 @@ public class PickaxeItemBuilder extends HandheldItemBuilder {
 			private boolean modified = false;
 
 			{
-				defaultModifiers = ArrayListMultimap.<Attribute, AttributeModifier>create();
-				defaultModifiers.putAll(defaultModifiers);
+				defaultModifiers = ArrayListMultimap.create(defaultModifiers);
 			}
 
 			@Override

--- a/common/src/main/java/dev/latvian/mods/kubejs/item/custom/ShovelItemBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/item/custom/ShovelItemBuilder.java
@@ -1,6 +1,12 @@
 package dev.latvian.mods.kubejs.item.custom;
 
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import dev.latvian.mods.kubejs.KubeJSRegistries;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ShovelItem;
 
@@ -11,6 +17,22 @@ public class ShovelItemBuilder extends HandheldItemBuilder {
 
 	@Override
 	public Item createObject() {
-		return new ShovelItem(toolTier, attackDamageBaseline, speedBaseline, createItemProperties());
+		return new ShovelItem(toolTier, attackDamageBaseline, speedBaseline, createItemProperties()) {
+			private boolean modified = false;
+
+			{
+				defaultModifiers = ArrayListMultimap.<Attribute, AttributeModifier>create();
+				defaultModifiers.putAll(defaultModifiers);
+			}
+
+			@Override
+			public Multimap<Attribute, AttributeModifier> getDefaultAttributeModifiers(EquipmentSlot equipmentSlot) {
+				if (!modified) {
+					modified = true;
+					attributes.forEach((r, m) -> defaultModifiers.put(KubeJSRegistries.attributes().get(r), m));
+				}
+				return super.getDefaultAttributeModifiers(equipmentSlot);
+			}
+		};
 	}
 }

--- a/common/src/main/java/dev/latvian/mods/kubejs/item/custom/ShovelItemBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/item/custom/ShovelItemBuilder.java
@@ -21,8 +21,7 @@ public class ShovelItemBuilder extends HandheldItemBuilder {
 			private boolean modified = false;
 
 			{
-				defaultModifiers = ArrayListMultimap.<Attribute, AttributeModifier>create();
-				defaultModifiers.putAll(defaultModifiers);
+				defaultModifiers = ArrayListMultimap.create(defaultModifiers);
 			}
 
 			@Override

--- a/common/src/main/java/dev/latvian/mods/kubejs/item/custom/SwordItemBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/item/custom/SwordItemBuilder.java
@@ -21,8 +21,7 @@ public class SwordItemBuilder extends HandheldItemBuilder {
 			private boolean modified = false;
 
 			{
-				defaultModifiers = ArrayListMultimap.<Attribute, AttributeModifier>create();
-				defaultModifiers.putAll(defaultModifiers);
+				defaultModifiers = ArrayListMultimap.create(defaultModifiers);
 			}
 
 			@Override

--- a/common/src/main/java/dev/latvian/mods/kubejs/item/custom/SwordItemBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/item/custom/SwordItemBuilder.java
@@ -1,6 +1,12 @@
 package dev.latvian.mods.kubejs.item.custom;
 
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import dev.latvian.mods.kubejs.KubeJSRegistries;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.SwordItem;
 
@@ -11,6 +17,22 @@ public class SwordItemBuilder extends HandheldItemBuilder {
 
 	@Override
 	public Item createObject() {
-		return new SwordItem(toolTier, (int) attackDamageBaseline, speedBaseline, createItemProperties());
+		return new SwordItem(toolTier, (int) attackDamageBaseline, speedBaseline, createItemProperties()) {
+			private boolean modified = false;
+
+			{
+				defaultModifiers = ArrayListMultimap.<Attribute, AttributeModifier>create();
+				defaultModifiers.putAll(defaultModifiers);
+			}
+
+			@Override
+			public Multimap<Attribute, AttributeModifier> getDefaultAttributeModifiers(EquipmentSlot equipmentSlot) {
+				if (!modified) {
+					modified = true;
+					attributes.forEach((r, m) -> defaultModifiers.put(KubeJSRegistries.attributes().get(r), m));
+				}
+				return super.getDefaultAttributeModifiers(equipmentSlot);
+			}
+		};
 	}
 }

--- a/common/src/main/java/dev/latvian/mods/kubejs/misc/BasicMobEffect.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/misc/BasicMobEffect.java
@@ -1,25 +1,75 @@
 package dev.latvian.mods.kubejs.misc;
 
+import dev.latvian.mods.kubejs.KubeJSRegistries;
 import dev.latvian.mods.kubejs.core.EntityKJS;
 import dev.latvian.mods.kubejs.entity.LivingEntityJS;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraft.world.entity.ai.attributes.AttributeInstance;
+import net.minecraft.world.entity.ai.attributes.AttributeMap;
+import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
 
 public class BasicMobEffect extends MobEffect {
 
 	private final MobEffectBuilder.EffectTickCallback effectTickCallback;
+	private final Map<ResourceLocation, AttributeModifier> modifierMap;
+	private final Map<Attribute, AttributeModifier> attributeMap;
+	private boolean modified = false;
 
 	public BasicMobEffect(Builder builder) {
 		super(builder.category, builder.color);
 		this.effectTickCallback = builder.effectTick;
-		this.getAttributeModifiers().putAll(builder.attributeModifiers);
+		modifierMap = builder.attributeModifiers;
+		attributeMap = new HashMap<>();
 	}
 
 	@Override
 	public void applyEffectTick(@NotNull LivingEntity livingEntity, int i) {
 		effectTickCallback.applyEffectTick((LivingEntityJS) ((EntityKJS) livingEntity).asKJS(), i);
+	}
+
+	private void applyAttributeModifications() {
+		if (!modified) {
+			modifierMap.forEach((r, m) -> attributeMap.put(KubeJSRegistries.attributes().get(r), m));
+		}
+	}
+
+	@Override
+	public Map<Attribute, AttributeModifier> getAttributeModifiers() {
+		this.applyAttributeModifications();
+		return attributeMap;
+	}
+
+	@Override
+	public void removeAttributeModifiers(LivingEntity livingEntity, AttributeMap attributeMap, int i) {
+		this.applyAttributeModifications();
+		for (Map.Entry<Attribute, AttributeModifier> entry : this.attributeMap.entrySet()) {
+			AttributeInstance attributeInstance = attributeMap.getInstance(entry.getKey());
+			if (attributeInstance != null) {
+				attributeInstance.removeModifier(entry.getValue());
+			}
+		}
+	}
+
+	@Override
+	public void addAttributeModifiers(LivingEntity livingEntity, AttributeMap attributeMap, int i) {
+		this.applyAttributeModifications();
+		for (Map.Entry<Attribute, AttributeModifier> attributeAttributeModifierEntry : this.attributeMap.entrySet()) {
+			AttributeInstance attributeInstance = attributeMap.getInstance(attributeAttributeModifierEntry.getKey());
+			if (attributeInstance != null) {
+				AttributeModifier attributeModifier = attributeAttributeModifierEntry.getValue();
+				attributeInstance.removeModifier(attributeModifier);
+				attributeInstance.addPermanentModifier(new AttributeModifier(attributeModifier.getId(), this.getDescriptionId() + " " + i, this.getAttributeModifierValue(i, attributeModifier), attributeModifier.getOperation()));
+			}
+		}
+
 	}
 
 	@Override

--- a/common/src/main/java/dev/latvian/mods/kubejs/misc/MobEffectBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/misc/MobEffectBuilder.java
@@ -1,14 +1,12 @@
 package dev.latvian.mods.kubejs.misc;
 
 import dev.latvian.mods.kubejs.BuilderBase;
-import dev.latvian.mods.kubejs.KubeJSRegistries;
 import dev.latvian.mods.kubejs.RegistryObjectBuilderTypes;
 import dev.latvian.mods.kubejs.entity.LivingEntityJS;
 import dev.latvian.mods.rhino.mod.util.color.Color;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.effect.MobEffectCategory;
-import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 
 import java.util.HashMap;
@@ -24,7 +22,7 @@ public abstract class MobEffectBuilder extends BuilderBase<MobEffect> {
 
 	public transient MobEffectCategory category;
 	public transient EffectTickCallback effectTick;
-	public transient Map<Attribute, AttributeModifier> attributeModifiers;
+	public transient Map<ResourceLocation, AttributeModifier> attributeModifiers;
 	public transient int color;
 
 	public MobEffectBuilder(ResourceLocation i) {
@@ -40,7 +38,7 @@ public abstract class MobEffectBuilder extends BuilderBase<MobEffect> {
 		return RegistryObjectBuilderTypes.MOB_EFFECT;
 	}
 
-	public MobEffectBuilder modifyAttribute(Attribute attribute, String identifier, double d, AttributeModifier.Operation operation) {
+	public MobEffectBuilder modifyAttribute(ResourceLocation attribute, String identifier, double d, AttributeModifier.Operation operation) {
 		AttributeModifier attributeModifier = new AttributeModifier(new UUID(identifier.hashCode(), identifier.hashCode()), identifier, d, operation);
 		attributeModifiers.put(attribute, attributeModifier);
 		return this;

--- a/common/src/main/java/dev/latvian/mods/kubejs/misc/MobEffectBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/misc/MobEffectBuilder.java
@@ -40,10 +40,9 @@ public abstract class MobEffectBuilder extends BuilderBase<MobEffect> {
 		return RegistryObjectBuilderTypes.MOB_EFFECT;
 	}
 
-	public MobEffectBuilder modifyAttribute(ResourceLocation attribute, String identifier, double d, AttributeModifier.Operation operation) {
+	public MobEffectBuilder modifyAttribute(Attribute attribute, String identifier, double d, AttributeModifier.Operation operation) {
 		AttributeModifier attributeModifier = new AttributeModifier(new UUID(identifier.hashCode(), identifier.hashCode()), identifier, d, operation);
-		Attribute attr = KubeJSRegistries.attributes().get(attribute);
-		attributeModifiers.put(attr, attributeModifier);
+		attributeModifiers.put(attribute, attributeModifier);
 		return this;
 	}
 

--- a/common/src/main/resources/kubejs.accesswidener
+++ b/common/src/main/resources/kubejs.accesswidener
@@ -8,6 +8,13 @@ accessible field net/minecraft/world/item/crafting/RecipeManager byName Ljava/ut
 accessible field net/minecraft/world/item/crafting/RecipeManager recipes Ljava/util/Map;
 accessible field net/minecraft/server/ReloadableServerResources tagManager Lnet/minecraft/tags/TagManager;
 
+accessible field net/minecraft/world/item/ArmorItem defaultModifiers Lcom/google/common/collect/Multimap;
+mutable field net/minecraft/world/item/ArmorItem defaultModifiers Lcom/google/common/collect/Multimap;
+accessible field net/minecraft/world/item/DiggerItem defaultModifiers Lcom/google/common/collect/Multimap;
+mutable field net/minecraft/world/item/DiggerItem defaultModifiers Lcom/google/common/collect/Multimap;
+accessible field net/minecraft/world/item/SwordItem defaultModifiers Lcom/google/common/collect/Multimap;
+mutable field net/minecraft/world/item/SwordItem defaultModifiers Lcom/google/common/collect/Multimap;
+
 accessible method net/minecraft/world/entity/ai/village/poi/PoiType <init> (Ljava/lang/String;Ljava/util/Set;II)V
 accessible method net/minecraft/world/entity/npc/VillagerType <init> (Ljava/lang/String;)V
 accessible method net/minecraft/world/entity/npc/VillagerProfession <init> (Ljava/lang/String;Lnet/minecraft/world/entity/ai/village/poi/PoiType;Lcom/google/common/collect/ImmutableSet;Lcom/google/common/collect/ImmutableSet;Lnet/minecraft/sounds/SoundEvent;)V

--- a/fabric/src/generated/resources/kubejs.accesswidener
+++ b/fabric/src/generated/resources/kubejs.accesswidener
@@ -8,6 +8,13 @@ accessible field net/minecraft/world/item/crafting/RecipeManager byName Ljava/ut
 accessible field net/minecraft/world/item/crafting/RecipeManager recipes Ljava/util/Map;
 accessible field net/minecraft/server/ReloadableServerResources tagManager Lnet/minecraft/tags/TagManager;
 
+accessible field net/minecraft/world/item/ArmorItem defaultModifiers Lcom/google/common/collect/Multimap;
+mutable field net/minecraft/world/item/ArmorItem defaultModifiers Lcom/google/common/collect/Multimap;
+accessible field net/minecraft/world/item/DiggerItem defaultModifiers Lcom/google/common/collect/Multimap;
+mutable field net/minecraft/world/item/DiggerItem defaultModifiers Lcom/google/common/collect/Multimap;
+accessible field net/minecraft/world/item/SwordItem defaultModifiers Lcom/google/common/collect/Multimap;
+mutable field net/minecraft/world/item/SwordItem defaultModifiers Lcom/google/common/collect/Multimap;
+
 accessible method net/minecraft/world/entity/ai/village/poi/PoiType <init> (Ljava/lang/String;Ljava/util/Set;II)V
 accessible method net/minecraft/world/entity/npc/VillagerType <init> (Ljava/lang/String;)V
 accessible method net/minecraft/world/entity/npc/VillagerProfession <init> (Ljava/lang/String;Lnet/minecraft/world/entity/ai/village/poi/PoiType;Lcom/google/common/collect/ImmutableSet;Lcom/google/common/collect/ImmutableSet;Lnet/minecraft/sounds/SoundEvent;)V


### PR DESCRIPTION
- Made `defaultModifiers` in `ArmorItem`, `DiggerItem` and `SwordItem` public mutable for efficiently overwriting attributes.
- Cleared code in `BasicItemJS` for attribute implementation.
- Added support to add different attributes to KubeJS custom items and tools.
- MobEffect now supports all kind of attributes.
- Exposed methods to modify attribute for `LivingEntityJS` directly.
Example code:
```js
onEvent("item.registry", event => {
    event.create("swift_sword", "sword")
        //Adds an attribute to the item.
        .modifyAttribute("generic.movement_speed", "kjs:super_speed_sword", 1, "addition")
})
```

```js
onEvent("entity.hurt", event => {
    if (event.entity.living) {
        let living = event.entity;
        living.modifyAttribute("generic.armor", "tough_on_crack", 100, "addition");
    }
})
```