### PR TITLE
Add Cardinally orientable blocks and shuffle asset generation code

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/BuiltinKubeJSPlugin.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/BuiltinKubeJSPlugin.java
@@ -175,7 +175,7 @@ public class BuiltinKubeJSPlugin extends KubeJSPlugin {
 		RegistryObjectBuilderTypes.BLOCK.addType("stone_button", StoneButtonBlockBuilder.class, StoneButtonBlockBuilder::new);
 		RegistryObjectBuilderTypes.BLOCK.addType("falling", FallingBlockBuilder.class, FallingBlockBuilder::new);
 		RegistryObjectBuilderTypes.BLOCK.addType("crop", CropBlockBuilder.class, CropBlockBuilder::new);
-		RegistryObjectBuilderTypes.BLOCK.addType("horizontal_directional", HorizontalDirectionalBlockBuilder.class, HorizontalDirectionalBlockBuilder::new);
+		RegistryObjectBuilderTypes.BLOCK.addType("cardinal", HorizontalDirectionalBlockBuilder.class, HorizontalDirectionalBlockBuilder::new);
 
 		RegistryObjectBuilderTypes.ITEM.addType("basic", BasicItemJS.Builder.class, BasicItemJS.Builder::new);
 		RegistryObjectBuilderTypes.ITEM.addType("sword", SwordItemBuilder.class, SwordItemBuilder::new);

--- a/common/src/main/java/dev/latvian/mods/kubejs/BuiltinKubeJSPlugin.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/BuiltinKubeJSPlugin.java
@@ -29,6 +29,7 @@ import dev.latvian.mods.kubejs.block.custom.CropBlockBuilder;
 import dev.latvian.mods.kubejs.block.custom.FallingBlockBuilder;
 import dev.latvian.mods.kubejs.block.custom.FenceBlockBuilder;
 import dev.latvian.mods.kubejs.block.custom.FenceGateBlockBuilder;
+import dev.latvian.mods.kubejs.block.custom.HorizontalDirectionalBlockBuilder;
 import dev.latvian.mods.kubejs.block.custom.SlabBlockBuilder;
 import dev.latvian.mods.kubejs.block.custom.StairBlockBuilder;
 import dev.latvian.mods.kubejs.block.custom.StoneButtonBlockBuilder;
@@ -174,6 +175,7 @@ public class BuiltinKubeJSPlugin extends KubeJSPlugin {
 		RegistryObjectBuilderTypes.BLOCK.addType("stone_button", StoneButtonBlockBuilder.class, StoneButtonBlockBuilder::new);
 		RegistryObjectBuilderTypes.BLOCK.addType("falling", FallingBlockBuilder.class, FallingBlockBuilder::new);
 		RegistryObjectBuilderTypes.BLOCK.addType("crop", CropBlockBuilder.class, CropBlockBuilder::new);
+		RegistryObjectBuilderTypes.BLOCK.addType("horizontal_directional", HorizontalDirectionalBlockBuilder.class, HorizontalDirectionalBlockBuilder::new);
 
 		RegistryObjectBuilderTypes.ITEM.addType("basic", BasicItemJS.Builder.class, BasicItemJS.Builder::new);
 		RegistryObjectBuilderTypes.ITEM.addType("sword", SwordItemBuilder.class, SwordItemBuilder::new);

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/BlockBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/BlockBuilder.java
@@ -427,15 +427,15 @@ public abstract class BlockBuilder extends BuilderBase<Block> {
 		return box(x0, y0, z0, x1, y1, z1, true);
 	}
 
-	public VoxelShape createShape() {
-		if (customShape.isEmpty()) {
+	public static VoxelShape createShape(List<AABB> boxes) {
+		if (boxes.isEmpty()) {
 			return Shapes.block();
 		}
 
-		var shape = Shapes.create(customShape.get(0));
+		var shape = Shapes.create(boxes.get(0));
 
-		for (var i = 1; i < customShape.size(); i++) {
-			shape = Shapes.or(shape, Shapes.create(customShape.get(i)));
+		for (var i = 1; i < boxes.size(); i++) {
+			shape = Shapes.or(shape, Shapes.create(boxes.get(i)));
 		}
 
 		return shape;

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/BlockBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/BlockBuilder.java
@@ -266,7 +266,7 @@ public abstract class BlockBuilder extends BuilderBase<Block> {
 		return map;
 	}
 
-	private boolean areAllTexturesEqual(JsonObject tex, String t) {
+	protected boolean areAllTexturesEqual(JsonObject tex, String t) {
 		for (var direction : Direction.values()) {
 			if (!tex.get(direction.getSerializedName()).getAsString().equals(t)) {
 				return false;

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/custom/BasicBlockJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/custom/BasicBlockJS.java
@@ -56,7 +56,7 @@ public class BasicBlockJS extends Block implements EntityBlockKJS, SimpleWaterlo
 	public BasicBlockJS(BlockBuilder p) {
 		super(p.createProperties());
 		blockBuilder = p;
-		shape = p.createShape();
+		shape = BlockBuilder.createShape(p.customShape);
 
 		var blockState = stateDefinition.any();
 		if (blockBuilder.defaultStateModification != null) {

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/custom/CropBlockBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/custom/CropBlockBuilder.java
@@ -8,7 +8,6 @@ import dev.latvian.mods.kubejs.block.BlockBuilder;
 import dev.latvian.mods.kubejs.block.MaterialListJS;
 import dev.latvian.mods.kubejs.block.RandomTickCallbackJS;
 import dev.latvian.mods.kubejs.block.SeedItemBuilder;
-import dev.latvian.mods.kubejs.client.ModelGenerator;
 import dev.latvian.mods.kubejs.client.VariantBlockStateGenerator;
 import dev.latvian.mods.kubejs.generator.AssetJsonGenerator;
 import dev.latvian.mods.kubejs.item.ItemStackJS;

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/custom/CropBlockBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/custom/CropBlockBuilder.java
@@ -8,6 +8,8 @@ import dev.latvian.mods.kubejs.block.BlockBuilder;
 import dev.latvian.mods.kubejs.block.MaterialListJS;
 import dev.latvian.mods.kubejs.block.RandomTickCallbackJS;
 import dev.latvian.mods.kubejs.block.SeedItemBuilder;
+import dev.latvian.mods.kubejs.client.ModelGenerator;
+import dev.latvian.mods.kubejs.client.VariantBlockStateGenerator;
 import dev.latvian.mods.kubejs.generator.AssetJsonGenerator;
 import dev.latvian.mods.kubejs.item.ItemStackJS;
 import dev.latvian.mods.kubejs.level.BlockContainerJS;
@@ -202,30 +204,22 @@ public class CropBlockBuilder extends BlockBuilder {
 	}
 
 	@Override
-	public void generateAssetJsons(AssetJsonGenerator generator) {
-		if (blockstateJson != null) {
-			generator.json(newID("blockstates/", ""), blockstateJson);
-		} else {
-			generator.blockState(id, bs -> {
-				for (int i = 0; i <= age; i++) {
-					bs.variant("age=%s".formatted(i), model.isEmpty() ? (id.getNamespace() + ":block/" + id.getPath() + i) : model);
-				}
+	protected void generateBlockStateJson(VariantBlockStateGenerator bs) {
+		for (int i = 0; i <= age; i++) {
+			bs.variant("age=%s".formatted(i), model.isEmpty() ? (id.getNamespace() + ":block/" + id.getPath() + i) : model);
+		}
+	}
+
+	@Override
+	protected void generateBlockModelJsons(AssetJsonGenerator generator) {
+		for (int i = 0; i <= age; i++) {
+			final int fi = i;
+			generator.blockModel(newID("", String.valueOf(i)), m -> {
+				m.parent("minecraft:block/crop");
+				m.texture("crop", textures.get(String.valueOf(fi)).getAsString());
 			});
 		}
-		if (modelJson != null) {
-			generator.json(newID("models/block/", ""), modelJson);
-		} else {
-			for (int i = 0; i <= age; i++) {
-				final int fi = i;
-				generator.blockModel(newID("", String.valueOf(i)), m -> {
-					m.parent("minecraft:block/crop");
-					m.texture("crop", textures.get(String.valueOf(fi)).getAsString());
-				});
-			}
-		}
-		if (itemBuilder != null) {
-			itemBuilder.generateAssetJsons(generator);
-		}
+
 	}
 
 	@Override

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/custom/FenceBlockBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/custom/FenceBlockBuilder.java
@@ -1,13 +1,15 @@
 package dev.latvian.mods.kubejs.block.custom;
 
 import dev.architectury.platform.Platform;
+import dev.latvian.mods.kubejs.client.ModelGenerator;
+import dev.latvian.mods.kubejs.client.MultipartBlockStateGenerator;
 import dev.latvian.mods.kubejs.generator.AssetJsonGenerator;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.FenceBlock;
 
-public class FenceBlockBuilder extends ShapedBlockBuilder {
+public class FenceBlockBuilder extends MultipartShapedBlockBuilder {
 	public FenceBlockBuilder(ResourceLocation i) {
 		super(i, "_fence");
 
@@ -24,32 +26,33 @@ public class FenceBlockBuilder extends ShapedBlockBuilder {
 	}
 
 	@Override
-	public void generateAssetJsons(AssetJsonGenerator generator) {
-		generator.multipartState(id, bs -> {
-			var modPost = newID("block/", "_post").toString();
-			var modSide = newID("block/", "_side").toString();
+	protected void generateMultipartBlockstateJson(MultipartBlockStateGenerator bs) {
+		var modPost = newID("block/", "_post").toString();
+		var modSide = newID("block/", "_side").toString();
 
-			bs.part("", modPost);
-			bs.part("north=true", p -> p.model(modSide).uvlock());
-			bs.part("east=true", p -> p.model(modSide).uvlock().y(90));
-			bs.part("south=true", p -> p.model(modSide).uvlock().y(180));
-			bs.part("west=true", p -> p.model(modSide).uvlock().y(270));
-		});
+		bs.part("", modPost);
+		bs.part("north=true", p -> p.model(modSide).uvlock());
+		bs.part("east=true", p -> p.model(modSide).uvlock().y(90));
+		bs.part("south=true", p -> p.model(modSide).uvlock().y(180));
+		bs.part("west=true", p -> p.model(modSide).uvlock().y(270));
+	}
 
-		final var texture = textures.get("texture").getAsString();
+	@Override
+	protected void generateItemModelJson(ModelGenerator m) {
+		m.parent("minecraft:block/fence_inventory");
+		m.texture("texture", textures.get("texture").getAsString());
+	}
+
+	@Override
+	protected void generateBlockModelJsons(AssetJsonGenerator generator) {
+		var texture = textures.get("texture").getAsString();
 
 		generator.blockModel(newID("", "_post"), m -> {
 			m.parent("minecraft:block/fence_post");
 			m.texture("texture", texture);
 		});
-
 		generator.blockModel(newID("", "_side"), m -> {
 			m.parent("minecraft:block/fence_side");
-			m.texture("texture", texture);
-		});
-
-		generator.itemModel(itemBuilder.id, m -> {
-			m.parent("minecraft:block/fence_inventory");
 			m.texture("texture", texture);
 		});
 	}

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/custom/FenceBlockBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/custom/FenceBlockBuilder.java
@@ -26,7 +26,7 @@ public class FenceBlockBuilder extends MultipartShapedBlockBuilder {
 	}
 
 	@Override
-	protected void generateMultipartBlockstateJson(MultipartBlockStateGenerator bs) {
+	protected void generateMultipartBlockStateJson(MultipartBlockStateGenerator bs) {
 		var modPost = newID("block/", "_post").toString();
 		var modSide = newID("block/", "_side").toString();
 

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/custom/FenceGateBlockBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/custom/FenceGateBlockBuilder.java
@@ -1,6 +1,8 @@
 package dev.latvian.mods.kubejs.block.custom;
 
 import dev.architectury.platform.Platform;
+import dev.latvian.mods.kubejs.client.ModelGenerator;
+import dev.latvian.mods.kubejs.client.VariantBlockStateGenerator;
 import dev.latvian.mods.kubejs.generator.AssetJsonGenerator;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.BlockTags;
@@ -23,32 +25,33 @@ public class FenceGateBlockBuilder extends ShapedBlockBuilder {
 	}
 
 	@Override
-	public void generateAssetJsons(AssetJsonGenerator generator) {
-		generator.blockState(id, bs -> {
-			var mod = newID("block/", "").toString();
-			var modOpen = newID("block/", "_open").toString();
-			var modWall = newID("block/", "_wall").toString();
-			var modWallOpen = newID("block/", "_wall_open").toString();
+	protected void generateBlockStateJson(VariantBlockStateGenerator bs) {
+		var mod = newID("block/", "").toString();
+		var modOpen = newID("block/", "_open").toString();
+		var modWall = newID("block/", "_wall").toString();
+		var modWallOpen = newID("block/", "_wall_open").toString();
 
-			bs.variant("facing=east,in_wall=false,open=false", v -> v.model(mod).y(270).uvlock());
-			bs.variant("facing=east,in_wall=false,open=true", v -> v.model(modOpen).y(270).uvlock());
-			bs.variant("facing=east,in_wall=true,open=false", v -> v.model(modWall).y(270).uvlock());
-			bs.variant("facing=east,in_wall=true,open=true", v -> v.model(modWallOpen).y(270).uvlock());
-			bs.variant("facing=north,in_wall=false,open=false", v -> v.model(mod).y(180).uvlock());
-			bs.variant("facing=north,in_wall=false,open=true", v -> v.model(modOpen).y(180).uvlock());
-			bs.variant("facing=north,in_wall=true,open=false", v -> v.model(modWall).y(180).uvlock());
-			bs.variant("facing=north,in_wall=true,open=true", v -> v.model(modWallOpen).y(180).uvlock());
-			bs.variant("facing=south,in_wall=false,open=false", v -> v.model(mod).y(0).uvlock());
-			bs.variant("facing=south,in_wall=false,open=true", v -> v.model(modOpen).y(0).uvlock());
-			bs.variant("facing=south,in_wall=true,open=false", v -> v.model(modWall).y(0).uvlock());
-			bs.variant("facing=south,in_wall=true,open=true", v -> v.model(modWallOpen).y(0).uvlock());
-			bs.variant("facing=west,in_wall=false,open=false", v -> v.model(mod).y(90).uvlock());
-			bs.variant("facing=west,in_wall=false,open=true", v -> v.model(modOpen).y(90).uvlock());
-			bs.variant("facing=west,in_wall=true,open=false", v -> v.model(modWall).y(90).uvlock());
-			bs.variant("facing=west,in_wall=true,open=true", v -> v.model(modWallOpen).y(90).uvlock());
-		});
+		bs.variant("facing=east,in_wall=false,open=false", v -> v.model(mod).y(270).uvlock());
+		bs.variant("facing=east,in_wall=false,open=true", v -> v.model(modOpen).y(270).uvlock());
+		bs.variant("facing=east,in_wall=true,open=false", v -> v.model(modWall).y(270).uvlock());
+		bs.variant("facing=east,in_wall=true,open=true", v -> v.model(modWallOpen).y(270).uvlock());
+		bs.variant("facing=north,in_wall=false,open=false", v -> v.model(mod).y(180).uvlock());
+		bs.variant("facing=north,in_wall=false,open=true", v -> v.model(modOpen).y(180).uvlock());
+		bs.variant("facing=north,in_wall=true,open=false", v -> v.model(modWall).y(180).uvlock());
+		bs.variant("facing=north,in_wall=true,open=true", v -> v.model(modWallOpen).y(180).uvlock());
+		bs.variant("facing=south,in_wall=false,open=false", v -> v.model(mod).y(0).uvlock());
+		bs.variant("facing=south,in_wall=false,open=true", v -> v.model(modOpen).y(0).uvlock());
+		bs.variant("facing=south,in_wall=true,open=false", v -> v.model(modWall).y(0).uvlock());
+		bs.variant("facing=south,in_wall=true,open=true", v -> v.model(modWallOpen).y(0).uvlock());
+		bs.variant("facing=west,in_wall=false,open=false", v -> v.model(mod).y(90).uvlock());
+		bs.variant("facing=west,in_wall=false,open=true", v -> v.model(modOpen).y(90).uvlock());
+		bs.variant("facing=west,in_wall=true,open=false", v -> v.model(modWall).y(90).uvlock());
+		bs.variant("facing=west,in_wall=true,open=true", v -> v.model(modWallOpen).y(90).uvlock());
+	}
 
-		final var texture = textures.get("texture").getAsString();
+	@Override
+	protected void generateBlockModelJsons(AssetJsonGenerator generator) {
+		var texture = textures.get("texture").getAsString();
 
 		generator.blockModel(id, m -> {
 			m.parent("minecraft:block/template_fence_gate");
@@ -69,10 +72,11 @@ public class FenceGateBlockBuilder extends ShapedBlockBuilder {
 			m.parent("minecraft:block/template_fence_gate_wall_open");
 			m.texture("texture", texture);
 		});
+	}
 
-		generator.itemModel(itemBuilder.id, m -> {
-			m.parent("minecraft:block/template_fence_gate");
-			m.texture("texture", texture);
-		});
+	@Override
+	protected void generateItemModelJson(ModelGenerator m) {
+		m.parent("minecraft:block/template_fence_gate");
+		m.texture("texture", textures.get("texture").getAsString());
 	}
 }

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/custom/HorizontalDirectionalBlockBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/custom/HorizontalDirectionalBlockBuilder.java
@@ -89,7 +89,7 @@ public class HorizontalDirectionalBlockBuilder extends BlockBuilder {
 		public BlockState getStateForPlacement(@NotNull BlockPlaceContext context) {
 			var state = defaultBlockState().setValue(FACING, context.getHorizontalDirection().getOpposite());
 
-			if (blockBuilder.waterlogged) {
+			if (blockBuilder.canBeWaterlogged()) {
 				state = state.setValue(BlockStateProperties.WATERLOGGED, context.getLevel().getFluidState(context.getClickedPos()).getType() == Fluids.WATER);
 			}
 

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/custom/HorizontalDirectionalBlockBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/custom/HorizontalDirectionalBlockBuilder.java
@@ -18,27 +18,6 @@ public class HorizontalDirectionalBlockBuilder extends BlockBuilder {
 		super(i);
 	}
 
-	@Override
-	public void generateAssetJsons(AssetJsonGenerator generator) {
-
-		if (blockstateJson != null) {
-			generator.json(newID("blockstates/", ""), blockstateJson);
-		} else {
-			generator.blockState(id, this::generateBlockStateJson);
-		}
-
-		if (modelJson != null) {
-			generator.json(newID("models/", ""), modelJson);
-		} else {
-			generator.blockModel(id, this::generateBlockModelJsons);
-		}
-
-		if (itemBuilder != null) {
-			generator.itemModel(itemBuilder.id, this::generateItemModelJson);
-		}
-
-	}
-
 	protected void generateBlockStateJson(VariantBlockStateGenerator bs) {
 		var modelLocation = model.isEmpty() ? newID("block/", "").toString() : model;
 		bs.variant("facing=north", v -> v.model(modelLocation));

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/custom/HorizontalDirectionalBlockBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/custom/HorizontalDirectionalBlockBuilder.java
@@ -1,0 +1,95 @@
+package dev.latvian.mods.kubejs.block.custom;
+
+import com.google.gson.JsonObject;
+import dev.latvian.mods.kubejs.block.BlockBuilder;
+import dev.latvian.mods.kubejs.client.ModelGenerator;
+import dev.latvian.mods.kubejs.client.VariantBlockStateGenerator;
+import dev.latvian.mods.kubejs.generator.AssetJsonGenerator;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.HorizontalDirectionalBlock;
+
+public class HorizontalDirectionalBlockBuilder extends BlockBuilder {
+
+	public HorizontalDirectionalBlockBuilder(ResourceLocation i) {
+		super(i);
+	}
+
+	@Override
+	public void generateAssetJsons(AssetJsonGenerator generator) {
+		var baseID = newID("block/", "").toString();
+
+		if (blockstateJson != null) {
+			generator.json(newID("blockstates/", ""), blockstateJson);
+		} else {
+			generator.blockState(id, this::generateBlockStateJson);
+		}
+
+		if (modelJson != null) {
+			generator.json(newID("models/", ""), modelJson);
+		} else {
+			generator.blockModel(id, this::generateBlockModelJsons);
+		}
+		generator.blockModel(id, mg -> {
+
+		});
+
+		if (itemBuilder != null) {
+			generator.itemModel(itemBuilder.id, this::generateItemModelJson);
+		}
+
+	}
+
+	protected void generateBlockStateJson(VariantBlockStateGenerator bs) {
+		var modelLocation = model.isEmpty() ? newID("block/", "").toString() : model;
+		bs.variant("facing=north", v -> v.model(modelLocation));
+		bs.variant("facing=east", v -> v.model(modelLocation).y(90));
+		bs.variant("facing=south", v -> v.model(modelLocation).y(180));
+		bs.variant("facing=west", v -> v.model(modelLocation).y(270));
+	}
+
+	protected void generateBlockModelJsons(ModelGenerator mg) {
+		var side = getTextureOrDefault("side", newID("block/", "").toString());
+		mg.texture("side", side);
+		mg.texture("front", getTextureOrDefault("front", newID("block/", "_front").toString()));
+		mg.texture("particle", textures.get("particle").getAsString());
+		mg.texture("top", getTextureOrDefault("top", side));
+
+		if (textures.has("bottom")) {
+			mg.parent("block/orientable_with_bottom");
+			mg.texture("bottom", textures.get("bottom").getAsString());
+		} else {
+			mg.parent("minecraft:block/orientable");
+		}
+	}
+
+	protected void generateItemModelJson(ModelGenerator mg) {
+		mg.parent(model.isEmpty() ? newID("block/", "").toString() : model);
+	}
+
+	public HorizontalDirectionalBlockBuilder textureFront(String tex) {
+		texture("front", tex);
+		return this;
+	}
+
+	public HorizontalDirectionalBlockBuilder textureSides(String tex) {
+		texture("side", tex);
+		return this;
+	}
+
+	@Override
+	public HorizontalDirectionalBlockBuilder textureAll(String tex) {
+		super.textureAll(tex);
+		texture("side", tex);
+		return this;
+	}
+
+	private String getTextureOrDefault(String name, String defaultTexture) {
+		return textures.has(name)?textures.get(name).getAsString():defaultTexture;
+	}
+
+	@Override
+	public Block createObject() {
+		return new HorizontalDirectionalBlock(createProperties()) {};
+	}
+}

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/custom/HorizontalDirectionalBlockBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/custom/HorizontalDirectionalBlockBuilder.java
@@ -62,8 +62,8 @@ public class HorizontalDirectionalBlockBuilder extends BlockBuilder {
 		}
 	}
 
-	protected void generateItemModelJson(ModelGenerator mg) {
-		mg.parent(model.isEmpty() ? newID("block/", "").toString() : model);
+	protected void generateItemModelJson(ModelGenerator m) {
+		m.parent(model.isEmpty() ? newID("block/", "").toString() : model);
 	}
 
 	@Override

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/custom/HorizontalDirectionalBlockBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/custom/HorizontalDirectionalBlockBuilder.java
@@ -14,10 +14,13 @@ import org.jetbrains.annotations.NotNull;
 
 public class HorizontalDirectionalBlockBuilder extends BlockBuilder {
 
+	// Cardinal blocks that can face any horizontal direction (NSEW).
+
 	public HorizontalDirectionalBlockBuilder(ResourceLocation i) {
 		super(i);
 	}
 
+	@Override
 	protected void generateBlockStateJson(VariantBlockStateGenerator bs) {
 		var modelLocation = model.isEmpty() ? newID("block/", "").toString() : model;
 		bs.variant("facing=north", v -> v.model(modelLocation));
@@ -26,21 +29,26 @@ public class HorizontalDirectionalBlockBuilder extends BlockBuilder {
 		bs.variant("facing=west", v -> v.model(modelLocation).y(270));
 	}
 
-	protected void generateBlockModelJsons(ModelGenerator mg) {
-		var side = getTextureOrDefault("side", newID("block/", "").toString());
-		mg.texture("side", side);
-		mg.texture("front", getTextureOrDefault("front", newID("block/", "_front").toString()));
-		mg.texture("particle", textures.get("particle").getAsString());
-		mg.texture("top", getTextureOrDefault("top", side));
+	@Override
+	protected void generateBlockModelJsons(AssetJsonGenerator gen) {
+		gen.blockModel(id, mg -> {
+			var side = getTextureOrDefault("side", newID("block/", "").toString());
 
-		if (textures.has("bottom")) {
-			mg.parent("block/orientable_with_bottom");
-			mg.texture("bottom", textures.get("bottom").getAsString());
-		} else {
-			mg.parent("minecraft:block/orientable");
-		}
+			mg.texture("side", side);
+			mg.texture("front", getTextureOrDefault("front", newID("block/", "_front").toString()));
+			mg.texture("particle", textures.get("particle").getAsString());
+			mg.texture("top", getTextureOrDefault("top", side));
+
+			if (textures.has("bottom")) {
+				mg.parent("block/orientable_with_bottom");
+				mg.texture("bottom", textures.get("bottom").getAsString());
+			} else {
+				mg.parent("minecraft:block/orientable");
+			}
+		});
 	}
 
+	@Override
 	protected void generateItemModelJson(ModelGenerator m) {
 		m.parent(model.isEmpty() ? newID("block/", "").toString() : model);
 	}

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/custom/HorizontalDirectionalBlockBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/custom/HorizontalDirectionalBlockBuilder.java
@@ -1,13 +1,16 @@
 package dev.latvian.mods.kubejs.block.custom;
 
-import com.google.gson.JsonObject;
 import dev.latvian.mods.kubejs.block.BlockBuilder;
 import dev.latvian.mods.kubejs.client.ModelGenerator;
 import dev.latvian.mods.kubejs.client.VariantBlockStateGenerator;
 import dev.latvian.mods.kubejs.generator.AssetJsonGenerator;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.HorizontalDirectionalBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.StateDefinition;
+import org.jetbrains.annotations.NotNull;
 
 public class HorizontalDirectionalBlockBuilder extends BlockBuilder {
 
@@ -17,7 +20,6 @@ public class HorizontalDirectionalBlockBuilder extends BlockBuilder {
 
 	@Override
 	public void generateAssetJsons(AssetJsonGenerator generator) {
-		var baseID = newID("block/", "").toString();
 
 		if (blockstateJson != null) {
 			generator.json(newID("blockstates/", ""), blockstateJson);
@@ -30,9 +32,6 @@ public class HorizontalDirectionalBlockBuilder extends BlockBuilder {
 		} else {
 			generator.blockModel(id, this::generateBlockModelJsons);
 		}
-		generator.blockModel(id, mg -> {
-
-		});
 
 		if (itemBuilder != null) {
 			generator.itemModel(itemBuilder.id, this::generateItemModelJson);
@@ -67,16 +66,6 @@ public class HorizontalDirectionalBlockBuilder extends BlockBuilder {
 		mg.parent(model.isEmpty() ? newID("block/", "").toString() : model);
 	}
 
-	public HorizontalDirectionalBlockBuilder textureFront(String tex) {
-		texture("front", tex);
-		return this;
-	}
-
-	public HorizontalDirectionalBlockBuilder textureSides(String tex) {
-		texture("side", tex);
-		return this;
-	}
-
 	@Override
 	public HorizontalDirectionalBlockBuilder textureAll(String tex) {
 		super.textureAll(tex);
@@ -85,11 +74,20 @@ public class HorizontalDirectionalBlockBuilder extends BlockBuilder {
 	}
 
 	private String getTextureOrDefault(String name, String defaultTexture) {
-		return textures.has(name)?textures.get(name).getAsString():defaultTexture;
+		return textures.has(name) ? textures.get(name).getAsString() : defaultTexture;
 	}
 
 	@Override
 	public Block createObject() {
-		return new HorizontalDirectionalBlock(createProperties()) {};
+		return new HorizontalDirectionalBlock(createProperties()) {
+			@Override
+			protected void createBlockStateDefinition(@NotNull StateDefinition.Builder<Block, BlockState> builder) {
+				builder.add(FACING);
+			}
+			@Override
+			public BlockState getStateForPlacement(@NotNull BlockPlaceContext arg) {
+				return this.defaultBlockState().setValue(FACING, arg.getHorizontalDirection().getOpposite());
+			}
+		};
 	}
 }

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/custom/MultipartShapedBlockBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/custom/MultipartShapedBlockBuilder.java
@@ -1,0 +1,38 @@
+package dev.latvian.mods.kubejs.block.custom;
+
+import dev.latvian.mods.kubejs.client.MultipartBlockStateGenerator;
+import dev.latvian.mods.kubejs.generator.AssetJsonGenerator;
+import net.minecraft.resources.ResourceLocation;
+
+public abstract class MultipartShapedBlockBuilder extends ShapedBlockBuilder{
+	public MultipartShapedBlockBuilder(ResourceLocation i, String... suffixes) {
+		super(i, suffixes);
+	}
+
+	@Override
+	public void generateAssetJsons(AssetJsonGenerator generator) {
+		if (blockstateJson != null) {
+			generator.json(newID("blockstates/", ""), blockstateJson);
+		} else {
+			generator.multipartState(id, this::generateMultipartBlockstateJson);
+		}
+
+		if (modelJson != null) {
+			generator.json(newID("models/", ""), modelJson);
+		} else {
+			generateBlockModelJsons(generator);
+		}
+
+		if (itemBuilder != null) {
+			if (itemBuilder.modelJson != null) {
+				generator.json(newID("models/item/", ""), itemBuilder.modelJson);
+			} else {
+				generator.itemModel(itemBuilder.id, this::generateItemModelJson);
+			}
+		}
+
+
+	}
+
+	protected abstract void generateMultipartBlockstateJson(MultipartBlockStateGenerator bs);
+}

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/custom/MultipartShapedBlockBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/custom/MultipartShapedBlockBuilder.java
@@ -14,7 +14,7 @@ public abstract class MultipartShapedBlockBuilder extends ShapedBlockBuilder{
 		if (blockstateJson != null) {
 			generator.json(newID("blockstates/", ""), blockstateJson);
 		} else {
-			generator.multipartState(id, this::generateMultipartBlockstateJson);
+			generator.multipartState(id, this::generateMultipartBlockStateJson);
 		}
 
 		if (modelJson != null) {
@@ -34,5 +34,5 @@ public abstract class MultipartShapedBlockBuilder extends ShapedBlockBuilder{
 
 	}
 
-	protected abstract void generateMultipartBlockstateJson(MultipartBlockStateGenerator bs);
+	protected abstract void generateMultipartBlockStateJson(MultipartBlockStateGenerator bs);
 }

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/custom/SlabBlockBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/custom/SlabBlockBuilder.java
@@ -1,5 +1,7 @@
 package dev.latvian.mods.kubejs.block.custom;
 
+import dev.latvian.mods.kubejs.client.ModelGenerator;
+import dev.latvian.mods.kubejs.client.VariantBlockStateGenerator;
 import dev.latvian.mods.kubejs.generator.AssetJsonGenerator;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.BlockTags;
@@ -18,13 +20,14 @@ public class SlabBlockBuilder extends ShapedBlockBuilder {
 	}
 
 	@Override
-	public void generateAssetJsons(AssetJsonGenerator generator) {
-		generator.blockState(id, bs -> {
-			bs.variant("type=double", v -> v.model(newID("block/", "_double").toString()));
-			bs.variant("type=bottom", v -> v.model(newID("block/", "_bottom").toString()));
-			bs.variant("type=top", v -> v.model(newID("block/", "_top").toString()));
-		});
+	protected void generateBlockStateJson(VariantBlockStateGenerator bs) {
+		bs.variant("type=double", v -> v.model(newID("block/", "_double").toString()));
+		bs.variant("type=bottom", v -> v.model(newID("block/", "_bottom").toString()));
+		bs.variant("type=top", v -> v.model(newID("block/", "_top").toString()));
+	}
 
+	@Override
+	protected void generateBlockModelJsons(AssetJsonGenerator generator) {
 		final var texture = textures.get("texture").getAsString();
 
 		generator.blockModel(newID("", "_double"), m -> {
@@ -45,7 +48,10 @@ public class SlabBlockBuilder extends ShapedBlockBuilder {
 			m.texture("top", texture);
 			m.texture("side", texture);
 		});
+	}
 
-		generator.itemModel(itemBuilder.id, m -> m.parent(newID("block/", "_bottom").toString()));
+	@Override
+	protected void generateItemModelJson(ModelGenerator m) {
+		m.parent(newID("block/", "_bottom").toString());
 	}
 }

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/custom/StairBlockBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/custom/StairBlockBuilder.java
@@ -1,5 +1,6 @@
 package dev.latvian.mods.kubejs.block.custom;
 
+import dev.latvian.mods.kubejs.client.VariantBlockStateGenerator;
 import dev.latvian.mods.kubejs.generator.AssetJsonGenerator;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.BlockTags;
@@ -19,55 +20,56 @@ public class StairBlockBuilder extends ShapedBlockBuilder {
 	}
 
 	@Override
-	public void generateAssetJsons(AssetJsonGenerator generator) {
-		generator.blockState(id, bs -> {
-			var mod = newID("block/", "").toString();
-			var modInner = newID("block/", "_inner").toString();
-			var modOuter = newID("block/", "_outer").toString();
+	protected void generateBlockStateJson(VariantBlockStateGenerator bs) {
+		var mod = newID("block/", "").toString();
+		var modInner = newID("block/", "_inner").toString();
+		var modOuter = newID("block/", "_outer").toString();
 
-			bs.variant("facing=east,half=bottom,shape=inner_left", v -> v.model(modInner).y(270).uvlock());
-			bs.variant("facing=east,half=bottom,shape=inner_right", v -> v.model(modInner));
-			bs.variant("facing=east,half=bottom,shape=outer_left", v -> v.model(modOuter).y(270).uvlock());
-			bs.variant("facing=east,half=bottom,shape=outer_right", v -> v.model(modOuter));
-			bs.variant("facing=east,half=bottom,shape=straight", v -> v.model(mod));
-			bs.variant("facing=east,half=top,shape=inner_left", v -> v.model(modInner).x(180).uvlock());
-			bs.variant("facing=east,half=top,shape=inner_right", v -> v.model(modInner).x(180).y(90).uvlock());
-			bs.variant("facing=east,half=top,shape=outer_left", v -> v.model(modOuter).x(180).uvlock());
-			bs.variant("facing=east,half=top,shape=outer_right", v -> v.model(modOuter).x(180).y(90).uvlock());
-			bs.variant("facing=east,half=top,shape=straight", v -> v.model(mod).x(180).uvlock());
-			bs.variant("facing=north,half=bottom,shape=inner_left", v -> v.model(modInner).y(180).uvlock());
-			bs.variant("facing=north,half=bottom,shape=inner_right", v -> v.model(modInner).y(270).uvlock());
-			bs.variant("facing=north,half=bottom,shape=outer_left", v -> v.model(modOuter).y(180).uvlock());
-			bs.variant("facing=north,half=bottom,shape=outer_right", v -> v.model(modOuter).y(270).uvlock());
-			bs.variant("facing=north,half=bottom,shape=straight", v -> v.model(mod).y(270).uvlock());
-			bs.variant("facing=north,half=top,shape=inner_left", v -> v.model(modInner).x(180).y(270).uvlock());
-			bs.variant("facing=north,half=top,shape=inner_right", v -> v.model(modInner).x(180).uvlock());
-			bs.variant("facing=north,half=top,shape=outer_left", v -> v.model(modOuter).x(180).y(270).uvlock());
-			bs.variant("facing=north,half=top,shape=outer_right", v -> v.model(modOuter).x(180).uvlock());
-			bs.variant("facing=north,half=top,shape=straight", v -> v.model(mod).x(180).y(270).uvlock());
-			bs.variant("facing=south,half=bottom,shape=inner_left", v -> v.model(modInner));
-			bs.variant("facing=south,half=bottom,shape=inner_right", v -> v.model(modInner).y(90).uvlock());
-			bs.variant("facing=south,half=bottom,shape=outer_left", v -> v.model(modOuter));
-			bs.variant("facing=south,half=bottom,shape=outer_right", v -> v.model(modOuter).y(90).uvlock());
-			bs.variant("facing=south,half=bottom,shape=straight", v -> v.model(mod).y(90).uvlock());
-			bs.variant("facing=south,half=top,shape=inner_left", v -> v.model(modInner).x(180).y(90).uvlock());
-			bs.variant("facing=south,half=top,shape=inner_right", v -> v.model(modInner).x(180).y(180).uvlock());
-			bs.variant("facing=south,half=top,shape=outer_left", v -> v.model(modOuter).x(180).y(90).uvlock());
-			bs.variant("facing=south,half=top,shape=outer_right", v -> v.model(modOuter).x(180).y(180).uvlock());
-			bs.variant("facing=south,half=top,shape=straight", v -> v.model(mod).x(180).y(90).uvlock());
-			bs.variant("facing=west,half=bottom,shape=inner_left", v -> v.model(modInner).y(90).uvlock());
-			bs.variant("facing=west,half=bottom,shape=inner_right", v -> v.model(modInner).y(180).uvlock());
-			bs.variant("facing=west,half=bottom,shape=outer_left", v -> v.model(modOuter).y(90).uvlock());
-			bs.variant("facing=west,half=bottom,shape=outer_right", v -> v.model(modOuter).y(180).uvlock());
-			bs.variant("facing=west,half=bottom,shape=straight", v -> v.model(mod).y(180).uvlock());
-			bs.variant("facing=west,half=top,shape=inner_left", v -> v.model(modInner).x(180).y(180).uvlock());
-			bs.variant("facing=west,half=top,shape=inner_right", v -> v.model(modInner).x(180).y(270).uvlock());
-			bs.variant("facing=west,half=top,shape=outer_left", v -> v.model(modOuter).x(180).y(180).uvlock());
-			bs.variant("facing=west,half=top,shape=outer_right", v -> v.model(modOuter).x(180).y(270).uvlock());
-			bs.variant("facing=west,half=top,shape=straight", v -> v.model(mod).x(180).y(180).uvlock());
-		});
+		bs.variant("facing=east,half=bottom,shape=inner_left", v -> v.model(modInner).y(270).uvlock());
+		bs.variant("facing=east,half=bottom,shape=inner_right", v -> v.model(modInner));
+		bs.variant("facing=east,half=bottom,shape=outer_left", v -> v.model(modOuter).y(270).uvlock());
+		bs.variant("facing=east,half=bottom,shape=outer_right", v -> v.model(modOuter));
+		bs.variant("facing=east,half=bottom,shape=straight", v -> v.model(mod));
+		bs.variant("facing=east,half=top,shape=inner_left", v -> v.model(modInner).x(180).uvlock());
+		bs.variant("facing=east,half=top,shape=inner_right", v -> v.model(modInner).x(180).y(90).uvlock());
+		bs.variant("facing=east,half=top,shape=outer_left", v -> v.model(modOuter).x(180).uvlock());
+		bs.variant("facing=east,half=top,shape=outer_right", v -> v.model(modOuter).x(180).y(90).uvlock());
+		bs.variant("facing=east,half=top,shape=straight", v -> v.model(mod).x(180).uvlock());
+		bs.variant("facing=north,half=bottom,shape=inner_left", v -> v.model(modInner).y(180).uvlock());
+		bs.variant("facing=north,half=bottom,shape=inner_right", v -> v.model(modInner).y(270).uvlock());
+		bs.variant("facing=north,half=bottom,shape=outer_left", v -> v.model(modOuter).y(180).uvlock());
+		bs.variant("facing=north,half=bottom,shape=outer_right", v -> v.model(modOuter).y(270).uvlock());
+		bs.variant("facing=north,half=bottom,shape=straight", v -> v.model(mod).y(270).uvlock());
+		bs.variant("facing=north,half=top,shape=inner_left", v -> v.model(modInner).x(180).y(270).uvlock());
+		bs.variant("facing=north,half=top,shape=inner_right", v -> v.model(modInner).x(180).uvlock());
+		bs.variant("facing=north,half=top,shape=outer_left", v -> v.model(modOuter).x(180).y(270).uvlock());
+		bs.variant("facing=north,half=top,shape=outer_right", v -> v.model(modOuter).x(180).uvlock());
+		bs.variant("facing=north,half=top,shape=straight", v -> v.model(mod).x(180).y(270).uvlock());
+		bs.variant("facing=south,half=bottom,shape=inner_left", v -> v.model(modInner));
+		bs.variant("facing=south,half=bottom,shape=inner_right", v -> v.model(modInner).y(90).uvlock());
+		bs.variant("facing=south,half=bottom,shape=outer_left", v -> v.model(modOuter));
+		bs.variant("facing=south,half=bottom,shape=outer_right", v -> v.model(modOuter).y(90).uvlock());
+		bs.variant("facing=south,half=bottom,shape=straight", v -> v.model(mod).y(90).uvlock());
+		bs.variant("facing=south,half=top,shape=inner_left", v -> v.model(modInner).x(180).y(90).uvlock());
+		bs.variant("facing=south,half=top,shape=inner_right", v -> v.model(modInner).x(180).y(180).uvlock());
+		bs.variant("facing=south,half=top,shape=outer_left", v -> v.model(modOuter).x(180).y(90).uvlock());
+		bs.variant("facing=south,half=top,shape=outer_right", v -> v.model(modOuter).x(180).y(180).uvlock());
+		bs.variant("facing=south,half=top,shape=straight", v -> v.model(mod).x(180).y(90).uvlock());
+		bs.variant("facing=west,half=bottom,shape=inner_left", v -> v.model(modInner).y(90).uvlock());
+		bs.variant("facing=west,half=bottom,shape=inner_right", v -> v.model(modInner).y(180).uvlock());
+		bs.variant("facing=west,half=bottom,shape=outer_left", v -> v.model(modOuter).y(90).uvlock());
+		bs.variant("facing=west,half=bottom,shape=outer_right", v -> v.model(modOuter).y(180).uvlock());
+		bs.variant("facing=west,half=bottom,shape=straight", v -> v.model(mod).y(180).uvlock());
+		bs.variant("facing=west,half=top,shape=inner_left", v -> v.model(modInner).x(180).y(180).uvlock());
+		bs.variant("facing=west,half=top,shape=inner_right", v -> v.model(modInner).x(180).y(270).uvlock());
+		bs.variant("facing=west,half=top,shape=outer_left", v -> v.model(modOuter).x(180).y(180).uvlock());
+		bs.variant("facing=west,half=top,shape=outer_right", v -> v.model(modOuter).x(180).y(270).uvlock());
+		bs.variant("facing=west,half=top,shape=straight", v -> v.model(mod).x(180).y(180).uvlock());
+	}
 
-		final var texture = textures.get("texture").getAsString();
+	@Override
+	protected void generateBlockModelJsons(AssetJsonGenerator generator) {
+		var texture = textures.get("texture").getAsString();
 
 		generator.blockModel(id, m -> {
 			m.parent("minecraft:block/stairs");
@@ -89,7 +91,5 @@ public class StairBlockBuilder extends ShapedBlockBuilder {
 			m.texture("top", texture);
 			m.texture("side", texture);
 		});
-
-		generator.itemModel(itemBuilder.id, m -> m.parent(newID("block/", "").toString()));
 	}
 }

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/custom/StoneButtonBlockBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/custom/StoneButtonBlockBuilder.java
@@ -1,5 +1,7 @@
 package dev.latvian.mods.kubejs.block.custom;
 
+import dev.latvian.mods.kubejs.client.ModelGenerator;
+import dev.latvian.mods.kubejs.client.VariantBlockStateGenerator;
 import dev.latvian.mods.kubejs.generator.AssetJsonGenerator;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.BlockTags;
@@ -19,38 +21,39 @@ public class StoneButtonBlockBuilder extends ShapedBlockBuilder {
 	}
 
 	@Override
-	public void generateAssetJsons(AssetJsonGenerator generator) {
-		generator.blockState(id, bs -> {
-			var mod0 = newID("block/", "").toString();
-			var mod1 = newID("block/", "_pressed").toString();
+	protected void generateBlockStateJson(VariantBlockStateGenerator bs) {
+		var mod0 = newID("block/", "").toString();
+		var mod1 = newID("block/", "_pressed").toString();
 
-			bs.variant("face=ceiling,facing=east,powered=false", v -> v.model(mod0).x(180).y(270));
-			bs.variant("face=ceiling,facing=east,powered=true", v -> v.model(mod1).x(180).y(270));
-			bs.variant("face=ceiling,facing=north,powered=false", v -> v.model(mod0).x(180).y(180));
-			bs.variant("face=ceiling,facing=north,powered=true", v -> v.model(mod1).x(180).y(180));
-			bs.variant("face=ceiling,facing=south,powered=false", v -> v.model(mod0).x(180));
-			bs.variant("face=ceiling,facing=south,powered=true", v -> v.model(mod1).x(180));
-			bs.variant("face=ceiling,facing=west,powered=false", v -> v.model(mod0).x(180).y(90));
-			bs.variant("face=ceiling,facing=west,powered=true", v -> v.model(mod1).x(180).y(90));
-			bs.variant("face=floor,facing=east,powered=false", v -> v.model(mod0).y(90));
-			bs.variant("face=floor,facing=east,powered=true", v -> v.model(mod1).y(90));
-			bs.variant("face=floor,facing=north,powered=false", v -> v.model(mod0));
-			bs.variant("face=floor,facing=north,powered=true", v -> v.model(mod1));
-			bs.variant("face=floor,facing=south,powered=false", v -> v.model(mod0).y(180));
-			bs.variant("face=floor,facing=south,powered=true", v -> v.model(mod1).y(180));
-			bs.variant("face=floor,facing=west,powered=false", v -> v.model(mod0).y(270));
-			bs.variant("face=floor,facing=west,powered=true", v -> v.model(mod1).y(270));
-			bs.variant("face=wall,facing=east,powered=false", v -> v.model(mod0).x(90).y(90).uvlock());
-			bs.variant("face=wall,facing=east,powered=true", v -> v.model(mod1).x(90).y(90).uvlock());
-			bs.variant("face=wall,facing=north,powered=false", v -> v.model(mod0).x(90).uvlock());
-			bs.variant("face=wall,facing=north,powered=true", v -> v.model(mod1).x(90).uvlock());
-			bs.variant("face=wall,facing=south,powered=false", v -> v.model(mod0).x(90).y(180).uvlock());
-			bs.variant("face=wall,facing=south,powered=true", v -> v.model(mod1).x(90).y(180).uvlock());
-			bs.variant("face=wall,facing=west,powered=false", v -> v.model(mod0).x(90).y(270).uvlock());
-			bs.variant("face=wall,facing=west,powered=true", v -> v.model(mod1).x(90).y(270).uvlock());
-		});
+		bs.variant("face=ceiling,facing=east,powered=false", v -> v.model(mod0).x(180).y(270));
+		bs.variant("face=ceiling,facing=east,powered=true", v -> v.model(mod1).x(180).y(270));
+		bs.variant("face=ceiling,facing=north,powered=false", v -> v.model(mod0).x(180).y(180));
+		bs.variant("face=ceiling,facing=north,powered=true", v -> v.model(mod1).x(180).y(180));
+		bs.variant("face=ceiling,facing=south,powered=false", v -> v.model(mod0).x(180));
+		bs.variant("face=ceiling,facing=south,powered=true", v -> v.model(mod1).x(180));
+		bs.variant("face=ceiling,facing=west,powered=false", v -> v.model(mod0).x(180).y(90));
+		bs.variant("face=ceiling,facing=west,powered=true", v -> v.model(mod1).x(180).y(90));
+		bs.variant("face=floor,facing=east,powered=false", v -> v.model(mod0).y(90));
+		bs.variant("face=floor,facing=east,powered=true", v -> v.model(mod1).y(90));
+		bs.variant("face=floor,facing=north,powered=false", v -> v.model(mod0));
+		bs.variant("face=floor,facing=north,powered=true", v -> v.model(mod1));
+		bs.variant("face=floor,facing=south,powered=false", v -> v.model(mod0).y(180));
+		bs.variant("face=floor,facing=south,powered=true", v -> v.model(mod1).y(180));
+		bs.variant("face=floor,facing=west,powered=false", v -> v.model(mod0).y(270));
+		bs.variant("face=floor,facing=west,powered=true", v -> v.model(mod1).y(270));
+		bs.variant("face=wall,facing=east,powered=false", v -> v.model(mod0).x(90).y(90).uvlock());
+		bs.variant("face=wall,facing=east,powered=true", v -> v.model(mod1).x(90).y(90).uvlock());
+		bs.variant("face=wall,facing=north,powered=false", v -> v.model(mod0).x(90).uvlock());
+		bs.variant("face=wall,facing=north,powered=true", v -> v.model(mod1).x(90).uvlock());
+		bs.variant("face=wall,facing=south,powered=false", v -> v.model(mod0).x(90).y(180).uvlock());
+		bs.variant("face=wall,facing=south,powered=true", v -> v.model(mod1).x(90).y(180).uvlock());
+		bs.variant("face=wall,facing=west,powered=false", v -> v.model(mod0).x(90).y(270).uvlock());
+		bs.variant("face=wall,facing=west,powered=true", v -> v.model(mod1).x(90).y(270).uvlock());
+	}
 
-		final var texture = textures.get("texture").getAsString();
+	@Override
+	protected void generateBlockModelJsons(AssetJsonGenerator generator) {
+		var texture = textures.get("texture").getAsString();
 
 		generator.blockModel(id, m -> {
 			m.parent("minecraft:block/button");
@@ -61,10 +64,11 @@ public class StoneButtonBlockBuilder extends ShapedBlockBuilder {
 			m.parent("minecraft:block/button_pressed");
 			m.texture("texture", texture);
 		});
+	}
 
-		generator.itemModel(itemBuilder.id, m -> {
-			m.parent("minecraft:block/button_inventory");
-			m.texture("texture", texture);
-		});
+	@Override
+	protected void generateItemModelJson(ModelGenerator m) {
+		m.parent("minecraft:block/button_inventory");
+		m.texture("texture", textures.get("texture").getAsString());
 	}
 }

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/custom/StonePressurePlateBlockBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/custom/StonePressurePlateBlockBuilder.java
@@ -1,5 +1,7 @@
 package dev.latvian.mods.kubejs.block.custom;
 
+import dev.latvian.mods.kubejs.client.ModelGenerator;
+import dev.latvian.mods.kubejs.client.VariantBlockStateGenerator;
 import dev.latvian.mods.kubejs.generator.AssetJsonGenerator;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.BlockTags;
@@ -20,13 +22,14 @@ public class StonePressurePlateBlockBuilder extends ShapedBlockBuilder {
 	}
 
 	@Override
-	public void generateAssetJsons(AssetJsonGenerator generator) {
-		generator.blockState(id, bs -> {
-			bs.variant("powered=true", v -> v.model(newID("block/", "_down").toString()));
-			bs.variant("powered=false", v -> v.model(newID("block/", "_up").toString()));
-		});
+	protected void generateBlockStateJson(VariantBlockStateGenerator bs) {
+		bs.variant("powered=true", v -> v.model(newID("block/", "_down").toString()));
+		bs.variant("powered=false", v -> v.model(newID("block/", "_up").toString()));
+	}
 
-		final var texture = textures.get("texture").getAsString();
+	@Override
+	protected void generateBlockModelJsons(AssetJsonGenerator generator) {
+		var texture = textures.get("texture").getAsString();
 
 		generator.blockModel(newID("", "_down"), m -> {
 			m.parent("minecraft:block/pressure_plate_down");
@@ -37,7 +40,10 @@ public class StonePressurePlateBlockBuilder extends ShapedBlockBuilder {
 			m.parent("minecraft:block/pressure_plate_up");
 			m.texture("texture", texture);
 		});
+	}
 
-		generator.itemModel(itemBuilder.id, m -> m.parent(newID("block/", "_up").toString()));
+	@Override
+	protected void generateItemModelJson(ModelGenerator m) {
+		m.parent(newID("block/", "_up").toString());
 	}
 }

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/custom/WallBlockBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/custom/WallBlockBuilder.java
@@ -1,12 +1,14 @@
 package dev.latvian.mods.kubejs.block.custom;
 
+import dev.latvian.mods.kubejs.client.ModelGenerator;
+import dev.latvian.mods.kubejs.client.MultipartBlockStateGenerator;
 import dev.latvian.mods.kubejs.generator.AssetJsonGenerator;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.WallBlock;
 
-public class WallBlockBuilder extends ShapedBlockBuilder {
+public class WallBlockBuilder extends MultipartShapedBlockBuilder {
 	public WallBlockBuilder(ResourceLocation i) {
 		super(i, "_wall");
 		tagBoth(BlockTags.WALLS.location());
@@ -18,24 +20,31 @@ public class WallBlockBuilder extends ShapedBlockBuilder {
 	}
 
 	@Override
-	public void generateAssetJsons(AssetJsonGenerator generator) {
-		generator.multipartState(id, bs -> {
-			var modPost = newID("block/", "_post").toString();
-			var modSide = newID("block/", "_side").toString();
-			var modSideTall = newID("block/", "_side_tall").toString();
+	protected void generateMultipartBlockstateJson(MultipartBlockStateGenerator bs) {
+		var modPost = newID("block/", "_post").toString();
+		var modSide = newID("block/", "_side").toString();
+		var modSideTall = newID("block/", "_side_tall").toString();
 
-			bs.part("up=true", modPost);
-			bs.part("north=low", p -> p.model(modSide).uvlock());
-			bs.part("east=low", p -> p.model(modSide).uvlock().y(90));
-			bs.part("south=low", p -> p.model(modSide).uvlock().y(180));
-			bs.part("west=low", p -> p.model(modSide).uvlock().y(270));
-			bs.part("north=tall", p -> p.model(modSideTall).uvlock());
-			bs.part("east=tall", p -> p.model(modSideTall).uvlock().y(90));
-			bs.part("south=tall", p -> p.model(modSideTall).uvlock().y(180));
-			bs.part("west=tall", p -> p.model(modSideTall).uvlock().y(270));
-		});
+		bs.part("up=true", modPost);
+		bs.part("north=low", p -> p.model(modSide).uvlock());
+		bs.part("east=low", p -> p.model(modSide).uvlock().y(90));
+		bs.part("south=low", p -> p.model(modSide).uvlock().y(180));
+		bs.part("west=low", p -> p.model(modSide).uvlock().y(270));
+		bs.part("north=tall", p -> p.model(modSideTall).uvlock());
+		bs.part("east=tall", p -> p.model(modSideTall).uvlock().y(90));
+		bs.part("south=tall", p -> p.model(modSideTall).uvlock().y(180));
+		bs.part("west=tall", p -> p.model(modSideTall).uvlock().y(270));
+	}
 
-		final var texture = textures.get("texture").getAsString();
+	@Override
+	protected void generateItemModelJson(ModelGenerator m) {
+		m.parent("minecraft:block/wall_inventory");
+		m.texture("wall", textures.get("texture").getAsString());
+	}
+
+	@Override
+	protected void generateBlockModelJsons(AssetJsonGenerator generator) {
+		var texture = textures.get("texture").getAsString();
 
 		generator.blockModel(newID("", "_post"), m -> {
 			m.parent("minecraft:block/template_wall_post");
@@ -51,12 +60,6 @@ public class WallBlockBuilder extends ShapedBlockBuilder {
 			m.parent("minecraft:block/template_wall_side_tall");
 			m.texture("wall", texture);
 		});
-
-		generator.itemModel(itemBuilder.id, m -> {
-			m.parent("minecraft:block/wall_inventory");
-			m.texture("wall", texture);
-		});
 	}
-
-	// FIXME: fix connection
+// FIXME: fix connection
 }

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/custom/WallBlockBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/custom/WallBlockBuilder.java
@@ -20,7 +20,7 @@ public class WallBlockBuilder extends MultipartShapedBlockBuilder {
 	}
 
 	@Override
-	protected void generateMultipartBlockstateJson(MultipartBlockStateGenerator bs) {
+	protected void generateMultipartBlockStateJson(MultipartBlockStateGenerator bs) {
 		var modPost = newID("block/", "_post").toString();
 		var modSide = newID("block/", "_side").toString();
 		var modSideTall = newID("block/", "_side_tall").toString();

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/custom/WoodenButtonBlockBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/custom/WoodenButtonBlockBuilder.java
@@ -1,5 +1,7 @@
 package dev.latvian.mods.kubejs.block.custom;
 
+import dev.latvian.mods.kubejs.client.ModelGenerator;
+import dev.latvian.mods.kubejs.client.VariantBlockStateGenerator;
 import dev.latvian.mods.kubejs.generator.AssetJsonGenerator;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.BlockTags;
@@ -20,38 +22,39 @@ public class WoodenButtonBlockBuilder extends ShapedBlockBuilder {
 	}
 
 	@Override
-	public void generateAssetJsons(AssetJsonGenerator generator) {
-		generator.blockState(id, bs -> {
-			var mod0 = newID("block/", "").toString();
-			var mod1 = newID("block/", "_pressed").toString();
+	protected void generateBlockStateJson(VariantBlockStateGenerator bs) {
+		var mod0 = newID("block/", "").toString();
+		var mod1 = newID("block/", "_pressed").toString();
 
-			bs.variant("face=ceiling,facing=east,powered=false", v -> v.model(mod0).x(180).y(270));
-			bs.variant("face=ceiling,facing=east,powered=true", v -> v.model(mod1).x(180).y(270));
-			bs.variant("face=ceiling,facing=north,powered=false", v -> v.model(mod0).x(180).y(180));
-			bs.variant("face=ceiling,facing=north,powered=true", v -> v.model(mod1).x(180).y(180));
-			bs.variant("face=ceiling,facing=south,powered=false", v -> v.model(mod0).x(180));
-			bs.variant("face=ceiling,facing=south,powered=true", v -> v.model(mod1).x(180));
-			bs.variant("face=ceiling,facing=west,powered=false", v -> v.model(mod0).x(180).y(90));
-			bs.variant("face=ceiling,facing=west,powered=true", v -> v.model(mod1).x(180).y(90));
-			bs.variant("face=floor,facing=east,powered=false", v -> v.model(mod0).y(90));
-			bs.variant("face=floor,facing=east,powered=true", v -> v.model(mod1).y(90));
-			bs.variant("face=floor,facing=north,powered=false", v -> v.model(mod0));
-			bs.variant("face=floor,facing=north,powered=true", v -> v.model(mod1));
-			bs.variant("face=floor,facing=south,powered=false", v -> v.model(mod0).y(180));
-			bs.variant("face=floor,facing=south,powered=true", v -> v.model(mod1).y(180));
-			bs.variant("face=floor,facing=west,powered=false", v -> v.model(mod0).y(270));
-			bs.variant("face=floor,facing=west,powered=true", v -> v.model(mod1).y(270));
-			bs.variant("face=wall,facing=east,powered=false", v -> v.model(mod0).x(90).y(90).uvlock());
-			bs.variant("face=wall,facing=east,powered=true", v -> v.model(mod1).x(90).y(90).uvlock());
-			bs.variant("face=wall,facing=north,powered=false", v -> v.model(mod0).x(90).uvlock());
-			bs.variant("face=wall,facing=north,powered=true", v -> v.model(mod1).x(90).uvlock());
-			bs.variant("face=wall,facing=south,powered=false", v -> v.model(mod0).x(90).y(180).uvlock());
-			bs.variant("face=wall,facing=south,powered=true", v -> v.model(mod1).x(90).y(180).uvlock());
-			bs.variant("face=wall,facing=west,powered=false", v -> v.model(mod0).x(90).y(270).uvlock());
-			bs.variant("face=wall,facing=west,powered=true", v -> v.model(mod1).x(90).y(270).uvlock());
-		});
+		bs.variant("face=ceiling,facing=east,powered=false", v -> v.model(mod0).x(180).y(270));
+		bs.variant("face=ceiling,facing=east,powered=true", v -> v.model(mod1).x(180).y(270));
+		bs.variant("face=ceiling,facing=north,powered=false", v -> v.model(mod0).x(180).y(180));
+		bs.variant("face=ceiling,facing=north,powered=true", v -> v.model(mod1).x(180).y(180));
+		bs.variant("face=ceiling,facing=south,powered=false", v -> v.model(mod0).x(180));
+		bs.variant("face=ceiling,facing=south,powered=true", v -> v.model(mod1).x(180));
+		bs.variant("face=ceiling,facing=west,powered=false", v -> v.model(mod0).x(180).y(90));
+		bs.variant("face=ceiling,facing=west,powered=true", v -> v.model(mod1).x(180).y(90));
+		bs.variant("face=floor,facing=east,powered=false", v -> v.model(mod0).y(90));
+		bs.variant("face=floor,facing=east,powered=true", v -> v.model(mod1).y(90));
+		bs.variant("face=floor,facing=north,powered=false", v -> v.model(mod0));
+		bs.variant("face=floor,facing=north,powered=true", v -> v.model(mod1));
+		bs.variant("face=floor,facing=south,powered=false", v -> v.model(mod0).y(180));
+		bs.variant("face=floor,facing=south,powered=true", v -> v.model(mod1).y(180));
+		bs.variant("face=floor,facing=west,powered=false", v -> v.model(mod0).y(270));
+		bs.variant("face=floor,facing=west,powered=true", v -> v.model(mod1).y(270));
+		bs.variant("face=wall,facing=east,powered=false", v -> v.model(mod0).x(90).y(90).uvlock());
+		bs.variant("face=wall,facing=east,powered=true", v -> v.model(mod1).x(90).y(90).uvlock());
+		bs.variant("face=wall,facing=north,powered=false", v -> v.model(mod0).x(90).uvlock());
+		bs.variant("face=wall,facing=north,powered=true", v -> v.model(mod1).x(90).uvlock());
+		bs.variant("face=wall,facing=south,powered=false", v -> v.model(mod0).x(90).y(180).uvlock());
+		bs.variant("face=wall,facing=south,powered=true", v -> v.model(mod1).x(90).y(180).uvlock());
+		bs.variant("face=wall,facing=west,powered=false", v -> v.model(mod0).x(90).y(270).uvlock());
+		bs.variant("face=wall,facing=west,powered=true", v -> v.model(mod1).x(90).y(270).uvlock());
+	}
 
-		final var texture = textures.get("texture").getAsString();
+	@Override
+	protected void generateBlockModelJsons(AssetJsonGenerator generator) {
+		var texture = textures.get("texture").getAsString();
 
 		generator.blockModel(id, m -> {
 			m.parent("minecraft:block/button");
@@ -62,10 +65,11 @@ public class WoodenButtonBlockBuilder extends ShapedBlockBuilder {
 			m.parent("minecraft:block/button_pressed");
 			m.texture("texture", texture);
 		});
+	}
 
-		generator.itemModel(itemBuilder.id, m -> {
-			m.parent("minecraft:block/button_inventory");
-			m.texture("texture", texture);
-		});
+	@Override
+	protected void generateItemModelJson(ModelGenerator m) {
+		m.parent("minecraft:block/button_inventory");
+		m.texture("texture", textures.get("texture").getAsString());
 	}
 }

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/custom/WoodenPressurePlateBlockBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/custom/WoodenPressurePlateBlockBuilder.java
@@ -1,5 +1,7 @@
 package dev.latvian.mods.kubejs.block.custom;
 
+import dev.latvian.mods.kubejs.client.ModelGenerator;
+import dev.latvian.mods.kubejs.client.VariantBlockStateGenerator;
 import dev.latvian.mods.kubejs.generator.AssetJsonGenerator;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.BlockTags;
@@ -20,13 +22,14 @@ public class WoodenPressurePlateBlockBuilder extends ShapedBlockBuilder {
 	}
 
 	@Override
-	public void generateAssetJsons(AssetJsonGenerator generator) {
-		generator.blockState(id, bs -> {
-			bs.variant("powered=true", v -> v.model(newID("block/", "_down").toString()));
-			bs.variant("powered=false", v -> v.model(newID("block/", "_up").toString()));
-		});
+	protected void generateBlockStateJson(VariantBlockStateGenerator bs) {
+		bs.variant("powered=true", v -> v.model(newID("block/", "_down").toString()));
+		bs.variant("powered=false", v -> v.model(newID("block/", "_up").toString()));
+	}
 
-		final var texture = textures.get("texture").getAsString();
+	@Override
+	protected void generateBlockModelJsons(AssetJsonGenerator generator) {
+		var texture = textures.get("texture").getAsString();
 
 		generator.blockModel(newID("", "_down"), m -> {
 			m.parent("minecraft:block/pressure_plate_down");
@@ -37,7 +40,10 @@ public class WoodenPressurePlateBlockBuilder extends ShapedBlockBuilder {
 			m.parent("minecraft:block/pressure_plate_up");
 			m.texture("texture", texture);
 		});
+	}
 
-		generator.itemModel(itemBuilder.id, m -> m.parent(newID("block/", "_up").toString()));
+	@Override
+	protected void generateItemModelJson(ModelGenerator m) {
+		m.parent(newID("block/", "_up").toString());
 	}
 }


### PR DESCRIPTION
```js
onEvent('block.registry', event => {
	event.create('test_block', 'cardinal')
		.texture('side', 'minecraft:block/furnace_top')
		.texture('front', 'minecraft:block/iron_block')
})
```

This also shuffles asset generation around sot it is now in five different methods.
`generateAssetJsons` no longer directly generates the assets. Instead it passes that on to `generateBlockStateJson`, `generateBlockModelJsons` and `generateItemModelJson`. This makes it so that subclasses only need to override the necessary methods.
The fifth method is `generateMultipartBlockstateJson` in `MultipartShapedBlockBuilder`, which should be used for blocks such as fences and walls that use multipart blockstates.
All KubeJS block builders now use this system, meaning that ones that used to remove the checks for the user overriding a model/blockstate json should no longer do that.
This should also not break addons that still override `generateAssetJsons`.