### PR TITLE
Make the error for type() a bit less confusing

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/BuilderBase.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/BuilderBase.java
@@ -45,7 +45,7 @@ public abstract class BuilderBase<T> implements Supplier<T> {
 	public abstract T createObject();
 
 	public final BuilderBase<T> type(String type) {
-		throw new RuntimeException("type(type: string) is no longer supported! Use event.create(id: string, type: string) now!");
+		throw new RuntimeException("type(type String) is no longer supported! Use event.create(id String, type String) now!");
 	}
 
 	public T transformObject(T obj) {

--- a/common/src/main/java/dev/latvian/mods/kubejs/BuilderBase.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/BuilderBase.java
@@ -45,7 +45,7 @@ public abstract class BuilderBase<T> implements Supplier<T> {
 	public abstract T createObject();
 
 	public final BuilderBase<T> type(String type) {
-		throw new RuntimeException("type(type String) is no longer supported! Use event.create(id String, type String) now!");
+		throw new RuntimeException("type(String type) is no longer supported! Use event.create(String id, String type) now!");
 	}
 
 	public T transformObject(T obj) {


### PR DESCRIPTION
As it is atm some people think you include the `id: ` and `type: ` bits, and the error for doing it like that is vague (`Error loading KubeJS script: missing ) after argument list`)