### PR TITLE
Added handling for DamageSource

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/bindings/DamageSourceWrapper.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/bindings/DamageSourceWrapper.java
@@ -1,6 +1,7 @@
 package dev.latvian.mods.kubejs.bindings;
 
 import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.player.Player;
 
 import java.lang.reflect.Modifier;
 import java.util.HashMap;
@@ -10,6 +11,14 @@ public class DamageSourceWrapper {
 	private static Map<String, DamageSource> damageSourceMap;
 
 	public static DamageSource of(Object name) {
+		if (name instanceof DamageSource damageSource) {
+			return damageSource;
+		}
+
+		if (name instanceof Player player) {
+			return DamageSource.playerAttack(player);
+		}
+
 		if (damageSourceMap == null) {
 			damageSourceMap = new HashMap<>();
 


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->
### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->

Added handling for `DamageSource`'s type wrapper:

- When the input is `DamageSource`, the input itself is returned.
- When the input is a `Player`, `DamageSource.playerAttack(player)` is returned.

#### Example Script <!-- Please provide an example script showing that the bug is fixed, or how the feature is used, if applicable -->
```js
ItemEvents.rightClicked(event => {
    //Attacks player themselves
    event.player.attack(event.player, 100)
})
```
When right clicked:

![image](https://user-images.githubusercontent.com/24620047/214881447-7ee49327-ad5a-4aca-abb7-0e3e77cca388.png)
