### PR TITLE
Decouple painter instance

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/BuiltinKubeJSPlugin.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/BuiltinKubeJSPlugin.java
@@ -27,6 +27,7 @@ import dev.latvian.mods.kubejs.block.custom.WoodenButtonBlockBuilder;
 import dev.latvian.mods.kubejs.block.custom.WoodenPressurePlateBlockBuilder;
 import dev.latvian.mods.kubejs.block.state.BlockStatePredicate;
 import dev.latvian.mods.kubejs.client.painter.Painter;
+import dev.latvian.mods.kubejs.client.painter.PainterRegistry;
 import dev.latvian.mods.kubejs.client.painter.screen.AtlasTextureObject;
 import dev.latvian.mods.kubejs.client.painter.screen.GradientObject;
 import dev.latvian.mods.kubejs.client.painter.screen.ItemObject;
@@ -210,12 +211,12 @@ public class BuiltinKubeJSPlugin extends KubeJSPlugin {
 	@Override
 	@Environment(EnvType.CLIENT)
 	public void clientInit() {
-		Painter.INSTANCE.registerObject("screen_group", ScreenGroup::new);
-		Painter.INSTANCE.registerObject("rectangle", RectangleObject::new);
-		Painter.INSTANCE.registerObject("text", TextObject::new);
-		Painter.INSTANCE.registerObject("atlas_texture", AtlasTextureObject::new);
-		Painter.INSTANCE.registerObject("gradient", GradientObject::new);
-		Painter.INSTANCE.registerObject("item", ItemObject::new);
+		PainterRegistry.register("screen_group", ScreenGroup::new);
+		PainterRegistry.register("rectangle", RectangleObject::new);
+		PainterRegistry.register("text", TextObject::new);
+		PainterRegistry.register("atlas_texture", AtlasTextureObject::new);
+		PainterRegistry.register("gradient", GradientObject::new);
+		PainterRegistry.register("item", ItemObject::new);
 	}
 
 	@Override

--- a/common/src/main/java/dev/latvian/mods/kubejs/client/painter/PainterObject.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/client/painter/PainterObject.java
@@ -1,29 +1,41 @@
 package dev.latvian.mods.kubejs.client.painter;
 
 import dev.latvian.mods.kubejs.util.ConsoleJS;
+import dev.latvian.mods.rhino.util.HideFromJS;
 import dev.latvian.mods.rhino.util.SpecialEquality;
 import dev.latvian.mods.unit.FixedBooleanUnit;
 import dev.latvian.mods.unit.Unit;
+import dev.latvian.mods.unit.UnitVariables;
 import net.minecraft.nbt.CompoundTag;
+
+import java.util.function.Consumer;
 
 public abstract class PainterObject implements SpecialEquality {
 	public String id = "";
-	public PainterObjectStorage parent;
 	public Unit visible = FixedBooleanUnit.TRUE;
+	public Consumer<PainterObject> removeListener;
 
 	public PainterObject id(String i) {
 		id = i;
 		return this;
 	}
 
+	@HideFromJS
+	public void setRemoveListener(Consumer<PainterObject> listener) {
+		removeListener = listener;
+	}
+
 	protected void load(PainterObjectProperties properties) {
 		visible = properties.getUnit("visible", visible);
 	}
 
+	@HideFromJS
+	public void init(UnitVariables variables) {}
+
 	public final void update(CompoundTag tag) {
 		if (tag.getBoolean("remove")) {
-			if (parent != null) {
-				parent.remove(id);
+			if (removeListener != null) {
+				removeListener.accept(this);
 			}
 		} else {
 			try {

--- a/common/src/main/java/dev/latvian/mods/kubejs/client/painter/PainterRegistry.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/client/painter/PainterRegistry.java
@@ -1,0 +1,21 @@
+package dev.latvian.mods.kubejs.client.painter;
+
+import javax.annotation.Nullable;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+public class PainterRegistry {
+	private static final Supplier<PainterObject> NULL_PAINTER_OBJECT = () -> null;
+	private static final Map<String, Supplier<PainterObject>> FACTORIES = new HashMap<>();
+
+	public static void register(String name, Supplier<PainterObject> factory) {
+		FACTORIES.put(name, factory);
+	}
+
+	@Nullable
+	public static PainterObject make(String name) {
+		return FACTORIES.getOrDefault(name, NULL_PAINTER_OBJECT).get();
+	}
+
+}

--- a/common/src/main/java/dev/latvian/mods/kubejs/client/painter/screen/AtlasTextureObject.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/client/painter/screen/AtlasTextureObject.java
@@ -45,15 +45,18 @@ public class AtlasTextureObject extends ScreenPainterObject {
 
 		var sprite = textureAtlas.getSprite(texture);
 
-		var u0 = sprite.getU0();
-		var v0 = sprite.getV0();
-		var u1 = sprite.getU1();
-		var v1 = sprite.getV1();
-		event.resetShaderColor();
-		event.setPositionColorTextureShader();
-		event.setShaderTexture(atlas);
-		event.beginQuads(true);
-		event.rectangle(ax, ay, az, aw, ah, color.getInt(event), u0, v0, u1, v1);
-		event.end();
+		// Happens when painter is used server side and then trigger client reload
+		if(sprite != null) {
+			var u0 = sprite.getU0();
+			var v0 = sprite.getV0();
+			var u1 = sprite.getU1();
+			var v1 = sprite.getV1();
+			event.resetShaderColor();
+			event.setPositionColorTextureShader();
+			event.setShaderTexture(atlas);
+			event.beginQuads(true);
+			event.rectangle(ax, ay, az, aw, ah, color.getInt(event), u0, v0, u1, v1);
+			event.end();
+		}
 	}
 }

--- a/common/src/main/java/dev/latvian/mods/kubejs/client/painter/screen/ScreenGroup.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/client/painter/screen/ScreenGroup.java
@@ -2,19 +2,26 @@ package dev.latvian.mods.kubejs.client.painter.screen;
 
 import dev.latvian.mods.kubejs.client.painter.PainterObjectProperties;
 import dev.latvian.mods.kubejs.client.painter.PainterObjectStorage;
+import dev.latvian.mods.kubejs.util.ConsoleJS;
 import dev.latvian.mods.unit.FixedNumberUnit;
 import dev.latvian.mods.unit.Unit;
+import dev.latvian.mods.unit.UnitVariables;
 import net.minecraft.nbt.CompoundTag;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class ScreenGroup extends ScreenPainterObject {
-	private final PainterObjectStorage storage = new PainterObjectStorage();
+	private PainterObjectStorage storage;
 	private Unit scaleX = FixedNumberUnit.ONE;
 	private Unit scaleY = FixedNumberUnit.ONE;
 	private Unit paddingW = FixedNumberUnit.ZERO;
 	private Unit paddingH = FixedNumberUnit.ZERO;
+
+	@Override
+	public void init(UnitVariables variables) {
+		storage = new PainterObjectStorage(variables);
+	}
 
 	@Override
 	protected void load(PainterObjectProperties properties) {
@@ -23,7 +30,11 @@ public class ScreenGroup extends ScreenPainterObject {
 		var c = properties.tag.get("children");
 
 		if (c instanceof CompoundTag tag) {
-			storage.handle(tag);
+			if (storage != null) {
+				storage.handle(tag);
+			} else {
+				ConsoleJS.CLIENT.warn("ScreenGroup was not correctly initialized!");
+			}
 		}
 
 		paddingW = properties.getUnit("paddingW", paddingW);

--- a/common/src/main/java/dev/latvian/mods/kubejs/client/painter/screen/ScreenPaintEventJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/client/painter/screen/ScreenPaintEventJS.java
@@ -2,8 +2,8 @@ package dev.latvian.mods.kubejs.client.painter.screen;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.math.Vector3f;
-import dev.latvian.mods.kubejs.client.painter.PaintEventJS;
 import dev.latvian.mods.kubejs.client.painter.Painter;
+import dev.latvian.mods.kubejs.client.painter.PaintEventJS;
 import dev.latvian.mods.unit.UnitVariables;
 import dev.latvian.mods.unit.VariableSet;
 import net.minecraft.client.Minecraft;
@@ -14,12 +14,14 @@ import net.minecraft.util.FormattedCharSequence;
 public class ScreenPaintEventJS extends PaintEventJS implements UnitVariables {
 	public final int mouseX;
 	public final int mouseY;
-	public final int width;
-	public final int height;
 	public final boolean inventory;
+	private final UnitVariables unitVariables;
+	public int width;
+	public int height;
 
-	public ScreenPaintEventJS(Minecraft m, Screen s, PoseStack ps, int mx, int my, float d) {
+	public ScreenPaintEventJS(UnitVariables unitVariables, Minecraft m, Screen s, PoseStack ps, int mx, int my, float d) {
 		super(m, ps, d, s);
+		this.unitVariables = unitVariables;
 		mouseX = mx;
 		mouseY = my;
 		width = mc.getWindow().getGuiScaledWidth();
@@ -27,13 +29,19 @@ public class ScreenPaintEventJS extends PaintEventJS implements UnitVariables {
 		inventory = true;
 	}
 
-	public ScreenPaintEventJS(Minecraft m, PoseStack ps, float d) {
+	public ScreenPaintEventJS(UnitVariables unitVariables, Minecraft m, PoseStack ps, float d) {
 		super(m, ps, d, null);
+		this.unitVariables = unitVariables;
 		mouseX = -1;
 		mouseY = -1;
 		width = mc.getWindow().getGuiScaledWidth();
 		height = mc.getWindow().getGuiScaledHeight();
 		inventory = false;
+	}
+
+	public void updateSize(int width, int height) {
+		this.width = width;
+		this.height = height;
 	}
 
 	public float alignX(float x, float w, int alignX) {
@@ -102,6 +110,6 @@ public class ScreenPaintEventJS extends PaintEventJS implements UnitVariables {
 
 	@Override
 	public VariableSet getVariables() {
-		return Painter.INSTANCE.getVariables();
+		return unitVariables.getVariables();
 	}
 }


### PR DESCRIPTION
Hey,

small PR to decouple the Painter Instance from PainterObjectStorage etc. Helpful to create own PainterObjectStorage scope with painter objects without relying on the `Painter` instance. Example would be for PonderJS adding a `PainterInstruction` to use painter inside the PonderUI
- If classes need the variables they now only get the `UnitVariables`. 
- `PainterRegistry` now exist for the object creation. 
- Small null pointer exception handling if reloading client, when using painter on server
