### PR TITLE
Fix removing tags from tags

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/server/TagEventJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/server/TagEventJS.java
@@ -129,7 +129,13 @@ public class TagEventJS<T> extends EventJS {
 				gatherTargets(stringId).ifLeft(wrapper -> {
 					var entryId = wrapper.id.toString();
 					var originalSize = proxyList.size();
-					proxyList.removeIf(proxy -> getIdOfEntry(proxy.entry()).equals(entryId));
+					proxyList.removeIf(proxy -> {
+						String proxyId = getIdOfEntry(proxy.entry());
+						if(proxyId.startsWith("#")) {
+							return proxyId.substring(1).equals(entryId);
+						}
+						return false;
+					});
 
 					var removedCount = originalSize - proxyList.size();
 					if (removedCount == 0) {


### PR DESCRIPTION
Current problem is that you can't remove tags inside a tag like:
```
#minecraft:logs
- #minecraft:logs_that_burn
- #minecraft:crimson_stems
- #minecraft:warped_stems
```

```js
onEvent("item.tags", (e) => {
	e.remove("minecraft:logs", "#minecraft:logs_that_burn");
});
```

Using the code would not remove the tag. The PR will fix this.

Result:
![image](https://user-images.githubusercontent.com/29131229/177012737-c718e2eb-2cce-4939-b343-ad14aa1a03d1.png)
