### PR TITLE
Deprecate fullNBT methods and replace with just nbt

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/core/EntityKJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/core/EntityKJS.java
@@ -6,6 +6,8 @@ import dev.architectury.registry.registries.Registries;
 import dev.latvian.mods.kubejs.entity.RayTraceResultJS;
 import dev.latvian.mods.kubejs.level.BlockContainerJS;
 import dev.latvian.mods.kubejs.player.EntityArrayList;
+import dev.latvian.mods.kubejs.script.ScriptManager;
+import dev.latvian.mods.kubejs.util.ConsoleJS;
 import dev.latvian.mods.rhino.util.HideFromJS;
 import dev.latvian.mods.rhino.util.RemapPrefixForJS;
 import net.minecraft.core.BlockPos;
@@ -239,24 +241,42 @@ public interface EntityKJS extends WithPersistentData, MessageSenderKJS {
 		return new BlockContainerJS(kjs$self().getLevel(), kjs$self().blockPosition());
 	}
 
+	@Deprecated
 	default CompoundTag kjs$getFullNBT() {
+		ConsoleJS.getCurrent(ScriptManager.getCurrentContext()).error("getFullNBT() and fullNBT are deprecated. Use getNbt() or nbt instead!");
+		return kjs$getNbt();
+	}
+
+	@Deprecated
+	default void kjs$setFullNBT(@Nullable CompoundTag nbt) {
+		ConsoleJS.getCurrent(ScriptManager.getCurrentContext()).error("setFullNBT() and fullNBT are deprecated. Use setNbt(CompoundTag) or nbt instead!");
+		kjs$setNbt(nbt);
+	}
+
+	@Deprecated
+	default Entity kjs$mergeFullNBT(@Nullable CompoundTag tag) {
+		ConsoleJS.getCurrent(ScriptManager.getCurrentContext()).error("mergeFullNBT() is deprecated. Use mergeNbt instead!");
+		return kjs$mergeNbt(tag);
+	}
+
+	default CompoundTag kjs$getNbt() {
 		var nbt = new CompoundTag();
 		kjs$self().saveWithoutId(nbt);
 		return nbt;
 	}
 
-	default void kjs$setFullNBT(@Nullable CompoundTag nbt) {
+	default void kjs$setNbt(@Nullable CompoundTag nbt) {
 		if (nbt != null) {
 			kjs$self().load(nbt);
 		}
 	}
 
-	default Entity kjs$mergeFullNBT(@Nullable CompoundTag tag) {
+	default Entity kjs$mergeNbt(@Nullable CompoundTag tag) {
 		if (tag == null || tag.isEmpty()) {
 			return kjs$self();
 		}
 
-		var nbt = kjs$getFullNBT();
+		var nbt = kjs$getNbt();
 
 		for (var k : tag.getAllKeys()) {
 			var t = tag.get(k);
@@ -268,7 +288,7 @@ public interface EntityKJS extends WithPersistentData, MessageSenderKJS {
 			}
 		}
 
-		kjs$setFullNBT(nbt);
+		kjs$setNbt(nbt);
 		return kjs$self();
 	}
 


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->
### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->
This fixes a discrepancy between various things methods for getting the NBT data attached to that object, where entities always had getFullNBT instead of getNbt, setFullNBT instead of setNbt and mergeFullNBT instead of mergeNbt like ItemStackKJS has.

It does this by deprecating the old methods and adding an error to anyone using those, hopefully encouraging them to switch before they are removed (probably in 1.20)

The loss of full NBT capitalization is to prevent odd beaning (getNBT beans to nBT).

#### Other details <!-- Any other important information, like if this is likely to break addons -->
This discrepancy comes from back when entities getNbt method return KubeJS' persistent data, which no one ever really used. Those methods were moved to the full name of getRawPersistentData and setRawPersistentData, leaving the simple getNbt and co unused.