### PR TITLE
Add a bunch of useful methods to BlockContainerJS

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/level/BlockContainerJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/level/BlockContainerJS.java
@@ -368,7 +368,7 @@ public class BlockContainerJS implements SpecialEquality {
 		Block.popResource(minecraftLevel, pos, item.getItemStack());
 	}
 
-	public void popItemFromface(ItemStackJS item, Direction dir) {
+	public void popItemFromFace(ItemStackJS item, Direction dir) {
 		Block.popResourceFromFace(minecraftLevel, pos, dir, item.getItemStack());
 	}
 

--- a/common/src/main/java/dev/latvian/mods/kubejs/level/BlockContainerJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/level/BlockContainerJS.java
@@ -12,6 +12,7 @@ import dev.latvian.mods.kubejs.item.ItemStackJS;
 import dev.latvian.mods.kubejs.player.EntityArrayList;
 import dev.latvian.mods.kubejs.player.PlayerJS;
 import dev.latvian.mods.kubejs.player.ServerPlayerJS;
+import dev.latvian.mods.kubejs.util.ListJS;
 import dev.latvian.mods.kubejs.util.Tags;
 import dev.latvian.mods.kubejs.util.UtilsJS;
 import dev.latvian.mods.rhino.util.SpecialEquality;
@@ -27,6 +28,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LightLayer;
 import net.minecraft.world.level.biome.Biomes;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
@@ -34,6 +36,7 @@ import net.minecraft.world.level.block.state.properties.Property;
 import net.minecraft.world.phys.AABB;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -322,6 +325,11 @@ public class BlockContainerJS implements SpecialEquality {
 	}
 
 	@Nullable
+	public InventoryJS getInventory() {
+		return getInventory(Direction.UP);
+	}
+
+	@Nullable
 	public InventoryJS getInventory(Direction facing) {
 		var tileEntity = getEntity();
 
@@ -339,6 +347,29 @@ public class BlockContainerJS implements SpecialEquality {
 	public ItemStackJS getItem() {
 		var state = getBlockState();
 		return ItemStackJS.of(state.getBlock().getCloneItemStack(minecraftLevel, pos, state));
+	}
+
+	public ListJS getDrops() {
+		return getDrops(null, null);
+	}
+
+	public ListJS getDrops(PlayerJS player, ItemStackJS heldItem) {
+		if (minecraftLevel instanceof ServerLevel) {
+			var drops = new ListJS();
+			Block.getDrops(getBlockState(), (ServerLevel) minecraftLevel, pos, getEntity(), player != null ? player.minecraftPlayer : null, heldItem != null ? heldItem.getItemStack() : null).forEach((drop) -> {
+				drops.add(new ItemStackJS(drop));
+			});
+			return  drops;
+		}
+		return null;
+	}
+
+	public void popItem(ItemStackJS item) {
+		Block.popResource(minecraftLevel, pos, item.getItemStack());
+	}
+
+	public void popItemFromface(ItemStackJS item, Direction dir) {
+		Block.popResourceFromFace(minecraftLevel, pos, dir, item.getItemStack());
 	}
 
 	@Override

--- a/common/src/main/java/dev/latvian/mods/kubejs/level/BlockContainerJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/level/BlockContainerJS.java
@@ -353,10 +353,13 @@ public class BlockContainerJS implements SpecialEquality {
 		return getDrops(null, null);
 	}
 
-	public ListJS getDrops(PlayerJS player, ItemStackJS heldItem) {
+	public ListJS getDrops(EntityJS entity, ItemStackJS heldItem) {
 		if (minecraftLevel instanceof ServerLevel) {
 			var drops = new ListJS();
-			Block.getDrops(getBlockState(), (ServerLevel) minecraftLevel, pos, getEntity(), player != null ? player.minecraftPlayer : null, heldItem != null ? heldItem.getItemStack() : null).forEach((drop) -> {
+			Block.getDrops(getBlockState(), (ServerLevel) minecraftLevel, pos, getEntity(),
+					entity != null ? entity.minecraftEntity : null,
+					heldItem != null ? heldItem.getItemStack() : null
+			).forEach((drop) -> {
 				drops.add(new ItemStackJS(drop));
 			});
 			return  drops;


### PR DESCRIPTION
Added methods:
.
 - `getInventory()`, returns the InventoryJS of the block from the top. Makes it beanable for simple inventories like chests
 - `getDrops(EntityJS, ItemStackJS)`, returns a ListJS of ItemStackJS, which contain the results of rolling the blocks loot table, taking into account the entities (usually a player) effects and the held items enchantments/properties. Also takes into account anything from the block entity.
 - `getDrops()`, returns a ListJS of ItemStackJS, which contain the results of rolling the blocks loot table but not taking into account any external factors (except the attached block entity), beanable
 - `popItem(ItemStackJS)`, pops an item from the block, like when you break a block. Does not return the item entity
 - ` popItemFromFace(ItemStackJS, Direction)`, pops an item from the face with more velocity away from that face (useful for when there is still a full block there, to avoid it shooting out in a random direction). Does not return the item entity

\
Feedback is appreciated
*now without 20 extra 1.18/main commits*