### PR TITLE
Intern and cache RegexIDFilter match results on recipe IDs

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/recipe/filter/RecipeFilter.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/recipe/filter/RecipeFilter.java
@@ -70,7 +70,7 @@ public interface RecipeFilter extends Predicate<RecipeJS> {
 			if (map.get("id") != null) {
 				var s = map.get("id").toString();
 				var pattern = UtilsJS.parseRegex(s);
-				predicate.list.add(pattern == null ? new IDFilter(UtilsJS.getMCID(s)) : new RegexIDFilter(pattern));
+				predicate.list.add(pattern == null ? new IDFilter(UtilsJS.getMCID(s)) : RegexIDFilter.of(pattern));
 			}
 
 			if (map.get("type") != null) {


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->
### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->

This PR introduces two new features:

1. `RegexIDFilter` instance interning, which ensures that the same instance of this class is used if the same regex is provided in a script. Important for the below optimization.
2. Each `RegexIDFilter` instance now caches its result for resource locations and reuses past results if possible. This avoids wasting CPU time running the same regex against the same set of recipes.

I'm PRing this to the 1.18 branch (as it's the version I'm currently experiencing the problem with) but it should almost certainly work out of the box on 1.19 as well.

#### Outstanding questions

Should the cache ever be cleared? Currently I opted for no, as the added RAM usage is likely minimal compared to other subsystems in the game, and it avoids needing to find a way to get a concurrent weak-keyed hash map.

#### Other details <!-- Any other important information, like if this is likely to break addons -->

I verified using a profiler that this mitigates the StoneBlock 3 startup delay I outlined in https://github.com/FTBTeam/FTB-Modpack-Issues/issues/2465. In total the worker threads now spent a combined total of 7.4 seconds on regex filter testing rather than about 5 minutes in my original measurement. Unless I have done the calculations incorrectly, this is a **97.3% time savings**.