### PR TITLE
Added way to create item name dynamically

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/item/ItemBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/item/ItemBuilder.java
@@ -92,6 +92,9 @@ public abstract class ItemBuilder extends BuilderBase<Item> {
 	public transient FoodBuilder foodBuilder;
 	public transient Function<ItemStackJS, Color> barColor;
 	public transient ToIntFunction<ItemStackJS> barWidth;
+
+	public transient Function<ItemStackJS, Component> getName;
+
 	public transient Multimap<ResourceLocation, AttributeModifier> attributes;
 	public transient UseAnim anim;
 	public transient ToIntFunction<ItemStackJS> useDuration;
@@ -281,6 +284,11 @@ public abstract class ItemBuilder extends BuilderBase<Item> {
 
 	public ItemBuilder barWidth(ToIntFunction<ItemStackJS> barWidth) {
 		this.barWidth = barWidth;
+		return this;
+	}
+
+	public ItemBuilder name(Function<ItemStackJS, Component> name) {
+		this.getName = name;
 		return this;
 	}
 

--- a/common/src/main/java/dev/latvian/mods/kubejs/item/ItemBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/item/ItemBuilder.java
@@ -93,7 +93,7 @@ public abstract class ItemBuilder extends BuilderBase<Item> {
 	public transient Function<ItemStackJS, Color> barColor;
 	public transient ToIntFunction<ItemStackJS> barWidth;
 
-	public transient Function<ItemStackJS, Component> getName;
+	public transient NameCallback nameGetter;
 
 	public transient Multimap<ResourceLocation, AttributeModifier> attributes;
 	public transient UseAnim anim;
@@ -287,8 +287,8 @@ public abstract class ItemBuilder extends BuilderBase<Item> {
 		return this;
 	}
 
-	public ItemBuilder name(Function<ItemStackJS, Component> name) {
-		this.getName = name;
+	public ItemBuilder name(NameCallback name) {
+		this.nameGetter = name;
 		return this;
 	}
 
@@ -391,5 +391,10 @@ public abstract class ItemBuilder extends BuilderBase<Item> {
 	@FunctionalInterface
 	public interface ReleaseUsingCallback {
 		void releaseUsing(ItemStackJS itemStack, LevelJS level, LivingEntityJS user, int tick);
+	}
+
+	@FunctionalInterface
+	public interface NameCallback {
+		Component apply(ItemStackJS itemStack);
 	}
 }

--- a/common/src/main/java/dev/latvian/mods/kubejs/mixin/common/ItemMixin.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/mixin/common/ItemMixin.java
@@ -160,8 +160,8 @@ public abstract class ItemMixin implements ItemKJS {
 
 	@Inject(method = "getName", at = @At("HEAD"), cancellable = true)
 	private void getName(ItemStack itemStack, CallbackInfoReturnable<Component> ci) {
-		if (itemBuilderKJS != null && itemBuilderKJS.getName != null) {
-			ci.setReturnValue(itemBuilderKJS.getName.apply(ItemStackJS.of(itemStack)));
+		if (itemBuilderKJS != null && itemBuilderKJS.nameGetter != null) {
+			ci.setReturnValue(itemBuilderKJS.nameGetter.apply(ItemStackJS.of(itemStack)));
 		}
 	}
 

--- a/common/src/main/java/dev/latvian/mods/kubejs/mixin/common/ItemMixin.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/mixin/common/ItemMixin.java
@@ -158,6 +158,13 @@ public abstract class ItemMixin implements ItemKJS {
 		}
 	}
 
+	@Inject(method = "getName", at = @At("HEAD"), cancellable = true)
+	private void getName(ItemStack itemStack, CallbackInfoReturnable<Component> ci) {
+		if (itemBuilderKJS != null && itemBuilderKJS.getName != null) {
+			ci.setReturnValue(itemBuilderKJS.getName.apply(ItemStackJS.of(itemStack)));
+		}
+	}
+
 	@Inject(method = "use", at = @At("HEAD"), cancellable = true)
 	private void use(Level level, Player player, InteractionHand interactionHand, CallbackInfoReturnable<InteractionResultHolder<ItemStack>> ci) {
 		if (itemBuilderKJS != null && itemBuilderKJS.use != null) {


### PR DESCRIPTION
Adds a way to generate item name dynamically by NBT or something else. It's especially useful when users want to create item like `%s of %s`, or `The %s Sword of %s`, or whatever.

Example Code:
```js
onEvent("item.registry", event => {
    event.create("sussy_baka")
        .name(itemStack => {
            return Component.of(`Sussy baka - ${Math.random()}`)
        })
        .texture("minecraft:item/sugar")
})
```

![3](https://user-images.githubusercontent.com/24620047/185755468-749d9f6e-38a4-4bc7-8af8-b065ede86293.gif)

Note that this function is called for every tick.
