### PR TITLE
Fix #330 - Non [a-z0-9_.-] character in namespace

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/BuiltinKubeJSPlugin.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/BuiltinKubeJSPlugin.java
@@ -450,7 +450,7 @@ public class BuiltinKubeJSPlugin extends KubeJSPlugin {
 		typeWrappers.register(Color.class, ColorWrapper::of);
 		typeWrappers.register(IngredientActionFilter.class, IngredientActionFilter::filterOf);
 		typeWrappers.register(Tier.class, o -> ItemBuilder.TOOL_TIERS.getOrDefault(String.valueOf(o), Tiers.IRON));
-		typeWrappers.register(ArmorMaterial.class, o -> ItemBuilder.ARMOR_TIERS.getOrDefault(String.valueOf(o), ArmorMaterials.IRON));
+		typeWrappers.register(ArmorMaterial.class, ItemBuilder::ofArmorMaterial);
 
 		KubeJS.PROXY.clientTypeWrappers(typeWrappers);
 	}

--- a/common/src/main/java/dev/latvian/mods/kubejs/item/ItemBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/item/ItemBuilder.java
@@ -29,6 +29,7 @@ import net.minecraft.world.item.Rarity;
 import net.minecraft.world.item.Tier;
 import net.minecraft.world.item.Tiers;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -54,6 +55,18 @@ public abstract class ItemBuilder extends BuilderBase<Item> {
 		for (var tier : ArmorMaterials.values()) {
 			ARMOR_TIERS.put(tier.toString().toLowerCase(), tier);
 		}
+	}
+
+	public static ArmorMaterial ofArmorMaterial(Object o) {
+		String asString = String.valueOf(o);
+
+		ArmorMaterial armorMaterial = ItemBuilder.ARMOR_TIERS.get(asString);
+		if (armorMaterial != null) {
+			return armorMaterial;
+		}
+
+		String withKube = KubeJS.appendModId(asString);
+		return ItemBuilder.ARMOR_TIERS.getOrDefault(withKube, ArmorMaterials.IRON);
 	}
 
 	public transient int maxStackSize;

--- a/common/src/main/java/dev/latvian/mods/kubejs/item/custom/ArmorItemBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/item/custom/ArmorItemBuilder.java
@@ -76,7 +76,7 @@ public class ArmorItemBuilder extends ItemBuilder {
 	}
 
 	public ArmorItemBuilder tier(ArmorMaterial t) {
-		armorTier = new MutableArmorTier(id.toString(), t);
+		armorTier = new MutableArmorTier(t.getName(), t);
 		return this;
 	}
 

--- a/common/src/main/java/dev/latvian/mods/kubejs/item/custom/ItemArmorTierEventJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/item/custom/ItemArmorTierEventJS.java
@@ -1,8 +1,10 @@
 package dev.latvian.mods.kubejs.item.custom;
 
+import dev.latvian.mods.kubejs.KubeJS;
 import dev.latvian.mods.kubejs.event.StartupEventJS;
 import dev.latvian.mods.kubejs.item.ItemBuilder;
 import dev.latvian.mods.kubejs.item.MutableArmorTier;
+import dev.latvian.mods.kubejs.util.UtilsJS;
 import net.minecraft.world.item.ArmorMaterials;
 
 import java.util.function.Consumer;
@@ -12,10 +14,11 @@ import java.util.function.Consumer;
  */
 public class ItemArmorTierEventJS extends StartupEventJS {
 	public void add(String id, String parent, Consumer<MutableArmorTier> tier) {
-		var material = ItemBuilder.ARMOR_TIERS.getOrDefault(parent, ArmorMaterials.IRON);
-		var t = new MutableArmorTier(id, material);
+		var material = ItemBuilder.ofArmorMaterial(parent);
+		var fullId = KubeJS.appendModId(id);
+		var t = new MutableArmorTier(fullId, material);
 		tier.accept(t);
-		ItemBuilder.ARMOR_TIERS.put(id, t);
+		ItemBuilder.ARMOR_TIERS.put(fullId, t);
 	}
 
 	public void add(String id, Consumer<MutableArmorTier> tier) {

--- a/fabric/src/main/java/dev/latvian/mods/kubejs/mixin/fabric/HumanoidArmorLayerMixin.java
+++ b/fabric/src/main/java/dev/latvian/mods/kubejs/mixin/fabric/HumanoidArmorLayerMixin.java
@@ -1,0 +1,37 @@
+package dev.latvian.mods.kubejs.mixin.fabric;
+
+import net.minecraft.client.renderer.entity.layers.HumanoidArmorLayer;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ArmorItem;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.Map;
+
+@Mixin(HumanoidArmorLayer.class)
+public class HumanoidArmorLayerMixin {
+
+	@Shadow
+	@Final
+	private static Map<String, ResourceLocation> ARMOR_LOCATION_CACHE;
+
+	@Inject(method = "getArmorLocation", at = @At("HEAD"), cancellable = true)
+	private void tryOverwriteArmorLocation(ArmorItem armorItem, boolean useSecondLayer, String suffix, CallbackInfoReturnable<ResourceLocation> cir) {
+		// If our armor item has a namespace, we will add this to the texture path
+		String materialName = armorItem.getMaterial().getName();
+		int separatorIndex = materialName.indexOf(':');
+		if (separatorIndex != -1) {
+			String namespace = materialName.substring(0, separatorIndex);
+			String path = materialName.substring(separatorIndex + 1);
+			ResourceLocation texture = new ResourceLocation(namespace, "textures/models/armor/" + path + "_layer_" + (useSecondLayer ? 2 : 1) + (suffix == null ? "" : "_" + suffix) + ".png");
+			if(!ARMOR_LOCATION_CACHE.containsKey(texture.toString())) {
+				ARMOR_LOCATION_CACHE.put(texture.toString(), texture);
+			}
+			cir.setReturnValue(texture);
+		}
+	}
+}

--- a/fabric/src/main/resources/kubejs-fabric.mixins.json
+++ b/fabric/src/main/resources/kubejs-fabric.mixins.json
@@ -5,6 +5,7 @@
 	"mixins": [
 	],
 	"client": [
+		"HumanoidArmorLayerMixin",
 		"ClientRecipeBookMixin"
 	],
 	"injectors": {


### PR DESCRIPTION
Fix for https://github.com/KubeJS-Mods/KubeJS/issues/330

### Whats new?
Creating armor materials will now be created with `kubejs` namespace, which will also be used for locate the armor location. 

Example: Armor material `foobar` will be stored as `kubejs:foobar` internally and textures should be stored in `kubejs\assets\kubejs\textures\models\armor` with `foobar_layer_1.png` and `foobar_layer_2.png`. 

### Potential problem
Modpacks with custom armor materials must move their armor textures to the new location. 

If this should not be the case, we could remove `HumanoidArmorLayerMixin` and don't prefix the materials. But I think we should prefix them as peoples first instinct is to put their textures into the `kubejs` namespace. 
