### PR TITLE
Fix several issues with KubeJSResourcePack

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/script/data/KubeJSResourcePack.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/script/data/KubeJSResourcePack.java
@@ -18,7 +18,9 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -128,19 +130,16 @@ public abstract class KubeJSResourcePack implements PackResources {
 
 		UtilsJS.tryIO(() ->
 		{
-			var root = KubeJSPaths.get(packType).toAbsolutePath();
-
-			if (Files.exists(root) && Files.isDirectory(root)) {
-				var inputPath = root.getFileSystem().getPath(path);
-
-				Files.walk(root)
-						.map(root::relativize)
-						.filter(p -> p.getNameCount() > 1)
-						.filter(p -> !p.toString().endsWith(".mcmeta"))
-						.filter(p -> p.subpath(1, p.getNameCount()).startsWith(inputPath))
-						.map(p -> new ResourceLocation(p.getName(0).toString(), Joiner.on('/').join(p.subpath(1, p.getNameCount()))))
-						.filter(filter)
-						.forEach(list::add);
+			var root = KubeJSPaths.get(packType).toAbsolutePath().resolve(namespace);
+			var walkRoot = root.resolve(path);
+			if (Files.exists(walkRoot) && Files.isDirectory(walkRoot)) {
+				try(var children = Files.walk(walkRoot)) {
+					children
+							.filter(p -> !p.toString().endsWith(".mcmeta") && !Files.isDirectory(p))
+							.map(p -> new ResourceLocation(namespace, Joiner.on('/').join(root.relativize(p))))
+							.filter(filter)
+							.forEach(list::add);
+				}
 			}
 		});
 
@@ -166,12 +165,13 @@ public abstract class KubeJSResourcePack implements PackResources {
 			var root = KubeJSPaths.get(packType).toAbsolutePath();
 
 			if (Files.exists(root) && Files.isDirectory(root)) {
-				Files.walk(root, 1)
-						.map(path -> root.relativize(path.toAbsolutePath()))
-						.filter(path -> path.getNameCount() > 0)
-						.map(p -> p.toString().replaceAll("/$", ""))
-						.filter(s -> !s.isEmpty())
-						.forEach(namespaces::add);
+				try (var children = Files.newDirectoryStream(root)) {
+					children.forEach(p -> {
+						if (Files.isDirectory(p)) {
+							namespaces.add(p.getFileName().toString());
+						}
+					});
+				}
 			}
 		});
 


### PR DESCRIPTION
### Description 
 - When listing resources, start the folder traversal relative to the requested path, not the resource pack root. This reduces the amount of work done (as only "useful" paths are visited) and fixes a bug where all namespaces would be included, not just the requested one.

 - Use `Files.newDirectoryStream` instead of `Files.walk` for listing namespaces. This has no change in functionality, but is much simpler to understand.

#### Other details
I put together a small test script to compare the behaviour of vanilla's `FolderPackResources` and KubeJS's implementation:

<details><summary>My terrible test code</summary>

```java
public class KubeJSResourcePackTest {
	public static void main(String[] args) {
		SharedConstants.tryDetectVersion();
		Bootstrap.bootStrap();
		FMLPaths.loadAbsolutePaths(Path.of("testFiles").toAbsolutePath());

		var kubeJs = new KubeJSResourcePack(PackType.SERVER_DATA) {
		};
		var vanilla = new FolderPackResources(KubeJSPaths.DIRECTORY.toFile());

		assertSame("Listing namespaces", kubeJs, vanilla, pack -> {
			var namespaces = pack.getNamespaces(PackType.SERVER_DATA);
			namespaces.remove("kubejs");
			namespaces.remove("kubejs_generated");
			return namespaces;
		});

		// Vanilla does this "wrong" too, so not worried too much.
		assertSame("Listing all resources", kubeJs, vanilla, pack ->
				pack.getResources(PackType.SERVER_DATA, "test_mod", "", x -> true));

		assertSame("Listing some resources", kubeJs, vanilla, pack ->
				pack.getResources(PackType.SERVER_DATA, "test_mod", "bar", x -> true));
	}

	public static <T> void assertSame(String message, PackResources kubeJs, PackResources vanilla, Function<PackResources, T> action) {
		var kubeJsResult = action.apply(kubeJs);
		var vanillaResult = action.apply(vanilla);
		System.out.println(message + " (KubeJS):  " + kubeJsResult);
		System.out.println(message + " (Vanilla):  " + vanillaResult);
		if (!Objects.equals(kubeJsResult, vanillaResult)) {
			System.out.println("# Mismatch!");
		}
	}
}
```

along with this test resource pack:

```
testFiles
├── config
├── kubejs
│   ├── assets
│   ├── config
│   ├── data
│   │   ├── another_mod
│   │   │   ├── bar
│   │   │   │   └── baz
│   │   │   └── foo
│   │   ├── notes.txt
│   │   └── test_mod
│   │       ├── bar
│   │       │   ├── a
│   │       │   │   └── b
│   │       │   │       └── c
│   │       │   └── baz
│   │       └── foo
│   └── exported
├── local
└── mods
```

</details>


It'd be quite nice to flesh this out and turn it into an actual test, but Architectury's platform abstractions don't seem very amenable to this. Don't know if you have any suggestions?