### PR TITLE
Basic BlockState Support and Misc Delegate Methods to LevelJS

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/BuiltinKubeJSPlugin.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/BuiltinKubeJSPlugin.java
@@ -130,6 +130,7 @@ import net.minecraft.world.item.Rarity;
 import net.minecraft.world.item.Tier;
 import net.minecraft.world.item.Tiers;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.levelgen.GenerationStep;
 import net.minecraft.world.level.levelgen.structure.templatesystem.RuleTest;
 import net.minecraft.world.level.storage.loot.LootContext;
@@ -347,6 +348,9 @@ public class BuiltinKubeJSPlugin extends KubeJSPlugin {
 		event.add("Vec3d", Vec3.class);
 		event.add("Vec3i", Vec3i.class);
 		event.add("BlockPos", BlockPos.class);
+
+		event.add("Properties", BlockStateProperties.class);
+		event.add("Property", BlockStateProperties.class);
 
 		KubeJS.PROXY.clientBindings(event);
 	}

--- a/common/src/main/java/dev/latvian/mods/kubejs/BuiltinKubeJSPlugin.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/BuiltinKubeJSPlugin.java
@@ -349,8 +349,7 @@ public class BuiltinKubeJSPlugin extends KubeJSPlugin {
 		event.add("Vec3i", Vec3i.class);
 		event.add("BlockPos", BlockPos.class);
 
-		event.add("Properties", BlockStateProperties.class);
-		event.add("Property", BlockStateProperties.class);
+		event.add("BlockProperties", BlockStateProperties.class);
 
 		KubeJS.PROXY.clientBindings(event);
 	}

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/BlockBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/BlockBuilder.java
@@ -555,49 +555,6 @@ public abstract class BlockBuilder extends BuilderBase<Block> {
 		return this;
 	}
 
