### PR TITLE
Add support for overriding a custom blocks canBeReplaced method

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/block/BlockBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/BlockBuilder.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
@@ -76,6 +77,7 @@ public abstract class BlockBuilder extends BuilderBase<Block> {
 	public transient Set<Property<?>> blockStateProperties;
 	public transient Consumer<BlockStateModifyCallbackJS> defaultStateModification;
 	public transient Consumer<BlockStateModifyPlacementCallbackJS> placementStateModification;
+	public transient Function<CanBeReplacedCallbackJS, Boolean> canBeReplacedFunction;
 
 	public BlockBuilder(ResourceLocation i) {
 		super(i);
@@ -114,6 +116,7 @@ public abstract class BlockBuilder extends BuilderBase<Block> {
 		blockStateProperties = new HashSet<>();
 		defaultStateModification = null;
 		placementStateModification = null;
+		canBeReplacedFunction = null;
 	}
 
 	@Override
@@ -569,6 +572,11 @@ public abstract class BlockBuilder extends BuilderBase<Block> {
 
 	public BlockBuilder placementState(Consumer<BlockStateModifyPlacementCallbackJS> callbackJS) {
 		placementStateModification = callbackJS;
+		return this;
+	}
+
+	public BlockBuilder canBeReplaced(Function<CanBeReplacedCallbackJS, Boolean> callbackJS) {
+		canBeReplacedFunction = callbackJS;
 		return this;
 	}
 

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/CanBeReplacedCallbackJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/CanBeReplacedCallbackJS.java
@@ -1,0 +1,99 @@
+package dev.latvian.mods.kubejs.block;
+
+import dev.latvian.mods.kubejs.item.ItemStackJS;
+import dev.latvian.mods.kubejs.level.BlockContainerJS;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.context.BlockPlaceContext;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.material.Fluid;
+import net.minecraft.world.level.material.FluidState;
+import net.minecraft.world.phys.Vec3;
+
+import javax.annotation.Nullable;
+
+public class CanBeReplacedCallbackJS {
+
+	private final BlockPlaceContext context;
+
+	public CanBeReplacedCallbackJS(BlockPlaceContext blockPlaceContext, BlockState state) {
+		context = blockPlaceContext;
+	}
+
+	public BlockPos getClickedPos() {
+		return context.getClickedPos();
+	}
+
+	public BlockContainerJS getClickedBlock() {
+		return new BlockContainerJS(getLevel(), getClickedPos());
+	}
+
+	public Direction getNearestLookingDirection() {
+		return context.getNearestLookingDirection();
+	}
+
+	public Direction getNearestLookingVerticalDirection() {
+		return context.getNearestLookingVerticalDirection();
+	}
+
+	public Direction[] getNearestLookingDirections() {
+		return context.getNearestLookingDirections();
+	}
+
+	public Direction getClickedFace() {
+		return context.getClickedFace();
+	}
+
+	public Vec3 getClickLocation() {
+		return context.getClickLocation();
+	}
+
+	public boolean isInside() {
+		return context.isInside();
+	}
+
+	public ItemStack getItem() {
+		return ItemStackJS.of(context.getItemInHand());
+	}
+
+	@Nullable
+	public Player getPlayer() {
+		return context.getPlayer();
+	}
+
+	public InteractionHand getHand() {
+		return context.getHand();
+	}
+
+	public Level getLevel() {
+		return context.getLevel();
+	}
+
+	public Direction getHorizontalDirection() {
+		return context.getHorizontalDirection();
+	}
+
+	public boolean isSecondaryUseActive() {
+		return context.isSecondaryUseActive();
+	}
+
+	public float getRotation() {
+		return context.getRotation();
+	}
+
+	public FluidState getFluidStateAtClickedPos() {
+		return context.getLevel().getFluidState(context.getClickedPos());
+	}
+
+	public boolean isClickedPosIn(Fluid fluid) {
+		return getFluidStateAtClickedPos().is(fluid);
+	}
+
+	public boolean canMaterialBeReplaced() {
+		return getLevel().getBlockState(getClickedPos()).getMaterial().isReplaceable();
+	}
+}

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/custom/BasicBlockJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/custom/BasicBlockJS.java
@@ -3,6 +3,7 @@ package dev.latvian.mods.kubejs.block.custom;
 import dev.latvian.mods.kubejs.block.BlockBuilder;
 import dev.latvian.mods.kubejs.block.BlockStateModifyCallbackJS;
 import dev.latvian.mods.kubejs.block.BlockStateModifyPlacementCallbackJS;
+import dev.latvian.mods.kubejs.block.CanBeReplacedCallbackJS;
 import dev.latvian.mods.kubejs.block.EntityBlockKJS;
 import dev.latvian.mods.kubejs.block.KubeJSBlockProperties;
 import dev.latvian.mods.kubejs.block.RandomTickCallbackJS;
@@ -111,6 +112,15 @@ public class BasicBlockJS extends Block implements EntityBlockKJS, SimpleWaterlo
 		}
 
 		return defaultBlockState().setValue(BlockStateProperties.WATERLOGGED, context.getLevel().getFluidState(context.getClickedPos()).getType() == Fluids.WATER);
+	}
+
+	@Override
+	public boolean canBeReplaced(BlockState blockState, BlockPlaceContext context) {
+		if (blockBuilder.canBeReplacedFunction != null) {
+			var callbackJS = new CanBeReplacedCallbackJS(context, blockState);
+			return blockBuilder.canBeReplacedFunction.apply(callbackJS);
+		}
+		return super.canBeReplaced(blockState, context);
 	}
 
 	@Override


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->
### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->
Adds support for overriding a custom blocks canBeReplaced method, so that you can have blocks like flowers or snow layers. Done for @Spyeedy, who (kind of) mentioned this in #609.

Most of the methods in the callback class come from the other existing callbacks that are quite similar.

#### Example Script <!-- Please provide an example script showing that the bug is fixed, or how the feature is used, if applicable -->
Creates a block that is replaced when clicked on by another block only if the player is crouching and that block is not itself. (If there is no player then the crouching check is skipped)
```js
StartupEvents.registry('block', event => {
  event.create('odd_framing').canBeReplaced(c => (c?.player?.crouching ?? true) && c.item.id != 'kubejs:odd_framing')
})
```

https://user-images.githubusercontent.com/73862885/234837348-c8569f30-8c72-4abb-bdd3-5a2d48281748.mp4


#### Other details <!-- Any other important information, like if this is likely to break addons -->
Unlike other callbacks like the ones to modify the state when placed, this one expects a return value (a boolean, to be specific).