### PR TITLE
Fix NetworkEvents oopsie

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/bindings/event/NetworkEvents.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/bindings/event/NetworkEvents.java
@@ -7,6 +7,6 @@ import dev.latvian.mods.kubejs.net.NetworkEventJS;
 
 public interface NetworkEvents {
 	EventGroup GROUP = EventGroup.of("NetworkEvents");
-	EventHandler FROM_SERVER = GROUP.server("fromServer", () -> NetworkEventJS.class).extra(Extra.REQUIRES_STRING).cancelable();
-	EventHandler FROM_CLIENT = GROUP.client("fromClient", () -> NetworkEventJS.class).extra(Extra.REQUIRES_STRING).cancelable();
+	EventHandler FROM_SERVER = GROUP.client("fromServer", () -> NetworkEventJS.class).extra(Extra.REQUIRES_STRING).cancelable();
+	EventHandler FROM_CLIENT = GROUP.server("fromClient", () -> NetworkEventJS.class).extra(Extra.REQUIRES_STRING).cancelable();
 }


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->
### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->
This PR fixes the NetworkEvents, so that `fromServer` can be received on client, and `fromClient` can be received on the server.

#### Example Script <!-- Please provide an example script showing that the bug is fixed, or how the feature is used, if applicable -->
In client_scripts
```js
NetworkEvents.fromServer('blah', event => {})
```
This will cause an error w/o this pr, because its in the 'wrong' script type.
#### Other details <!-- Any other important information, like if this is likely to break addons -->
