### PR TITLE
Enforce issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: Discord
     url: https://discord.gg/bPFfH6P


### PR DESCRIPTION
Prevent blank issues, as the information contained within the bug template is more than likely still required, even if not deemed to be a bug.