### PR TITLE
Fixed error in id squeezer recipe parsing

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/recipe/mod/IDSqueezerRecipeJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/recipe/mod/IDSqueezerRecipeJS.java
@@ -42,7 +42,7 @@ public class IDSqueezerRecipeJS extends RecipeJS {
 				if (stack.getFluidStack() != null) {
 					o.add("fluid", stack.toResultJson());
 				} else {
-					a.add(stack.toResultJson());
+					a.add(toIDResultJson(stack.toResultJson()));
 				}
 			}
 
@@ -62,5 +62,26 @@ public class IDSqueezerRecipeJS extends RecipeJS {
 		json.addProperty("duration", i);
 		save();
 		return this;
+	}
+
+	@Override
+	public ItemStackJS parseResultItem(@Nullable Object o) {
+		if (o instanceof JsonObject obj) {
+			if (obj.has("item")) {
+				var item = obj.get("item");
+				return super.parseResultItem(item.isJsonObject() ? item.getAsJsonObject() : item.getAsString());
+			} else {
+				return parseIngredientItem(o).getFirst();
+			}
+		} else {
+			return super.parseResultItem(o);
+		}
+
+	}
+
+	private JsonElement toIDResultJson(JsonElement result) {
+		var o = new JsonObject();
+		o.add("item", result);
+		return o;
 	}
 }


### PR DESCRIPTION
Updated Integrated Dynamics compact to fix parsing of:

![YD@ _BFGE_%G~US7B EUSL5](https://user-images.githubusercontent.com/24620047/168746017-ca9612af-0da4-48dd-bc10-947a5a7cbf55.png)

![U55_U`F1BUF978L `Z)XZ~M](https://user-images.githubusercontent.com/24620047/168746066-829dfab6-cf97-45b9-b984-5eb085f025ac.png)

Which will throw error with code before.