### PR TITLE
Change/Qualify rhino to rhino-forge in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ modImplementation("dev.latvian.mods:kubejs-<loader>:${kubejs_version}")
 implementation fg.deobf("dev.latvian.mods:kubejs-forge:${kubejs_version}")
 
 // these two are unfortunately needed since fg.deobf doesn't respect transitive dependencies yet
-implementation fg.deobf("dev.latvian.mods:rhino:${rhino_version}")
+implementation fg.deobf("dev.latvian.mods:rhino-forge:${rhino_version}")
 implementation fg.deobf("dev.architectury:architectury-forge:${architectury_version}")
 ```
 


### PR DESCRIPTION
Following **exactly** what the readme says had me running into a classdefnotfound exception for `JsonSerializer`

- Minecraft Version 1.18.2
- Relevant kubejs versions
```
kubejs_version=1802.5.5-build.569
rhino_version=1802.2.1-build.255
architectury_version=4.11.89
```

I imagine what is in the readme might be correct for fabric? so maybe need to add a note and include both options.