### PR TITLE
Fixed crash when generating assets for seeds

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/block/SeedItemBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/SeedItemBuilder.java
@@ -1,5 +1,6 @@
 package dev.latvian.mods.kubejs.block;
 
+import dev.latvian.mods.kubejs.generator.AssetJsonGenerator;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemNameBlockItem;
@@ -21,5 +22,26 @@ public class SeedItemBuilder extends BlockItemBuilder {
 	@Override
 	public Item createObject() {
 		return new ItemNameBlockItem(blockBuilder.get(), createItemProperties());
+	}
+
+	@Override
+	public void generateAssetJsons(AssetJsonGenerator generator) {
+		if (modelJson != null) {
+			generator.json(AssetJsonGenerator.asItemModelLocation(id), modelJson);
+			return;
+		}
+
+		generator.itemModel(id, m -> {
+			if (!parentModel.isEmpty()) {
+				m.parent(parentModel);
+			} else {
+				m.parent("minecraft:item/generated");
+			}
+
+			if (textureJson.size() == 0) {
+				texture(newID("item/", "").toString());
+			}
+			m.textures(textureJson);
+		});
 	}
 }

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/custom/CropBlockBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/custom/CropBlockBuilder.java
@@ -233,10 +233,7 @@ public class CropBlockBuilder extends BlockBuilder {
 			}
 		}
 		if (itemBuilder != null) {
-			generator.itemModel(itemBuilder.id, m -> {
-				m.parent("minecraft:item/generated");
-				m.texture("layer0", itemBuilder.texture.isEmpty() ? itemBuilder.newID("item/", "").toString() : itemBuilder.texture);
-			});
+			itemBuilder.generateAssetJsons(generator);
 		}
 	}
 


### PR DESCRIPTION
Fixed:
```
Time: 5/10/22, 2:52 AM
Description: Rendering overlay

java.lang.NullPointerException: Cannot invoke "String.isEmpty()" because "this.itemBuilder.texture" is null
	at dev.latvian.mods.kubejs.block.custom.CropBlockBuilder.lambda$generateAssetJsons$6(CropBlockBuilder.java:238) ~[kubejs-forge-1802.5.2-build.405.jar%2369!/:1802.5.2-build.405] {re:classloading}
	at net.minecraft.Util.m_137469_(Util.java:351) ~[client-1.18.2-20220404.173914-srg.jar%2384!/:?] {re:mixin,re:classloading,pl:mixin:APP:ftbchunks-common.mixins.json:UtilMixin,pl:mixin:APP:kubejs-common.mixins.json:UtilMixin,pl:mixin:A}
	at dev.latvian.mods.kubejs.generator.AssetJsonGenerator.itemModel(AssetJsonGenerator.java:35) ~[kubejs-forge-1802.5.2-build.405.jar%2369!/:1802.5.2-build.405] {re:classloading}
	at dev.latvian.mods.kubejs.block.custom.CropBlockBuilder.generateAssetJsons(CropBlockBuilder.java:236) ~[kubejs-forge-1802.5.2-build.405.jar%2369!/:1802.5.2-build.405] {re:classloading}
	at dev.latvian.mods.kubejs.BuiltinKubeJSPlugin.generateAssetJsons(BuiltinKubeJSPlugin.java:560) ~[kubejs-forge-1802.5.2-build.405.jar%2369!/:1802.5.2-build.405] {re:mixin,re:classloading}
	at dev.latvian.mods.kubejs.client.KubeJSClientResourcePack.lambda$generateJsonFiles$0(KubeJSClientResourcePack.java:38) ~[kubejs-forge-1802.5.2-build.405.jar%2369!/:1802.5.2-build.405] {re:mixin,re:classloading}
	at java.util.ArrayList.forEach(ArrayList.java:1511) ~[?:?] {re:computing_frames,re:mixin}
	at dev.latvian.mods.kubejs.util.KubeJSPlugins.forEachPlugin(KubeJSPlugins.java:83) ~[kubejs-forge-1802.5.2-build.405.jar%2369!/:1802.5.2-build.405] {re:classloading}
	at dev.latvian.mods.kubejs.client.KubeJSClientResourcePack.generateJsonFiles(KubeJSClientResourcePack.java:38) ~[kubejs-forge-1802.5.2-build.405.jar%2369!/:1802.5.2-build.405] {re:mixin,re:classloading}
	at dev.latvian.mods.kubejs.script.data.KubeJSResourcePack.getCachedResources(KubeJSResourcePack.java:96) ~[kubejs-forge-1802.5.2-build.405.jar%2369!/:1802.5.2-build.405] {re:mixin,re:classloading}
	at dev.latvian.mods.kubejs.script.data.KubeJSResourcePack.m_7211_(KubeJSResourcePack.java:83) ~[kubejs-forge-1802.5.2-build.405.jar%2369!/:1802.5.2-build.405] {re:mixin,re:classloading}
	at net.minecraft.server.packs.resources.FallbackResourceManager.m_7396_(FallbackResourceManager.java:102) ~[client-1.18.2-20220404.173914-srg.jar%2384!/:?] {re:classloading,pl:accesstransformer:B}
	at net.minecraft.server.packs.resources.MultiPackResourceManager.m_7396_(MultiPackResourceManager.java:69) ~[client-1.18.2-20220404.173914-srg.jar%2384!/:?] {re:classloading,pl:accesstransformer:B}
	at net.minecraft.client.sounds.SoundManager.m_5944_(SoundManager.java:64) ~[client-1.18.2-20220404.173914-srg.jar%2384!/:?] {re:classloading}
	at net.minecraft.client.sounds.SoundManager.m_5944_(SoundManager.java:39) ~[client-1.18.2-20220404.173914-srg.jar%2384!/:?] {re:classloading}
	at net.minecraft.server.packs.resources.SimplePreparableReloadListener.m_10786_(SimplePreparableReloadListener.java:11) ~[client-1.18.2-20220404.173914-srg.jar%2384!/:?] {re:classloading,re:mixin}
	at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768) ~[?:?] {}
	at java.util.concurrent.CompletableFuture$AsyncSupply.exec(CompletableFuture.java:1760) ~[?:?] {}
	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:373) ~[?:?] {}
	at java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1182) ~[?:?] {}
	at java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1655) ~[?:?] {re:computing_frames}
	at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1622) ~[?:?] {re:computing_frames}
	at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165) ~[?:?] {}
```

Occurred due to `itemBuilder.texture` becomes null by default after update, also made the seed item assets generation more like a "normal" item, thus one can change how it looks like more freely.

https://github.com/KubeJS-Mods/KubeJS/blob/2aa982f997c64c3450c69b3bd35a5cd41c079d9b/common/src/main/java/dev/latvian/mods/kubejs/block/custom/CropBlockBuilder.java#L238

