### PR TITLE
Allow adding custom objects to registries.

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/BuilderBase.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/BuilderBase.java
@@ -135,4 +135,39 @@ public abstract class BuilderBase<T> implements Supplier<T> {
 	protected final RegistrySupplier<T> asRegistrySupplier() {
 		return Objects.requireNonNull(object, () -> "Object '%s' of registry '%s' hasn't been registered yet!".formatted(id, getRegistryType().registryKey.location()));
 	}
+
+	// Class that acts as a holder for a custom registry object, usually based off a class from another mod.
+	static class CustomBuilderObject<T> extends BuilderBase<T> {
+
+		private final T object;
+		private final RegistryObjectBuilderTypes<T> registry;
+
+		public CustomBuilderObject(ResourceLocation i, T object, RegistryObjectBuilderTypes<T> registry) {
+			super(i);
+			this.object = object;
+			this.registry = registry;
+			// This, along with overriding getTranslationKeyGroup, is to avoid a crash occurring from getRegistryType returning null
+			// when called from the super constructor, because the value it returns is not set until after the super constructor is run
+			this.translationKey = getTranslationKeyGroup();
+		}
+
+		@Override
+		public String getTranslationKeyGroup() {
+			if (getRegistryType() == null) {
+				return "If you see this something broke. Please file a bug report.";
+			} else {
+				return super.getTranslationKeyGroup();
+			}
+		}
+
+		@Override
+		public RegistryObjectBuilderTypes<? super T> getRegistryType() {
+			return registry;
+		}
+
+		@Override
+		public T createObject() {
+			return object;
+		}
+	}
 }

--- a/common/src/main/java/dev/latvian/mods/kubejs/RegistryObjectBuilderTypes.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/RegistryObjectBuilderTypes.java
@@ -82,6 +82,24 @@ public final class RegistryObjectBuilderTypes<T> {
 
 			return b;
 		}
+
+		public BuilderBase.CustomBuilderObject<T> custom(String id, T object) {
+			if (object == null) {
+				throw new IllegalArgumentException("Tried to register a null object with id: " + id);
+			}
+			var rl = new ResourceLocation(KubeJS.appendModId(id));
+
+			return (BuilderBase.CustomBuilderObject<T>) custom(new BuilderBase.CustomBuilderObject<>(rl, object, registry));
+		}
+
+		public BuilderBase<T> custom(BuilderBase<T> b) {
+			if (b == null) {
+				throw new IllegalArgumentException("Tried to register a null builder with event.custom");
+			}
+
+			registry.addBuilder(b);
+			return b;
+		}
 	}
 
 	public static final Map<ResourceKey<? extends Registry<?>>, RegistryObjectBuilderTypes<?>> MAP = new LinkedHashMap<>();

--- a/common/src/main/java/dev/latvian/mods/kubejs/RegistryObjectBuilderTypes.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/RegistryObjectBuilderTypes.java
@@ -89,10 +89,10 @@ public final class RegistryObjectBuilderTypes<T> {
 			}
 			var rl = new ResourceLocation(KubeJS.appendModId(id));
 
-			return (BuilderBase.CustomBuilderObject<T>) custom(new BuilderBase.CustomBuilderObject<>(rl, object, registry));
+			return (BuilderBase.CustomBuilderObject<T>) fromBuilder(new BuilderBase.CustomBuilderObject<>(rl, object, registry));
 		}
 
-		public BuilderBase<T> custom(BuilderBase<T> b) {
+		public BuilderBase<T> fromBuilder(BuilderBase<T> b) {
 			if (b == null) {
 				throw new IllegalArgumentException("Tried to register a null builder with event.custom");
 			}


### PR DESCRIPTION
This opens up a lot of possibilities with registering things based on other mods classes, including things that do not have a default ('basic') type, such as Block Entities or Entities.

Example script, which adds a custom waystone block and item. They are fully functional.
```js
const WaystoneBlock = java('net.blay09.mods.waystones.block.WaystoneBlock')
const BProperties = java('net.minecraft.world.level.block.state.BlockBehaviour$Properties')
const Material = java('net.minecraft.world.level.material.Material')
const BlockItem = java('net.minecraft.world.item.BlockItem')
const IProperties = java('net.minecraft.world.item.Item$Properties')

let thingo

StartupEvents.registry('block', event => {
	thingo = event.custom('epic_waystone', new WaystoneBlock(BProperties.of(Material.AMETHYST)))
})
StartupEvents.registry('item', event => {
	event.custom('epic_waystone', new BlockItem(thingo.get(), new IProperties()))
})
```
Additionally, there is `event.fromBuilder` that takes a BuilderBase, for situations where you want to base it off an existing builder but not around some of the restrictions it normal has (Like a BlockItemBuilder)

It is expected that scripters provide their own assets and data jsons for custom registry objects, as trying to generate them generically is not possible.


Tested and works on both forge and fabric