### PR TITLE
Add ability to create bindings through resources

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/BuiltinKubeJSPlugin.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/BuiltinKubeJSPlugin.java
@@ -364,6 +364,7 @@ public class BuiltinKubeJSPlugin extends KubeJSPlugin {
 		event.add("BlockProperties", BlockStateProperties.class);
 
 		KubeJS.PROXY.clientBindings(event);
+		KubeJSPlugins.addSidedBindings(event);
 	}
 
 	@Override

--- a/common/src/main/java/dev/latvian/mods/kubejs/util/KubeJSPlugins.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/util/KubeJSPlugins.java
@@ -5,6 +5,7 @@ import dev.architectury.platform.Platform;
 import dev.latvian.mods.kubejs.DevProperties;
 import dev.latvian.mods.kubejs.KubeJS;
 import dev.latvian.mods.kubejs.KubeJSPlugin;
+import dev.latvian.mods.kubejs.script.BindingsEvent;
 import dev.latvian.mods.kubejs.script.ScriptType;
 
 import java.io.IOException;
@@ -18,6 +19,7 @@ import java.util.stream.Stream;
 public class KubeJSPlugins {
 	private static final List<KubeJSPlugin> LIST = new ArrayList<>();
 	private static final List<String> GLOBAL_CLASS_FILTER = new ArrayList<>();
+	private static final ModResourceBindings BINDINGS = new ModResourceBindings();
 
 	public static void load(Mod mod) throws IOException {
 		var pp = mod.findResource("kubejs.plugins.txt");
@@ -29,6 +31,8 @@ public class KubeJSPlugins {
 		if (pc.isPresent()) {
 			GLOBAL_CLASS_FILTER.addAll(Files.readAllLines(pc.get()));
 		}
+
+		BINDINGS.readBindings(mod);
 	}
 
 	private static void loadFromFile(Stream<String> contents, String source) {
@@ -92,5 +96,9 @@ public class KubeJSPlugins {
 
 	public static List<KubeJSPlugin> getAll() {
 		return Collections.unmodifiableList(LIST);
+	}
+
+	public static void addSidedBindings(BindingsEvent event) {
+		BINDINGS.addBindings(event);
 	}
 }

--- a/common/src/main/java/dev/latvian/mods/kubejs/util/ModResourceBindings.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/util/ModResourceBindings.java
@@ -1,0 +1,207 @@
+package dev.latvian.mods.kubejs.util;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import dev.architectury.platform.Mod;
+import dev.latvian.mods.kubejs.KubeJS;
+import dev.latvian.mods.kubejs.script.BindingsEvent;
+import dev.latvian.mods.kubejs.script.ScriptType;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Predicate;
+
+public class ModResourceBindings {
+
+	private final Multimap<String, BindingProvider> bindings = HashMultimap.create();
+
+	public void addBindings(BindingsEvent event) {
+		bindings.asMap().forEach((modName, providers) -> {
+			var addedBindings = new ArrayList<>();
+			providers.forEach(p -> {
+				String name = p.name();
+				if (!p.test(event.getType())) {
+					return;
+				}
+
+				try {
+					event.add(name, p.generate());
+					addedBindings.add(name);
+				} catch (Exception e) {
+					KubeJS.LOGGER.error("Error adding binding for script type {} from mod '{}': {}", event.getType(), modName, name, e);
+				}
+			});
+			KubeJS.LOGGER.info("Added bindings for script type {} from mod '{}': {}", event.getType(), modName, addedBindings);
+		});
+	}
+
+	public void readBindings(Mod mod) throws IOException {
+		var resource = mod.findResource("kubejs.bindings.txt");
+		if (resource.isEmpty()) {
+			return;
+		}
+
+		try (var lines = Files.lines(resource.get())) {
+			List<BindingProvider> providers = lines
+					.map(this::removeComment)
+					.map(String::trim)
+					.filter(line -> !line.isEmpty())
+					.map(line -> createProvider(mod, line))
+					.filter(Objects::nonNull)
+					.toList();
+			bindings.putAll(mod.getModId(), providers);
+		}
+	}
+
+	private String removeComment(String line) {
+		int index = line.indexOf('#');
+		return index == -1 ? line : line.substring(0, index);
+	}
+
+	@Nullable
+	private BindingProvider createProvider(Mod mod, String line) {
+		// SERVER name class field/method/<init>?
+		String[] split = line.split(" +");
+		if (split.length < 3) {
+			KubeJS.LOGGER.error("Invalid binding for '{}' in line: {}", mod.getModId(), line);
+			return null;
+		}
+
+		var scriptTypeFilter = createScriptTypeFilter(split[0]);
+		var name = split[1];
+		var className = split[2];
+		ClassBindingProvider classProvider = new ClassBindingProvider(name, scriptTypeFilter, className);
+		if (split.length == 3) {
+			return classProvider;
+		}
+
+		var methodFieldOrConstructor = split[3];
+		if (methodFieldOrConstructor.equals("<init>")) {
+			return new InstanceBindingProvider(classProvider);
+		}
+
+		return new InvokeBindingProvider(classProvider, methodFieldOrConstructor);
+	}
+
+	private Predicate<ScriptType> createScriptTypeFilter(String potentialType) {
+		if (potentialType.equals("*")) {
+			return type -> true;
+		}
+
+		ScriptType type = ScriptType.valueOf(potentialType.toUpperCase());
+		return type::equals;
+	}
+
+	interface BindingProvider extends Predicate<ScriptType> {
+
+		String name();
+
+		Object generate();
+	}
+
+	record ClassBindingProvider(String name, Predicate<ScriptType> filter, String className) implements BindingProvider {
+
+		@Override
+		public Object generate() {
+			try {
+				return this.getClass().getClassLoader().loadClass(className);
+			} catch (ClassNotFoundException e) {
+				throw new RuntimeException(e);
+			}
+		}
+
+		@Override
+		public boolean test(ScriptType scriptType) {
+			return filter.test(scriptType);
+		}
+	}
+
+	record InstanceBindingProvider(ClassBindingProvider parent) implements BindingProvider {
+
+		@Override
+		public String name() {
+			return parent.name();
+		}
+
+		@Override
+		public Object generate() {
+			Class<?> clazz = (Class<?>) parent().generate();
+			try {
+				Constructor<?> constructor = clazz.getConstructor();
+				return constructor.newInstance();
+			} catch (NoSuchMethodException | InvocationTargetException | InstantiationException | IllegalAccessException e) {
+				throw new IllegalStateException("[Bindings] Failed to find default constructor in class '" + clazz.getName() + "'");
+			}
+		}
+
+		@Override
+		public boolean test(ScriptType scriptType) {
+			return parent.test(scriptType);
+		}
+	}
+
+	record InvokeBindingProvider(ClassBindingProvider parent, String methodOrField) implements BindingProvider {
+
+		@Override
+		public String name() {
+			return parent().name();
+		}
+
+		@Override
+		public Object generate() {
+			Class<?> clazz = (Class<?>) parent().generate();
+
+			Object f = byField(clazz);
+			if (f != null) {
+				return f;
+			}
+
+			Object m = byMethod(clazz);
+			if (m != null) {
+				return m;
+			}
+
+			throw new IllegalStateException("[Bindings] Failed to find static field or method '" + methodOrField + "' in class '" + clazz.getName() + "'");
+		}
+
+		@Override
+		public boolean test(ScriptType scriptType) {
+			return parent.test(scriptType);
+		}
+
+		@Nullable
+		private Object byField(Class<?> clazz) {
+			try {
+				Field field = clazz.getField(methodOrField);
+				if (Modifier.isStatic(field.getModifiers())) {
+					return field.get(null);
+				}
+			} catch (NoSuchFieldException | IllegalAccessException e) {
+				throw new IllegalStateException("[Bindings] Failed to get static field '" + methodOrField + "' in class '" + clazz.getName() + "'", e);
+			}
+			return null;
+		}
+
+		@Nullable
+		private Object byMethod(Class<?> clazz) {
+			try {
+				Method method = clazz.getMethod(methodOrField);
+				if (Modifier.isStatic(method.getModifiers())) {
+					return method.invoke(null);
+				}
+			} catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+				throw new IllegalStateException("[Bindings] Failed to invoke static method '" + methodOrField + "' in class '" + clazz.getName() + "'", e);
+			}
+			return null;
+		}
+	}
+}


### PR DESCRIPTION
Gives mods the ability to create bindings with a simple resource file.
Just create a `kubejs.bindings.txt` in the root resource directory.

Format is:
`SIDE NAME CLASS` or `SIDE NAME CLASS <init>` or `SIDE NAME CLASS STATIC_METHOD_OR_FIELD`

For side you can either use `*` to match all sides or `SERVER`, `CLIENT`, `STARTUP`

```
* TestVec3 net.minecraft.world.phys.Vec3
* TEST_V3_ZERO net.minecraft.world.phys.Vec3 ZERO
SERVER TEST_V3_ZERO_SIDED net.minecraft.world.phys.Vec3 ZERO # with comment
CLIENT TEST_V3_ZERO_SIDED net.minecraft.world.phys.Vec3 ZERO
SERVER TEST_LIST java.util.ArrayList <init>

# This stuff will fail
* FAIL_NOT_EXIST net.does.not.exist 
* FAIL_NO_CLASS
* FAIL_NO_METHOD net.minecraft.world.phys.Vec3 invalid_method_name
* FAIL_NO_FIELD net.minecraft.world.phys.Vec3 invalid_field_name
```