### PR TITLE
Fix NullPointerException for `properties`

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/block/predicate/BlockIDPredicate.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/predicate/BlockIDPredicate.java
@@ -25,17 +25,18 @@ public class BlockIDPredicate implements BlockPredicate {
 	}
 
 	private final ResourceLocation id;
-	private Map<String, String> properties;
+	private final Map<String, String> properties;
 	private Block cachedBlock;
 	private List<PropertyObject> cachedProperties;
 
 	public BlockIDPredicate(ResourceLocation i) {
 		id = i;
+		properties = new HashMap<>();
 	}
 
 	@Override
 	public String toString() {
-		if (properties == null || properties.isEmpty()) {
+		if (properties.isEmpty()) {
 			return id.toString();
 		}
 
@@ -61,10 +62,6 @@ public class BlockIDPredicate implements BlockPredicate {
 	}
 
 	public BlockIDPredicate with(String key, String value) {
-		if (properties == null) {
-			properties = new HashMap<>();
-		}
-
 		properties.put(key, value);
 		cachedBlock = null;
 		cachedProperties = null;
@@ -132,7 +129,7 @@ public class BlockIDPredicate implements BlockPredicate {
 			return false;
 		}
 
-		if (properties == null || properties.isEmpty()) {
+		if (properties.isEmpty()) {
 			return true;
 		}
 


### PR DESCRIPTION
Problem:

`Block.id("block_id").getBlockState()` results into a NullPointerException as the property map is not initialized yet. The property map only gets initialized if you set a property through `Block.id("block_id").with(key, value)`.