### PR TITLE
Add click events to some chat outputs for ease of use

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/command/KubeJSCommands.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/command/KubeJSCommands.java
@@ -284,10 +284,19 @@ public class KubeJSCommands {
 			source.sendSuccess(new TextComponent("[" + (i + 1) + "] " + ScriptType.SERVER.errors.get(i)).withStyle(ChatFormatting.RED), false);
 		}
 
-		source.sendSuccess(new TextComponent("More info in 'logs/kubejs/server.txt'").withStyle(ChatFormatting.DARK_RED), false);
+		source.sendSuccess(new TextComponent("More info in ")
+				.append(new TextComponent("'logs/kubejs/server.txt'")
+						.click(new ClickEvent(ClickEvent.Action.OPEN_FILE, ScriptType.SERVER.getLogFile().toString()))
+						.hover(new TextComponent("Click to open"))).withStyle(ChatFormatting.DARK_RED),
+				false);
 
 		if (!ScriptType.SERVER.warnings.isEmpty()) {
-			source.sendSuccess(new TextComponent(ScriptType.SERVER.warnings.size() + " warnings found. Run '/kubejs warnings' to see them").withStyle(Style.EMPTY.withColor(TextColor.fromRgb(0xFFA500))), false);
+			source.sendSuccess(new TextComponent(ScriptType.SERVER.warnings.size() + " warnings found. Run ")
+							.append(new TextComponent("'/kubejs warnings'")
+									.click(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/kubejs warnings"))
+									.hover(new TextComponent("Click to run"))).append(" to see them")
+							.withStyle(Style.EMPTY.withColor(TextColor.fromRgb(0xFFA500))),
+			false);
 		}
 
 		return 1;
@@ -318,7 +327,11 @@ public class KubeJSCommands {
 	private static int reloadServer(CommandSourceStack source) {
 		ServerScriptManager.instance.reloadScriptManager(((MinecraftServerKJS) source.getServer()).getReloadableResourcesKJS().resourceManager());
 		UtilsJS.postModificationEvents();
-		source.sendSuccess(new TextComponent("Done! To reload recipes, tags, loot tables and other datapack things, run /reload"), false);
+		source.sendSuccess(new TextComponent("Done! To reload recipes, tags, loot tables and other datapack things, run ")
+						.append(new TextComponent("'/reload'")
+						.click(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/reload"))
+						.hover(new TextComponent("Click to run"))),
+		false);
 		return 1;
 	}
 

--- a/common/src/main/java/dev/latvian/mods/kubejs/core/LootTablesKJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/core/LootTablesKJS.java
@@ -13,6 +13,7 @@ import dev.latvian.mods.kubejs.server.ServerJS;
 import dev.latvian.mods.kubejs.server.ServerSettings;
 import dev.latvian.mods.kubejs.util.ConsoleJS;
 import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.TextComponent;
 import net.minecraft.resources.ResourceLocation;
 
@@ -47,7 +48,13 @@ public interface LootTablesKJS {
 			if (ScriptType.SERVER.errors.isEmpty()) {
 				ServerJS.instance.tell(new TextComponent("Reloaded with no KubeJS errors!").withStyle(ChatFormatting.GREEN));
 			} else {
-				ServerJS.instance.tell(new TextComponent("KubeJS errors found [" + ScriptType.SERVER.errors.size() + "]! Run '/kubejs errors' for more info").withStyle(ChatFormatting.DARK_RED));
+				ServerJS.instance.tell(new TextComponent("KubeJS errors found [" + ScriptType.SERVER.errors.size() + "]! Run ")
+						.append(new TextComponent("'/kubejs errors'")
+								.click(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "kubejs errors")))
+								.hover(new TextComponent("Click to run"))
+						.append(new TextComponent(" for more info"))
+						.withStyle(ChatFormatting.DARK_RED)
+				);
 			}
 		}
 	}

--- a/common/src/main/java/dev/latvian/mods/kubejs/core/LootTablesKJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/core/LootTablesKJS.java
@@ -50,7 +50,7 @@ public interface LootTablesKJS {
 			} else {
 				ServerJS.instance.tell(new TextComponent("KubeJS errors found [" + ScriptType.SERVER.errors.size() + "]! Run ")
 						.append(new TextComponent("'/kubejs errors'")
-								.click(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "kubejs errors")))
+								.click(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/kubejs errors")))
 								.hover(new TextComponent("Click to run"))
 						.append(new TextComponent(" for more info"))
 						.withStyle(ChatFormatting.DARK_RED)

--- a/common/src/main/java/dev/latvian/mods/kubejs/player/KubeJSPlayerEventHandler.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/player/KubeJSPlayerEventHandler.java
@@ -14,6 +14,7 @@ import dev.latvian.mods.kubejs.server.ServerJS;
 import dev.latvian.mods.kubejs.stages.Stages;
 import net.minecraft.ChatFormatting;
 import net.minecraft.advancements.Advancement;
+import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.TextComponent;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.network.TextFilter;
@@ -50,7 +51,13 @@ public class KubeJSPlayerEventHandler {
 		}
 
 		if (!ScriptType.SERVER.errors.isEmpty() && !CommonProperties.get().hideServerScriptErrors) {
-			player.displayClientMessage(new TextComponent("KubeJS errors found [" + ScriptType.SERVER.errors.size() + "]! Run '/kubejs errors' for more info").withStyle(ChatFormatting.DARK_RED), false);
+			player.displayClientMessage(new TextComponent("KubeJS errors found [" + ScriptType.SERVER.errors.size() + "]! Run ")
+					.append(new TextComponent("'/kubejs errors'")
+							.click(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/kubejs errors"))
+							.hover(new TextComponent("Click to run")))
+					.append(new TextComponent(" for more info"))
+					.withStyle(ChatFormatting.DARK_RED),
+			false);
 		}
 
 		Stages.get(player).sync();


### PR DESCRIPTION
The `/kubejs errors` command in `KubeJS errors found [x]! Run '/kubejs errors' for more info` is now clickable and will run that command.

The log file path and `/kubejs warnings` command in the output of `/kubejs errors` are now clickable to open the log file and run the command respectively

The `/reload` command in the output of `/kubejs reload server_scripts` is now clickable to run that command.

\
All of these also have hover text saying either "Click to run" or "Click to open", depending on what it does.
