### PR TITLE
Implement Block Entities

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/BuiltinKubeJSPlugin.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/BuiltinKubeJSPlugin.java
@@ -1,5 +1,5 @@
-package dev.latvian.mods.kubejs;
 
+package dev.latvian.mods.kubejs;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -37,6 +37,10 @@ import dev.latvian.mods.kubejs.block.custom.StonePressurePlateBlockBuilder;
 import dev.latvian.mods.kubejs.block.custom.WallBlockBuilder;
 import dev.latvian.mods.kubejs.block.custom.WoodenButtonBlockBuilder;
 import dev.latvian.mods.kubejs.block.custom.WoodenPressurePlateBlockBuilder;
+import dev.latvian.mods.kubejs.block.entity.BlockEntityBuilder;
+import dev.latvian.mods.kubejs.block.entity.ablities.EnergyBlockAbility;
+import dev.latvian.mods.kubejs.block.entity.ablities.FluidBlockAbility;
+import dev.latvian.mods.kubejs.block.entity.ablities.ItemBlockAbility;
 import dev.latvian.mods.kubejs.block.state.BlockStatePredicate;
 import dev.latvian.mods.kubejs.client.painter.Painter;
 import dev.latvian.mods.kubejs.client.painter.screen.AtlasTextureObject;
@@ -193,7 +197,7 @@ public class BuiltinKubeJSPlugin extends KubeJSPlugin {
 		RegistryObjectBuilderTypes.ENCHANTMENT.addType("basic", EnchantmentBuilder.class, EnchantmentBuilder::new);
 		RegistryObjectBuilderTypes.MOB_EFFECT.addType("basic", BasicMobEffect.Builder.class, BasicMobEffect.Builder::new);
 		// ENTITY_TYPE
-		// BLOCK_ENTITY_TYPE
+		RegistryObjectBuilderTypes.BLOCK_ENTITY_TYPE.addType("basic", BlockEntityBuilder.class, BlockEntityBuilder::new);
 		RegistryObjectBuilderTypes.POTION.addType("basic", PotionBuilder.class, PotionBuilder::new);
 		RegistryObjectBuilderTypes.PARTICLE_TYPE.addType("basic", ParticleTypeBuilder.class, ParticleTypeBuilder::new);
 		RegistryObjectBuilderTypes.PAINTING_VARIANT.addType("basic", PaintingVariantBuilder.class, PaintingVariantBuilder::new);

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/BlockBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/BlockBuilder.java
@@ -6,6 +6,7 @@ import dev.architectury.registry.client.rendering.ColorHandlerRegistry;
 import dev.architectury.registry.client.rendering.RenderTypeRegistry;
 import dev.latvian.mods.kubejs.BuilderBase;
 import dev.latvian.mods.kubejs.RegistryObjectBuilderTypes;
+import dev.latvian.mods.kubejs.block.entity.BlockEntityBuilder;
 import dev.latvian.mods.kubejs.client.ModelGenerator;
 import dev.latvian.mods.kubejs.client.VariantBlockStateGenerator;
 import dev.latvian.mods.kubejs.generator.AssetJsonGenerator;
@@ -77,6 +78,8 @@ public abstract class BlockBuilder extends BuilderBase<Block> {
 	public transient Consumer<BlockStateModifyCallbackJS> defaultStateModification;
 	public transient Consumer<BlockStateModifyPlacementCallbackJS> placementStateModification;
 
+	public transient BlockEntityBuilder blockEntityBuilder;
+
 	public BlockBuilder(ResourceLocation i) {
 		super(i);
 		material = MaterialListJS.INSTANCE.map.get("wood");
@@ -98,6 +101,7 @@ public abstract class BlockBuilder extends BuilderBase<Block> {
 		noCollision = false;
 		notSolid = false;
 		randomTickCallback = null;
+		blockEntityBuilder = null;
 
 		lootTable = loot -> loot.addPool(pool -> {
 			pool.survivesExplosion();
@@ -411,6 +415,19 @@ public abstract class BlockBuilder extends BuilderBase<Block> {
 
 	public BlockBuilder noItem() {
 		return item(null);
+	}
+
+	public BlockBuilder blockEntity(@Nullable Consumer<BlockEntityBuilder> i) {
+		if (i == null) {
+			blockEntityBuilder = null;
+		} else  {
+			BlockEntityBuilder te = new BlockEntityBuilder(id);
+			te.blockBuilder = this;
+			this.blockEntityBuilder = te;
+			i.accept(te);
+		}
+
+		return this;
 	}
 
 	public BlockBuilder box(double x0, double y0, double z0, double x1, double y1, double z1, boolean scale16) {

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/custom/BasicBlockJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/custom/BasicBlockJS.java
@@ -17,9 +17,13 @@ import net.minecraft.util.RandomSource;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.SimpleWaterloggedBlock;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityTicker;
+import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
@@ -140,6 +144,16 @@ public class BasicBlockJS extends Block implements EntityBlockKJS, SimpleWaterlo
 	@Override
 	public boolean isRandomlyTicking(BlockState state) {
 		return blockBuilder.randomTickCallback != null;
+	}
+
+	@Override
+	public @Nullable BlockEntity newBlockEntity(BlockPos blockPos, BlockState blockState) {
+		return blockBuilder.blockEntityBuilder != null ? blockBuilder.blockEntityBuilder.newBlockEntity(blockPos, blockState) : null;
+	}
+
+	@Override
+	public @Nullable <T extends BlockEntity> BlockEntityTicker<T> getTicker(Level level, BlockState blockState, BlockEntityType<T> blockEntityType) {
+		return blockBuilder.blockEntityBuilder != null ? blockBuilder.blockEntityBuilder.getTicker(level, blockState, blockEntityType) : null;
 	}
 
 	@Override

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/entity/BasicBlockEntity.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/entity/BasicBlockEntity.java
@@ -1,0 +1,72 @@
+package dev.latvian.mods.kubejs.block.entity;
+
+import dev.latvian.mods.kubejs.KubeJSRegistries;
+import dev.latvian.mods.kubejs.RegistryObjectBuilderTypes;
+import dev.latvian.mods.kubejs.block.entity.ablities.BlockAbility;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.state.BlockState;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class BasicBlockEntity extends BlockEntity {
+	public transient BlockEntityBuilder blockEntityBuilder;
+	public transient Map<String, BlockAbility<?>> blockAbilities = new HashMap<>();
+
+	public BasicBlockEntity(BlockEntityType<?> blockEntityType, BlockPos blockPos, BlockState blockState) {
+		super(blockEntityType, blockPos, blockState);
+		for (var ele : RegistryObjectBuilderTypes.BLOCK_ENTITY_TYPE.objects.values()) {
+			if (ele instanceof BlockEntityBuilder e) {
+				if (e.get() == blockEntityType) {
+					init(e);
+					break;
+				}
+			}
+		}
+	}
+
+	public BasicBlockEntity(BlockPos blockPos, BlockState blockState, BlockEntityBuilder blockEntityBuilder) {
+		super(blockEntityBuilder.get(), blockPos, blockState);
+		init(blockEntityBuilder);
+	}
+
+	public void init(BlockEntityBuilder blockEntityBuilder) {
+		if (this.blockEntityBuilder == null) {
+			this.blockEntityBuilder = blockEntityBuilder;
+			for (var pair : blockEntityBuilder.blockAbilities.entrySet()) {
+				blockAbilities.put(pair.getKey(), pair.getValue().getB().apply(pair.getValue().getA()));
+			}
+		}
+	}
+
+	@Override
+	protected void saveAdditional(CompoundTag compoundTag) {
+		super.saveAdditional(compoundTag);
+		CompoundTag blockAbilitiesNbt = new CompoundTag();
+		for (var pair : blockAbilities.entrySet()) {
+			blockAbilitiesNbt.put(pair.getKey(), pair.getValue().toTag());
+		}
+		compoundTag.put("abilities", blockAbilitiesNbt);
+	}
+
+
+
+	@Override
+	public void load(CompoundTag compoundTag) {
+		super.load(compoundTag);
+		CompoundTag blockAbilitiesNbt = compoundTag.getCompound("abilities");
+		for (var key : blockAbilitiesNbt.getAllKeys()) {
+			CompoundTag abilityNbt = blockAbilitiesNbt.getCompound(key);
+			blockAbilities.get(key).fromTag(abilityNbt);
+		}
+	}
+
+	public BlockAbility<?> getAbility(String id) {
+		return blockAbilities.get(id);
+	}
+}

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/entity/BlockEntityBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/entity/BlockEntityBuilder.java
@@ -1,0 +1,102 @@
+package dev.latvian.mods.kubejs.block.entity;
+
+import com.google.common.collect.ImmutableSet;
+import dev.latvian.mods.kubejs.BuilderBase;
+import dev.latvian.mods.kubejs.RegistryObjectBuilderTypes;
+import dev.latvian.mods.kubejs.block.BlockBuilder;
+import dev.latvian.mods.kubejs.block.entity.ablities.BlockAbility;
+import dev.latvian.mods.kubejs.block.entity.screen.event.DOMLoadedEvent;
+import dev.latvian.mods.kubejs.level.BlockContainerJS;
+import dev.latvian.mods.kubejs.util.UtilsJS;
+import dev.latvian.mods.rhino.NativeArray;
+import dev.latvian.mods.rhino.NativeObject;
+import dev.latvian.mods.rhino.util.HideFromJS;
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.Tuple;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityTicker;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.state.BlockState;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public class BlockEntityBuilder extends BuilderBase<BlockEntityType<?>> {
+	public transient BlockBuilder blockBuilder = null;
+	public transient Consumer<TickerCallback> ticker = null;
+	public transient float ticksEvery;
+
+	public transient Map<String, Tuple<BlockAbility.AbilityJS, Function<BlockAbility.AbilityJS, BlockAbility<?>>>> blockAbilities = new HashMap<>();
+	public transient Consumer<DOMLoadedEvent> onDomLoaded;
+
+	public BlockEntityBuilder(ResourceLocation i) {
+		super(i);
+	}
+
+	public BlockEntityBuilder tick(float ticks, Consumer<TickerCallback> tc) {
+		this.ticker = tc;
+		this.ticksEvery = ticks;
+		return this;
+	}
+
+	public BlockEntityBuilder ability(String id, NativeObject abilityjs) {
+		BlockAbility.AbilityJS ability = BlockAbility.AbilityJS.of(abilityjs);
+		if (ability.type() != null) {
+			this.blockAbilities.put(id, new Tuple<>(ability, BlockAbility.registry.get(ability.type())));
+		} else {
+			throw new IllegalArgumentException("Abilities must provide a type!");
+		}
+		return this;
+	}
+
+	public BlockEntityBuilder createScreen(String screen) {
+
+		return this;
+	}
+
+	public BlockEntityBuilder onContentLoaded(Consumer<DOMLoadedEvent> cb) {
+		this.onDomLoaded = cb;
+		return this;
+	}
+
+	@HideFromJS
+	public @Nullable BlockEntity newBlockEntity(BlockPos blockPos, BlockState blockState) {
+		return new BasicBlockEntity(blockPos, blockState, this);
+	}
+
+	@HideFromJS
+	public @Nullable <T extends BlockEntity> BlockEntityTicker<T> getTicker(Level _level, BlockState _blockState, BlockEntityType<T> _blockEntityType) {
+		if (this.ticker != null) {
+			AtomicInteger ticks = new AtomicInteger();
+			return (level, blockPos, blockState, blockEntity) -> {
+				if (ticks.get() % ticksEvery == 0) {
+					TickerCallback tc = new TickerCallback(new BlockContainerJS(level, blockPos), blockEntity);
+					this.ticker.accept(tc);
+				}
+				ticks.getAndIncrement();
+			};
+		}
+		return null;
+	}
+
+	@Override
+	public RegistryObjectBuilderTypes<? super BlockEntityType<?>> getRegistryType() {
+		return RegistryObjectBuilderTypes.BLOCK_ENTITY_TYPE;
+	}
+
+	@Override
+	public BlockEntityType<?> createObject() {
+		return new BlockEntityType<>(
+				(blockPos, blockState) -> new BasicBlockEntity(blockPos, blockState, this),
+				ImmutableSet.of(blockBuilder.get()),
+				null
+		);
+	}
+}

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/entity/TickerCallback.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/entity/TickerCallback.java
@@ -1,0 +1,28 @@
+package dev.latvian.mods.kubejs.block.entity;
+
+import dev.latvian.mods.kubejs.level.BlockContainerJS;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+
+public class TickerCallback {
+	public BlockContainerJS block;
+	public BlockEntity blockEntity;
+
+	public TickerCallback(BlockContainerJS containerJS, BlockEntity blockEntity) {
+		this.block = containerJS;
+		this.blockEntity = blockEntity;
+	}
+
+	public Level getLevel() {
+		return this.block.getLevel();
+	}
+
+	public MinecraftServer getServer() {
+		return this.getLevel().getServer();
+	}
+
+	public BlockEntity getBlockEntity() {
+		return this.blockEntity;
+	}
+}

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/entity/ablities/BlockAbility.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/entity/ablities/BlockAbility.java
@@ -1,0 +1,156 @@
+package dev.latvian.mods.kubejs.block.entity.ablities;
+
+import dev.latvian.mods.kubejs.block.entity.ablities.wrappers.AbilityTypeWrapper;
+import dev.latvian.mods.kubejs.util.MapJS;
+import dev.latvian.mods.kubejs.util.UtilsJS;
+import dev.latvian.mods.rhino.NativeArray;
+import dev.latvian.mods.rhino.NativeObject;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.Tag;
+
+import java.lang.annotation.Native;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+@SuppressWarnings("StaticInitializerReferencesSubClass")
+public abstract class BlockAbility<T> {
+	public static final HashMap<String, Function<AbilityJS, BlockAbility<?>>> registry = new HashMap<>();
+
+	static {
+		BlockAbility.registry.put("energy", EnergyBlockAbility::new);
+		BlockAbility.registry.put("fluid", FluidBlockAbility::new);
+		BlockAbility.registry.put("item", ItemBlockAbility::new);
+	}
+
+	public record SlotDefinition(String id, Number limit, boolean input, boolean output) {
+		public static List<SlotDefinition> ofList(Object o) {
+			if (o instanceof NativeArray arr) {
+				return arr.stream().map(SlotDefinition::of).toList();
+			}
+			return null;
+		}
+
+		public static SlotDefinition of(Object o) {
+			if (o instanceof NativeObject obj) {
+				return new SlotDefinition(
+						obj.get("id").toString(),
+						UtilsJS.parseLong(obj.get("limit"), 1),
+						UtilsJS.cast(obj.get("input")),
+						UtilsJS.cast(obj.get("output"))
+				);
+			}
+			return null;
+		}
+	}
+	public record AbilityJS(String type, List<SlotDefinition> slots) {
+		public static AbilityJS of(Object o) {
+			if (o instanceof NativeObject obj) {
+				return new AbilityJS(obj.get("type").toString(), SlotDefinition.ofList(obj.get("slots")));
+			}
+			return null;
+		}
+	}
+
+	public BlockAbility(AbilityJS map) {
+
+	}
+
+	public abstract Map<String, AbilityTypeWrapper<T>> getSlotMap();
+
+	public Set<String> getSlots() {
+		return getSlotMap().keySet();
+	};
+	public int getSlotsLength() {
+		return getSlotMap().size();
+	}
+	public AbilityTypeWrapper<T> get(String slot) {
+		return getSlotMap().get(slot);
+	}
+	public void set(String slot, T object) {
+		getSlotMap().get(slot).setRaw(object);
+	}
+
+	public long getMax(String slot) {
+		return getSlotMap().get(slot).getMax();
+	};
+
+	public T grow(String slot, int num, boolean simulate) {
+		return insert(slot, get(slot).withCount(num).getRaw(), simulate);
+	}
+
+	public T shrink(String slot, int num, boolean simulate) {
+		return extract(slot, num, simulate);
+	}
+
+	public T insert(String slot, T object, boolean simulate) {
+		var slotWrapper = get(slot);
+		if (slotWrapper.compatible(object)) {
+			if (slotWrapper.isEmpty()) {
+				var empty = slotWrapper.copy();
+				slotWrapper.setRaw(object);
+				return empty.getRaw();
+			} else {
+				var copy = slotWrapper.withRaw(object);
+				var remainder = copy.withCount(slotWrapper.grow(copy.getCount(), simulate));
+				return remainder.getRaw();
+			}
+		}
+		return object;
+	}
+
+	public boolean canInsert(String slot, T object) {
+		var slotWrapper = get(slot);
+		return slotWrapper.compatible(object);
+	}
+
+	public T extract(String slot, int amount, boolean simulate) {
+		var slotWrapper = get(slot);
+		var remainder = slotWrapper.shrink(amount, simulate);
+		return slotWrapper.withCount(remainder).getRaw();
+	};
+
+	public abstract void markDirty(String slot);
+
+	public void markDirty() {
+		for (var key : getSlots()) {
+			markDirty(key);
+		}
+	}
+
+	public void forEach(BiConsumer<AbilityTypeWrapper<T>, String> cb) {
+		for (var key : getSlots()) {
+			cb.accept(get(key), key);
+		}
+	}
+
+	public void map(BiFunction<AbilityTypeWrapper<T>, String, AbilityTypeWrapper<T>> cb) {
+		for (var key : getSlots()) {
+			set(key, cb.apply(get(key), key).getRaw());
+		}
+	}
+
+	public abstract void onChanged(BiConsumer<String, AbilityTypeWrapper<T>> cb);
+
+	public abstract void onSlotChanged(String slot, Consumer<AbilityTypeWrapper<T>> cb);
+
+	public Tag toTag() {
+		CompoundTag nbt = new CompoundTag();
+		for (var key : getSlots()) {
+			nbt.put(key, get(key).toTag());
+		}
+		return nbt;
+	}
+
+	public void fromTag(Tag tag) {
+		CompoundTag nbt = (CompoundTag) (tag);
+		for (var key : nbt.getAllKeys()) {
+			get(key).fromTag(nbt.get(key));
+		}
+	}
+}

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/entity/ablities/EnergyBlockAbility.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/entity/ablities/EnergyBlockAbility.java
@@ -1,0 +1,42 @@
+package dev.latvian.mods.kubejs.block.entity.ablities;
+
+import dev.latvian.mods.kubejs.block.entity.ablities.wrappers.AbilityTypeWrapper;
+import dev.latvian.mods.kubejs.block.entity.ablities.wrappers.IntegerAbilityWrapper;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+public class EnergyBlockAbility extends BlockAbility<Integer> {
+	public final Map<String, AbilityTypeWrapper<Integer>> slots = new HashMap<>();
+
+	public EnergyBlockAbility(AbilityJS map) {
+		super(map);
+		for (var slot : map.slots()) {
+			// todo, input / output / filter
+			slots.put(slot.id(), new IntegerAbilityWrapper(slot.limit().intValue()));
+		}
+	}
+
+	@Override
+	public Map<String, AbilityTypeWrapper<Integer>> getSlotMap() {
+		return slots;
+	}
+
+	@Override
+	public void markDirty(String slot) {
+
+	}
+
+	@Override
+	public void onChanged(BiConsumer<String, AbilityTypeWrapper<Integer>> cb) {
+
+	}
+
+	@Override
+	public void onSlotChanged(String slot, Consumer<AbilityTypeWrapper<Integer>> cb) {
+
+	}
+
+}

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/entity/ablities/FluidBlockAbility.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/entity/ablities/FluidBlockAbility.java
@@ -1,0 +1,47 @@
+package dev.latvian.mods.kubejs.block.entity.ablities;
+
+import dev.latvian.mods.kubejs.block.entity.ablities.wrappers.AbilityTypeWrapper;
+import dev.latvian.mods.kubejs.block.entity.ablities.wrappers.FluidAbilityWrapper;
+import dev.latvian.mods.kubejs.block.entity.ablities.wrappers.IntegerAbilityWrapper;
+import dev.latvian.mods.kubejs.fluid.FluidStackJS;
+import dev.latvian.mods.kubejs.util.ListJS;
+import dev.latvian.mods.kubejs.util.MapJS;
+import dev.latvian.mods.kubejs.util.UtilsJS;
+import net.minecraft.nbt.CompoundTag;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+public class FluidBlockAbility extends BlockAbility<FluidStackJS> {
+	public Map<String, AbilityTypeWrapper<FluidStackJS>> slots = new HashMap<>();
+
+	public FluidBlockAbility(AbilityJS map) {
+		super(map);
+		for (var slot : map.slots()) {
+			// todo, input / output / filter
+			slots.put(slot.id(), new FluidAbilityWrapper(slot.limit().longValue()));
+		}
+	}
+
+	@Override
+	public Map<String, AbilityTypeWrapper<FluidStackJS>> getSlotMap() {
+		return slots;
+	}
+
+	@Override
+	public void markDirty(String slot) {
+
+	}
+
+	@Override
+	public void onChanged(BiConsumer<String, AbilityTypeWrapper<FluidStackJS>> cb) {
+
+	}
+
+	@Override
+	public void onSlotChanged(String slot, Consumer<AbilityTypeWrapper<FluidStackJS>> cb) {
+
+	}
+}

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/entity/ablities/ItemBlockAbility.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/entity/ablities/ItemBlockAbility.java
@@ -1,0 +1,44 @@
+package dev.latvian.mods.kubejs.block.entity.ablities;
+
+import dev.latvian.mods.kubejs.block.entity.ablities.wrappers.AbilityTypeWrapper;
+import dev.latvian.mods.kubejs.block.entity.ablities.wrappers.IntegerAbilityWrapper;
+import dev.latvian.mods.kubejs.block.entity.ablities.wrappers.ItemAbilityWrapper;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+public class ItemBlockAbility extends BlockAbility<ItemStack> {
+
+	public Map<String, AbilityTypeWrapper<ItemStack>> slots = new HashMap<>();
+
+	public ItemBlockAbility(AbilityJS map) {
+		super(map);
+		for (var slot : map.slots()) {
+			// todo, input / output / filter
+			slots.put(slot.id(), new ItemAbilityWrapper(slot.limit().intValue()));
+		}
+	}
+
+	@Override
+	public Map<String, AbilityTypeWrapper<ItemStack>> getSlotMap() {
+		return slots;
+	}
+
+	@Override
+	public void markDirty(String slot) {
+
+	}
+
+	@Override
+	public void onChanged(BiConsumer<String, AbilityTypeWrapper<ItemStack>> cb) {
+
+	}
+
+	@Override
+	public void onSlotChanged(String slot, Consumer<AbilityTypeWrapper<ItemStack>> cb) {
+
+	}
+}

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/entity/ablities/wrappers/AbilityTypeWrapper.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/entity/ablities/wrappers/AbilityTypeWrapper.java
@@ -1,0 +1,74 @@
+package dev.latvian.mods.kubejs.block.entity.ablities.wrappers;
+
+import net.minecraft.nbt.Tag;
+
+public interface AbilityTypeWrapper<T> {
+	boolean isEmpty();
+
+	AbilityTypeWrapper<T> copy();
+
+	default AbilityTypeWrapper<T> withCount(long num) {
+		AbilityTypeWrapper<T> copy = copy();
+		copy.setCount(num);
+		return copy;
+	}
+
+	default AbilityTypeWrapper<T> withRaw(T raw) {
+		AbilityTypeWrapper<T> copy = copy();
+		copy.setRaw(raw);
+		return copy;
+	}
+
+	void setCount(long num);
+
+	long getCount();
+
+	long getMax();
+
+	// @returns remainder
+	default long safeSetCount(long num, boolean simulate) {
+		var max = getMax();
+		var initCount = getCount();
+		if (num > max) {
+			if (!simulate) setCount(max);
+			return max - num;
+		}
+		if (num < 0) {
+			if (!simulate) setCount(0);
+			return Math.abs(num);
+		}
+		if (!simulate) setCount(num);
+		return initCount - num;
+	}
+	default long safeSetCount(long num) {
+		return safeSetCount(num, false);
+	}
+
+	// @returns remainder
+	default long shrink(long num, boolean simulate) {
+		return safeSetCount(getCount() - num, simulate);
+	}
+	default long shrink(long num) {
+		return shrink(num, false);
+	}
+
+	// @returns remainder
+	default long grow(long num, boolean simulate) {
+		return safeSetCount(getCount() + num, simulate);
+	}
+	default long grow(long num) {
+		return grow(num, false);
+	}
+
+	T getRaw();
+
+	void setRaw(T other);
+
+	// i.e, item.id == other.id
+	boolean compatible(T other);
+
+	// These do mutate *this* instance, yes this is weird behavior
+	Tag toTag();
+
+	AbilityTypeWrapper<T> fromTag(Tag tag);
+}

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/entity/ablities/wrappers/FluidAbilityWrapper.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/entity/ablities/wrappers/FluidAbilityWrapper.java
@@ -1,0 +1,75 @@
+package dev.latvian.mods.kubejs.block.entity.ablities.wrappers;
+
+import dev.latvian.mods.kubejs.fluid.EmptyFluidStackJS;
+import dev.latvian.mods.kubejs.fluid.FluidStackJS;
+import dev.latvian.mods.kubejs.util.UtilsJS;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.LongTag;
+import net.minecraft.nbt.Tag;
+
+public class FluidAbilityWrapper implements AbilityTypeWrapper<FluidStackJS> {
+	public FluidStackJS fluid = EmptyFluidStackJS.INSTANCE;
+	public long max;
+
+	public FluidAbilityWrapper(long max) {
+		this.max = max;
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return fluid.isEmpty();
+	}
+
+	@Override
+	public AbilityTypeWrapper<FluidStackJS> copy() {
+		var copy = new FluidAbilityWrapper(max);
+		copy.setRaw(getRaw().copy());
+		return copy;
+	}
+
+	@Override
+	public void setCount(long num) {
+		fluid.setAmount(num);
+	}
+
+	@Override
+	public long getCount() {
+		return fluid.getAmount();
+	}
+
+	@Override
+	public long getMax() {
+		return max;
+	}
+
+	@Override
+	public FluidStackJS getRaw() {
+		return fluid;
+	}
+
+	@Override
+	public void setRaw(FluidStackJS other) {
+		fluid = other;
+	}
+
+	@Override
+	public boolean compatible(FluidStackJS other) {
+		return other != null && fluid.getId().equals(other.getId());
+	}
+
+	@Override
+	public Tag toTag() {
+		ListTag tag = new ListTag();
+		tag.add(fluid.toNBT());
+		tag.add(LongTag.valueOf(max));
+		return tag;
+	}
+
+	@Override
+	public AbilityTypeWrapper<FluidStackJS> fromTag(Tag tag) {
+		ListTag nbt = UtilsJS.cast(tag);
+		fluid = FluidStackJS.of(nbt.get(0));
+		max = ((LongTag) nbt.get(1)).getAsLong();
+		return this;
+	}
+}

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/entity/ablities/wrappers/IntegerAbilityWrapper.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/entity/ablities/wrappers/IntegerAbilityWrapper.java
@@ -1,0 +1,69 @@
+package dev.latvian.mods.kubejs.block.entity.ablities.wrappers;
+
+import dev.latvian.mods.kubejs.util.UtilsJS;
+import net.minecraft.nbt.IntArrayTag;
+import net.minecraft.nbt.Tag;
+
+public class IntegerAbilityWrapper implements AbilityTypeWrapper<Integer> {
+	public int amount = 0;
+	public int max = 1;
+
+	public IntegerAbilityWrapper(int max) {
+		this.max = max;
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return amount == 0;
+	}
+
+	@Override
+	public AbilityTypeWrapper<Integer> copy() {
+		var copy = new IntegerAbilityWrapper(max);
+		copy.setRaw(getRaw());
+		return copy;
+	}
+
+	@Override
+	public void setCount(long num) {
+		amount = UtilsJS.parseInt(num, 0);
+	}
+
+	@Override
+	public long getCount() {
+		return amount;
+	}
+
+	@Override
+	public long getMax() {
+		return max;
+	}
+
+	@Override
+	public Integer getRaw() {
+		return amount;
+	}
+
+	@Override
+	public void setRaw(Integer other) {
+		amount = other;
+	}
+
+	@Override
+	public boolean compatible(Integer other) {
+		return true;
+	}
+
+	@Override
+	public Tag toTag() {
+		return new IntArrayTag(new int[]{amount, max});
+	}
+
+	@Override
+	public AbilityTypeWrapper<Integer> fromTag(Tag tag) {
+		IntArrayTag nbt = UtilsJS.cast(tag);
+		amount = nbt.get(0).getAsInt();
+		max = nbt.get(1).getAsInt();
+		return this;
+	}
+}

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/entity/ablities/wrappers/ItemAbilityWrapper.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/entity/ablities/wrappers/ItemAbilityWrapper.java
@@ -1,0 +1,79 @@
+package dev.latvian.mods.kubejs.block.entity.ablities.wrappers;
+
+import dev.latvian.mods.kubejs.item.ItemStackJS;
+import dev.latvian.mods.kubejs.util.UtilsJS;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.LongTag;
+import net.minecraft.nbt.StringTag;
+import net.minecraft.nbt.Tag;
+import net.minecraft.world.item.ItemStack;
+
+public class ItemAbilityWrapper implements AbilityTypeWrapper<ItemStack> {
+	static AbilityTypeWrapper<ItemStackJS> a = null;
+	public ItemStack item = ItemStack.EMPTY;
+	public int max;
+
+
+	public ItemAbilityWrapper(int max) {
+		this.max = max;
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return item.isEmpty();
+	}
+
+	@Override
+	public AbilityTypeWrapper<ItemStack> copy() {
+		var copy = new ItemAbilityWrapper(max);
+		copy.setRaw(item.copy());
+		return copy;
+	}
+
+	@Override
+	public void setCount(long num) {
+		item.setCount(UtilsJS.parseInt(num, 0));
+	}
+
+	@Override
+	public long getCount() {
+		return item.getCount();
+	}
+
+	@Override
+	public long getMax() {
+		return max;
+	}
+
+	@Override
+	public ItemStack getRaw() {
+		return item;
+	}
+
+	@Override
+	public void setRaw(ItemStack other) {
+		item = other;
+	}
+
+	@Override
+	public boolean compatible(ItemStack other) {
+		return item.isEmpty() || item.kjs$equalsIgnoringCount(other);
+	}
+
+	@Override
+	public Tag toTag() {
+		CompoundTag nbt = new CompoundTag();
+		nbt.put("item", StringTag.valueOf(item.kjs$getId()));
+		nbt.put("count", LongTag.valueOf(item.getCount()));
+		if (item.hasTag()) {
+			nbt.put("nbt", item.getTag());
+		}
+		return nbt;
+	}
+
+	@Override
+	public AbilityTypeWrapper<ItemStack> fromTag(Tag tag) {
+		item = ItemStackJS.of(tag);
+		return this;
+	}
+}

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/entity/screen/ScreenBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/entity/screen/ScreenBuilder.java
@@ -1,0 +1,4 @@
+package dev.latvian.mods.kubejs.block.entity.screen;
+
+public class ScreenBuilder {
+}

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/entity/screen/event/DOMLoadedEvent.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/entity/screen/event/DOMLoadedEvent.java
@@ -1,0 +1,4 @@
+package dev.latvian.mods.kubejs.block.entity.screen.event;
+
+public class DOMLoadedEvent {
+}

--- a/forge/src/main/java/dev/latvian/mods/kubejs/forge/KubeJSForge.java
+++ b/forge/src/main/java/dev/latvian/mods/kubejs/forge/KubeJSForge.java
@@ -5,21 +5,49 @@ import dev.latvian.mods.kubejs.CommonProperties;
 import dev.latvian.mods.kubejs.KubeJS;
 import dev.latvian.mods.kubejs.KubeJSRegistries;
 import dev.latvian.mods.kubejs.bindings.ItemWrapper;
+import dev.latvian.mods.kubejs.block.entity.BasicBlockEntity;
+import dev.latvian.mods.kubejs.block.entity.ablities.BlockAbility;
+import dev.latvian.mods.kubejs.block.entity.ablities.EnergyBlockAbility;
+import dev.latvian.mods.kubejs.block.entity.ablities.FluidBlockAbility;
+import dev.latvian.mods.kubejs.block.entity.ablities.ItemBlockAbility;
 import dev.latvian.mods.kubejs.entity.forge.LivingEntityDropsEventJS;
 import dev.latvian.mods.kubejs.item.forge.ItemDestroyedEventJS;
 import dev.latvian.mods.kubejs.platform.ingredient.IngredientPlatformHelperImpl;
+import dev.latvian.mods.kubejs.util.UtilsJS;
+import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraftforge.common.ForgeMod;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.ForgeCapabilities;
+import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import net.minecraftforge.common.util.Lazy;
+import net.minecraftforge.common.util.LazyOptional;
+import net.minecraftforge.energy.IEnergyStorage;
+import net.minecraftforge.event.AttachCapabilitiesEvent;
 import net.minecraftforge.event.entity.living.LivingDropsEvent;
 import net.minecraftforge.event.entity.player.PlayerDestroyItemEvent;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.fml.IExtensionPoint;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLLoadCompleteEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.network.NetworkConstants;
 import net.minecraftforge.registries.RegisterEvent;
+import org.apache.commons.lang3.NotImplementedException;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @Mod(KubeJS.MOD_ID)
 public class KubeJSForge {
@@ -33,6 +61,7 @@ public class KubeJSForge {
 
 		MinecraftForge.EVENT_BUS.addListener(KubeJSForge::itemDestroyed);
 		MinecraftForge.EVENT_BUS.addListener(KubeJSForge::livingDrops);
+		MinecraftForge.EVENT_BUS.addGenericListener(BlockEntity.class, KubeJSForge::onAttachCapabilities);
 
 		if (!CommonProperties.get().serverOnly) {
 			ForgeMod.enableMilkFluid();
@@ -67,6 +96,176 @@ public class KubeJSForge {
 		} else if (e.eventDrops != null) {
 			event.getDrops().clear();
 			event.getDrops().addAll(e.eventDrops);
+		}
+	}
+
+	public static class SimpleCapProvider implements ICapabilityProvider {
+		public boolean lazyCapsInit = false;
+		public Map<Capability<?>, LazyOptional<?>> capablities = new HashMap<>();
+		public LazyOptional<?> lazyGetCap(Capability<?> cap) {
+			if (!lazyCapsInit) {
+				for (var ability : be.blockAbilities.values()) {
+					if (ability instanceof ItemBlockAbility) {
+						capablities.put(
+								ForgeCapabilities.ITEM_HANDLER,
+								LazyOptional.of(() -> new IItemHandler() {
+									private final BlockAbility<ItemStack> abl = UtilsJS.cast(ability);
+									private final List<String> indexedSlots = abl.getSlotMap().keySet().stream().toList();
+
+									@Override
+									public int getSlots() {
+										return indexedSlots.size();
+									}
+
+									@Override
+									public @NotNull ItemStack getStackInSlot(int i) {
+										return abl.get(indexedSlots.get(i)).getRaw();
+									}
+
+									@Override
+									public @NotNull ItemStack insertItem(int i, @NotNull ItemStack arg, boolean bl) {
+										var ret = abl.insert(indexedSlots.get(i), arg, bl);
+										if (!bl) be.setChanged();
+										return ret;
+									}
+
+									@Override
+									public @NotNull ItemStack extractItem(int i, int j, boolean bl) {
+										var ret = abl.extract(indexedSlots.get(i), j, bl);
+										if (!bl) be.setChanged();
+										return ret;
+									}
+
+									@Override
+									public int getSlotLimit(int i) {
+										return (int) abl.getMax(indexedSlots.get(i));
+									}
+
+									@Override
+									public boolean isItemValid(int i, @NotNull ItemStack arg) {
+										return abl.canInsert(indexedSlots.get(i), arg);
+									}
+								})
+						);
+					} else if (ability instanceof FluidBlockAbility) {
+						capablities.put(
+								ForgeCapabilities.FLUID_HANDLER,
+								LazyOptional.of(() -> new IFluidHandler() {
+									private final BlockAbility<FluidStack> abl = UtilsJS.cast(ability);
+									private final List<String> indexedSlots = abl.getSlotMap().keySet().stream().toList();
+
+									@Override
+									public int getTanks() {
+										return indexedSlots.size();
+									}
+
+									@Override
+									public @NotNull FluidStack getFluidInTank(int i) {
+										return abl.get(indexedSlots.get(i)).getRaw();
+									}
+
+									@Override
+									public int getTankCapacity(int i) {
+										return (int) abl.getMax(indexedSlots.get(i));
+									}
+
+									@Override
+									public boolean isFluidValid(int i, @NotNull FluidStack fluidStack) {
+										return abl.canInsert(indexedSlots.get(i), fluidStack);
+									}
+
+									@Override
+									public int fill(FluidStack fluidStack, FluidAction fluidAction) {
+										var ret = abl.insert(indexedSlots.get(0), fluidStack, fluidAction.simulate()).getAmount();
+										if (!fluidAction.simulate()) be.setChanged();
+										return ret;
+									}
+
+									@Override
+									public @NotNull FluidStack drain(FluidStack fluidStack, FluidAction fluidAction) {
+										var slot = abl.get(indexedSlots.get(0));
+										if (slot.compatible(fluidStack)) {
+											var ret = abl.extract(indexedSlots.get(0), fluidStack.getAmount(), fluidAction.simulate()).getAmount();
+											if (!fluidAction.simulate()) be.setChanged();
+											return slot.withCount(ret).getRaw();
+										}
+										return slot.withCount(0).getRaw();
+									}
+
+									@Override
+									public @NotNull FluidStack drain(int i, FluidAction fluidAction) {
+										var ret = abl.extract(indexedSlots.get(0), i, fluidAction.simulate()).getAmount();
+										if (!fluidAction.simulate()) be.setChanged();
+										return abl.get(indexedSlots.get(0)).withCount(ret).getRaw();
+									}
+								})
+						);
+					} else if (ability instanceof EnergyBlockAbility) {
+						capablities.put(
+								ForgeCapabilities.FLUID_HANDLER,
+								LazyOptional.of(() -> new IEnergyStorage() {
+									private final BlockAbility<Integer> abl = UtilsJS.cast(ability);
+									private final List<String> indexedSlots = abl.getSlotMap().keySet().stream().toList();
+
+									@Override
+									public int receiveEnergy(int i, boolean bl) {
+										var ret = abl.grow(indexedSlots.get(0), i, bl);
+										be.setChanged();
+										return ret;
+									}
+
+									@Override
+									public int extractEnergy(int i, boolean bl) {
+										var ret = abl.shrink(indexedSlots.get(0), i, bl);
+										be.setChanged();
+										return ret;
+									}
+
+									@Override
+									public int getEnergyStored() {
+										return (int) abl.get(indexedSlots.get(0)).getCount();
+									}
+
+									@Override
+									public int getMaxEnergyStored() {
+										return (int) abl.getMax(indexedSlots.get(0));
+									}
+
+									@Override
+									public boolean canExtract() {
+										// TODO: output
+										return true;
+									}
+
+									@Override
+									public boolean canReceive() {
+										return abl.canInsert(indexedSlots.get(0), 0);
+									}
+								})
+						);
+					}
+
+				}
+				lazyCapsInit = true;
+			}
+			return capablities.get(cap);
+		}
+		public BasicBlockEntity be;
+
+		public SimpleCapProvider(BasicBlockEntity be) {
+			this.be = be;
+		}
+
+		@Override
+		public @NotNull <T> LazyOptional<T> getCapability(@NotNull Capability<T> capability, @Nullable Direction arg) {
+			var cap = lazyGetCap(capability);
+			return cap != null ? cap.cast() : LazyOptional.empty();
+		}
+	}
+
+	private static void onAttachCapabilities(AttachCapabilitiesEvent<BlockEntity> event) {
+		if (event.getObject() instanceof BasicBlockEntity be) {
+			event.addCapability(BlockEntityType.getKey(be.getType()), new SimpleCapProvider(be));
 		}
 	}
 }


### PR DESCRIPTION
Implements Block Entities, does not implement Screens, Custom Render Models, or much else besides Capabilities (Forge), and custom tickers. This PR does not contain these as they are in and of themselves complex systems.

### Example

```js
StartupEvents.registry('block', event => {
  event
    .create('example_block')
    .material('wood')
    .hardness(1.0)
    .displayName('Example Block')
    .blockEntity((builder) => {
      builder
      .ability("inventory", {
        type: "item", // can be any of fluid, energy, or item
        slots: [
          {
            id: "slot1",
            limit: 64 * 3 * 7,
            input: true, // todo 
            output: true, // todo
            filter: "minecraft:dirt" // todo
          }
        ]
      })
      // inventory-gui sets up the player's inventory for you
      // NOTE: Currently not supported, but dummy method has been put in place to be used at a later date
      .createScreen(`<inventory-gui>
        <div style="justify-items: center;">
          <slot attach="inventory#slot1" />
          <br />
          <button id="empty">Empty Dirt</button>
        </div>
      </inventory-gui>`)
      // NOTE: Currently not supported, see above
      .onContentLoaded((ev) => {
        ev.document.querySelector("#empty").addEventListener("click", () => {
          ev.blockEntity.getAbility("inventory").setCount("slot1", 0);
        })
      })
      .tick(20, (ev) => { // runs function every X ticks
        Utils.server.tell("hi")
      })
    })
})
```