-	public BlockBuilder boolProperty(String propertyName) {
-		property(BooleanProperty.create(propertyName));
-		return this;
-	}
-
-	public BlockBuilder intProperty(String propertyName, int min, int max) {
-		property(IntegerProperty.create(propertyName, min, max));
-		return this;
-	}
-
-	public BlockBuilder dirProperty(String propertyName) {
-		property(DirectionProperty.create(propertyName));
-		return this;
-	}
-
-	public BlockBuilder dirProperty(String propertyName, Predicate<Direction> directionPredicate) {
-		property(DirectionProperty.create(propertyName, directionPredicate));
-		return this;
-	}
-
-
-	public BlockBuilder dirProperty(String propertyName, Direction... directions) {
-		property(DirectionProperty.create(propertyName, directions));
-		return this;
-	}
-
-	public <T extends Enum<T> & StringRepresentable> BlockBuilder enumProperty(String propertyName, Class<T> enumClass, Predicate<T> enumPredicate) {
-		EnumProperty<T> property = EnumProperty.create(propertyName, enumClass, enumPredicate);
-		property(property);
-		return this;
-	}
-
-	public <T extends Enum<T> & StringRepresentable> BlockBuilder enumProperty(String propertyName, Class<T> enumClass, T... enums) {
-		EnumProperty<T> property;
-		if(enums.length <= 1) {
-			property = EnumProperty.create(propertyName, enumClass);
-		} else {
-			property = EnumProperty.create(propertyName, enumClass, enums);
-		}
-		property(property);
-		return this;
-	}
-
 	public Block.Properties createProperties() {
 		var properties = BlockBehaviour.Properties.of(material.getMinecraftMaterial());
 		properties.sound(material.getSound());

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/BlockBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/BlockBuilder.java
@@ -20,15 +20,10 @@ import net.minecraft.client.renderer.RenderType;
 import net.minecraft.core.Direction;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.PackType;
-import net.minecraft.util.StringRepresentable;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
-import net.minecraft.world.level.block.state.properties.BooleanProperty;
-import net.minecraft.world.level.block.state.properties.DirectionProperty;
-import net.minecraft.world.level.block.state.properties.EnumProperty;
-import net.minecraft.world.level.block.state.properties.IntegerProperty;
 import net.minecraft.world.level.block.state.properties.Property;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.shapes.Shapes;
@@ -37,10 +32,11 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
-import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 /**
@@ -76,7 +72,7 @@ public abstract class BlockBuilder extends BuilderBase<Block> {
 	public transient boolean viewBlocking;
 	public transient boolean redstoneConductor;
 	public transient boolean transparent;
-	public transient List<Property<?>> blockStateProperties;
+	public transient Set<Property<?>> blockStateProperties;
 	public transient Consumer<BlockStateModifyCallbackJS> defaultStateModification;
 	public transient Consumer<BlockStateModifyPlacementCallbackJS> placementStateModification;
 
@@ -115,7 +111,7 @@ public abstract class BlockBuilder extends BuilderBase<Block> {
 		viewBlocking = true;
 		redstoneConductor = true;
 		transparent = false;
-		blockStateProperties = new ArrayList<>();
+		blockStateProperties = new HashSet<>();
 		defaultStateModification = null;
 		placementStateModification = null;
 	}

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/BlockBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/BlockBuilder.java
@@ -442,7 +442,7 @@ public abstract class BlockBuilder extends BuilderBase<Block> {
 	@Deprecated
 	public BlockBuilder waterlogged() {
 		property(BlockStateProperties.WATERLOGGED);
-		KubeJS.startupScriptManager.type.console.warn("Use of deprecated method \"BlockBuilder.waterlogged\". Please use \"BlockBuilder.property(Property.WATERLOGGED)\" moving forward.");
+		KubeJS.startupScriptManager.type.console.warn("Use of deprecated method \"BlockBuilder.waterlogged\". Please use \"BlockBuilder.property(BlockProperties.WATERLOGGED)\" moving forward.");
 		return this;
 	}
 

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/BlockStateModifyCallbackJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/BlockStateModifyCallbackJS.java
@@ -3,10 +3,14 @@ package dev.latvian.mods.kubejs.block;
 import com.google.common.collect.ImmutableMap;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.util.StringRepresentable;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.Mirror;
 import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.BooleanProperty;
+import net.minecraft.world.level.block.state.properties.EnumProperty;
+import net.minecraft.world.level.block.state.properties.IntegerProperty;
 import net.minecraft.world.level.block.state.properties.Property;
 
 import java.util.Collection;
@@ -45,6 +49,10 @@ public class BlockStateModifyCallbackJS {
 		return state.getValue(property);
 	}
 
+	public <T extends Comparable<T>> T get(Property<T> property) {
+		return state.getValue(property);
+	}
+
 	public <T extends Comparable<T>> Optional<T> getOptionalValue(Property<T> property) {
 		return state.getOptionalValue(property);
 	}
@@ -53,6 +61,27 @@ public class BlockStateModifyCallbackJS {
 		this.state = state.setValue(property, comparable);
 		return this;
 	}
+
+	public BlockStateModifyCallbackJS set(BooleanProperty property, boolean value) {
+		this.state = state.setValue(property, value);
+		return this;
+	}
+
+	public BlockStateModifyCallbackJS set(IntegerProperty property, Integer value) {
+		this.state = state.setValue(property, value);
+		return this;
+	}
+
+	public <T extends Enum<T> & StringRepresentable> BlockStateModifyCallbackJS set(EnumProperty<T> property, T value) {
+		this.state = state.setValue(property, value);
+		return this;
+	}
+
+	public <T extends Enum<T> & StringRepresentable> BlockStateModifyCallbackJS set(EnumProperty<T> property, String value) {
+		this.state = state.setValue(property, property.getValue(value).get());
+		return this;
+	}
+
 
 	public BlockStateModifyCallbackJS populateNeighbours(Map<Map<Property<?>, Comparable<?>>, BlockState> map) {
 		state.populateNeighbours(map);
@@ -77,4 +106,6 @@ public class BlockStateModifyCallbackJS {
 		this.state = state.updateShape(direction, blockState, levelAccessor, blockPos, blockPos2);
 		return this;
 	}
+
+
 }

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/BlockStateModifyCallbackJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/BlockStateModifyCallbackJS.java
@@ -19,8 +19,9 @@ public class BlockStateModifyCallbackJS {
 		this.state = state;
 	}
 
-	public <T extends Comparable<T>> BlockState cycle(Property<T> property) {
-		return this.state = state.cycle(property);
+	public <T extends Comparable<T>> BlockStateModifyCallbackJS cycle(Property<T> property) {
+		this.state = state.cycle(property);
+		return this;
 	}
 
 	public BlockState getState() {
@@ -48,27 +49,32 @@ public class BlockStateModifyCallbackJS {
 		return state.getOptionalValue(property);
 	}
 
-	public <T extends Comparable<T>, V extends T> BlockState setValue(Property<T> property, V comparable) {
-		return this.state = state.setValue(property, comparable);
+	public <T extends Comparable<T>, V extends T> BlockStateModifyCallbackJS setValue(Property<T> property, V comparable) {
+		this.state = state.setValue(property, comparable);
+		return this;
 	}
 
-	public void populateNeighbours(Map<Map<Property<?>, Comparable<?>>, BlockState> map) {
+	public BlockStateModifyCallbackJS populateNeighbours(Map<Map<Property<?>, Comparable<?>>, BlockState> map) {
 		state.populateNeighbours(map);
+		return this;
 	}
 
 	public ImmutableMap<Property<?>, Comparable<?>> getValues() {
 		return state.getValues();
 	}
 
-	public BlockState rotate(Rotation rotation) {
-		return this.state = state.rotate(rotation);
+	public BlockStateModifyCallbackJS rotate(Rotation rotation) {
+		this.state = state.rotate(rotation);
+		return this;
 	}
 
-	public BlockState mirror(Mirror mirror) {
-		return this.state = state.mirror(mirror);
+	public BlockStateModifyCallbackJS mirror(Mirror mirror) {
+		this.state = state.mirror(mirror);
+		return this;
 	}
 
-	public BlockState updateShape(Direction direction, BlockState blockState, LevelAccessor levelAccessor, BlockPos blockPos, BlockPos blockPos2) {
-		return this.state = state.updateShape(direction, blockState, levelAccessor, blockPos, blockPos2);
+	public BlockStateModifyCallbackJS updateShape(Direction direction, BlockState blockState, LevelAccessor levelAccessor, BlockPos blockPos, BlockPos blockPos2) {
+		this.state = state.updateShape(direction, blockState, levelAccessor, blockPos, blockPos2);
+		return this;
 	}
 }

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/BlockStateModifyCallbackJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/BlockStateModifyCallbackJS.java
@@ -1,0 +1,74 @@
+package dev.latvian.mods.kubejs.block;
+
+import com.google.common.collect.ImmutableMap;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.level.block.Mirror;
+import net.minecraft.world.level.block.Rotation;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.Property;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+
+public class BlockStateModifyCallbackJS {
+	private BlockState state;
+	public BlockStateModifyCallbackJS(BlockState state) {
+		this.state = state;
+	}
+
+	public <T extends Comparable<T>> BlockState cycle(Property<T> property) {
+		return this.state = state.cycle(property);
+	}
+
+	public BlockState getState() {
+		return state;
+	}
+
+	@Override
+	public String toString() {
+		return state.toString();
+	}
+
+	public Collection<Property<?>> getProperties() {
+		return state.getProperties();
+	}
+
+	public <T extends Comparable<T>> boolean hasProperty(Property<T> property) {
+		return state.hasProperty(property);
+	}
+
+	public <T extends Comparable<T>> T getValue(Property<T> property) {
+		return state.getValue(property);
+	}
+
+	public <T extends Comparable<T>> Optional<T> getOptionalValue(Property<T> property) {
+		return state.getOptionalValue(property);
+	}
+
+	public <T extends Comparable<T>, V extends T> BlockState setValue(Property<T> property, V comparable) {
+		return this.state = state.setValue(property, comparable);
+	}
+
+	public void populateNeighbours(Map<Map<Property<?>, Comparable<?>>, BlockState> map) {
+		state.populateNeighbours(map);
+	}
+
+	public ImmutableMap<Property<?>, Comparable<?>> getValues() {
+		return state.getValues();
+	}
+
+	public BlockState rotate(Rotation rotation) {
+		return this.state = state.rotate(rotation);
+	}
+
+	public BlockState mirror(Mirror mirror) {
+		return this.state = state.mirror(mirror);
+	}
+
+	public BlockState updateShape(Direction direction, BlockState blockState, LevelAccessor levelAccessor, BlockPos blockPos, BlockPos blockPos2) {
+		return this.state = state.updateShape(direction, blockState, levelAccessor, blockPos, blockPos2);
+	}
+}

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/BlockStateModifyPlacementCallbackJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/BlockStateModifyPlacementCallbackJS.java
@@ -10,7 +10,6 @@ import net.minecraft.core.Direction;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.FluidState;

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/BlockStateModifyPlacementCallbackJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/BlockStateModifyPlacementCallbackJS.java
@@ -67,7 +67,7 @@ public class BlockStateModifyPlacementCallbackJS extends BlockStateModifyCallbac
 		return context.isInside();
 	}
 
-	public ItemStackJS getItemInHand() {
+	public ItemStackJS getItem() {
 		return ItemStackJS.of(context.getItemInHand());
 	}
 

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/BlockStateModifyPlacementCallbackJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/BlockStateModifyPlacementCallbackJS.java
@@ -106,12 +106,17 @@ public class BlockStateModifyPlacementCallbackJS extends BlockStateModifyCallbac
 		return getFluidStateAtClickedPos().is(fluid);
 	}
 
-	public BlockStateModifyPlacementCallbackJS waterlogged() {
-		setValue(BlockStateProperties.WATERLOGGED, isWaterLogged());
+	public BlockStateModifyPlacementCallbackJS waterlogged(boolean waterlogged) {
+		setValue(BlockStateProperties.WATERLOGGED, waterlogged);
 		return this;
 	}
 
-	public boolean isWaterLogged() {
+	public BlockStateModifyPlacementCallbackJS waterlogged() {
+		waterlogged(isInWater());
+		return this;
+	}
+
+	public boolean isInWater() {
 		return getFluidStateAtClickedPos().getType() == Fluids.WATER;
 	}
 }

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/BlockStateModifyPlacementCallbackJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/BlockStateModifyPlacementCallbackJS.java
@@ -1,0 +1,106 @@
+package dev.latvian.mods.kubejs.block;
+
+import dev.latvian.mods.kubejs.item.ItemStackJS;
+import dev.latvian.mods.kubejs.level.BlockContainerJS;
+import dev.latvian.mods.kubejs.level.LevelJS;
+import dev.latvian.mods.kubejs.player.PlayerJS;
+import dev.latvian.mods.kubejs.util.UtilsJS;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.item.context.BlockPlaceContext;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.material.Fluid;
+import net.minecraft.world.level.material.FluidState;
+import net.minecraft.world.phys.Vec3;
+import org.jetbrains.annotations.Nullable;
+
+public class BlockStateModifyPlacementCallbackJS extends BlockStateModifyCallbackJS {
+	public final BlockPlaceContext context;
+	public final Block minecraftBlock;
+	public BlockContainerJS block;
+
+	public BlockStateModifyPlacementCallbackJS(BlockPlaceContext context, Block block) {
+		super(block.defaultBlockState());
+		this.context = context;
+		this.minecraftBlock = block;
+		this.block = new BlockContainerJS(context.getLevel(), context.getClickedPos());
+	}
+
+	public BlockPos getClickedPos() {
+		return context.getClickedPos();
+	}
+
+	public BlockContainerJS getClickedBlock() {
+		return getLevel().getBlock(context.getClickedPos());
+	}
+
+	public boolean canPlace() {
+		return context.canPlace();
+	}
+
+	public boolean replacingClickedOnBlock() {
+		return context.replacingClickedOnBlock();
+	}
+
+	public Direction getNearestLookingDirection() {
+		return context.getNearestLookingDirection();
+	}
+
+	public Direction getNearestLookingVerticalDirection() {
+		return context.getNearestLookingVerticalDirection();
+	}
+
+	public Direction[] getNearestLookingDirections() {
+		return context.getNearestLookingDirections();
+	}
+
+	public Direction getClickedFace() {
+		return context.getClickedFace();
+	}
+
+	public Vec3 getClickLocation() {
+		return context.getClickLocation();
+	}
+
+	public boolean isInside() {
+		return context.isInside();
+	}
+
+	public ItemStackJS getItemInHand() {
+		return ItemStackJS.of(context.getItemInHand());
+	}
+
+	@Nullable
+	public PlayerJS<?> getPlayer() {
+		return getLevel().getPlayer(context.getPlayer());
+	}
+
+	public InteractionHand getHand() {
+		return context.getHand();
+	}
+
+	public LevelJS getLevel() {
+		return UtilsJS.getLevel(context.getLevel());
+	}
+
+	public Direction getHorizontalDirection() {
+		return context.getHorizontalDirection();
+	}
+
+	public boolean isSecondaryUseActive() {
+		return context.isSecondaryUseActive();
+	}
+
+	public float getRotation() {
+		return context.getRotation();
+	}
+
+	public FluidState getFluidStateAtClickedPos() {
+		return context.getLevel().getFluidState(context.getClickedPos());
+	}
+
+	public boolean isClickedPosIn(Fluid fluid) {
+		return getFluidStateAtClickedPos().is(fluid);
+	}
+}

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/BlockStateModifyPlacementCallbackJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/BlockStateModifyPlacementCallbackJS.java
@@ -10,8 +10,11 @@ import net.minecraft.core.Direction;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Rotation;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.FluidState;
+import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.Nullable;
 
@@ -102,5 +105,14 @@ public class BlockStateModifyPlacementCallbackJS extends BlockStateModifyCallbac
 
 	public boolean isClickedPosIn(Fluid fluid) {
 		return getFluidStateAtClickedPos().is(fluid);
+	}
+
+	public BlockStateModifyPlacementCallbackJS waterlogged() {
+		setValue(BlockStateProperties.WATERLOGGED, isWaterLogged());
+		return this;
+	}
+
+	public boolean isWaterLogged() {
+		return getFluidStateAtClickedPos().getType() == Fluids.WATER;
 	}
 }

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/custom/BasicBlockJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/custom/BasicBlockJS.java
@@ -98,7 +98,8 @@ public class BasicBlockJS extends Block implements EntityBlockKJS {
 			if (!safeCallback(blockBuilder.placementStateModification, callbackJS, "Error while modifying BlockState placement of " + blockBuilder.id)) {
 				return callbackJS.getState();
 			}
-		} else if (!blockBuilder.waterlogged) {
+		}
+		if (!blockBuilder.waterlogged) {
 			return defaultBlockState();
 		}
 

--- a/common/src/main/java/dev/latvian/mods/kubejs/level/LevelJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/level/LevelJS.java
@@ -17,6 +17,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.Difficulty;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
@@ -25,6 +26,7 @@ import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.border.WorldBorder;
 import net.minecraft.world.phys.AABB;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
@@ -190,6 +192,22 @@ public abstract class LevelJS implements WithAttachedData {
 
 	public EntityArrayList getEntitiesWithin(AABB aabb) {
 		return new EntityArrayList(this, minecraftLevel.getEntities(null, aabb));
+	}
+
+	public WorldBorder getWorldBorder() {
+		return minecraftLevel.getWorldBorder();
+	}
+
+	public Difficulty getDifficulty() {
+		return minecraftLevel.getDifficulty();
+	}
+
+	public float getMoonBrightness() {
+		return minecraftLevel.getMoonBrightness();
+	}
+
+	public int getMoonPhase() {
+		return minecraftLevel.getMoonPhase();
 	}
 
 	@ApiStatus.OverrideOnly


### PR DESCRIPTION
Added BlockState Support to Custom Blocks
**--Modifications--**
BuiltinKubeJSPlugin:
- Added "BlockProperties" binding to BlockStateProperties class.

LevelJS:
- Added Delegate Methods for the following:
  - getWorldBorder()
  - getDifficulty()
  - getMoonPhase()
  - getMoonBrightness()

BlockBuilder:
 - Added set of BlockState properties
 - Added defaultStateModification callback, usable with `defaultState`
 - Added placementStateModification callback, usable with `placementState`
 - Added "BlockBuilder.property(Property)" for use with "BlockProperties" binding or any BlockstateProperty
 - Deprecated waterlogged and removed all usages of waterlogged.

BasicBlockJS
 - Implemented BlockBuilder.defaultState
 - Implemented BlockBuilder.placementState
 - Removed usages of BlockBuilder.waterlogged in a handful of places without removing functionality.
 - Added private method safeCallback for catching and logging exceptions in callback functions to startup script console.
 - Fixed waterlogged not being bucket friendly.

Additions:
 - BlockStateModifyCallbackJS (Used for registering default state)
 - BlockStateModifyPlacementCallbackJS (Used for modifying blockstate on placement, extension of BlockStateModifyCallbackJS)


Example Startup Script:
```js
global["defaultStateHandler"] = function(event) {
	let prop = BlockProperties.NOTEBLOCK_INSTRUMENT;
	// console.log(BlockProperties.NOTEBLOCK_INSTRUMENT.getPossibleValues());
	// console.log(BlockProperties.NOTEBLOCK_INSTRUMENT.getValue("bell"))

	event.set(prop, "bell");
}

global["placementStateHandler"] = function(event) {
	if(event.clickedPos.x % 2 ==0) {
		//event.set(BlockProperties.WATERLOGGED, true);
		event.waterlogged(true);
	}else {
		//event.set(BlockProperties.WATERLOGGED, false);
		event.waterlogged(false);
		
	}
}
onEvent('block.registry', event => {
	event.create('example_block')
			.material('wood')
			.hardness(1.0)
			.displayName('Example Block')
			.property(BlockProperties.NOTEBLOCK_INSTRUMENT)
			.property(BlockProperties.WATERLOGGED)
			.property(BlockProperties.BITES)
			.defaultState((event) => {global["defaultStateHandler"](event);})
			.placementState((event) => {global["placementStateHandler"](event);})
	;
})
```
