### PR TITLE
Add LootTables to /kubejs export.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+<!-- These comments won't appear in the final PR, so you can just leave them here -->
+### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->
+
+
+
+#### Example Script <!-- Please provide an example script showing that the bug is fixed, or how the feature is used, if applicable -->
+```js
+```
+
+#### Other details <!-- Any other important information, like if this is likely to break addons -->

--- a/common/src/main/java/dev/latvian/mods/kubejs/core/LootTablesKJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/core/LootTablesKJS.java
@@ -1,6 +1,7 @@
 package dev.latvian.mods.kubejs.core;
 
 import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import dev.latvian.mods.kubejs.CommonProperties;
 import dev.latvian.mods.kubejs.bindings.event.ServerEvents;
 import dev.latvian.mods.kubejs.loot.BlockLootEventJS;
@@ -34,15 +35,17 @@ public interface LootTablesKJS {
 		ServerEvents.FISHING_LOOT_TABLES.post(ScriptType.SERVER, new FishingLootEventJS(map1));
 		ServerEvents.CHEST_LOOT_TABLES.post(ScriptType.SERVER, new ChestLootEventJS(map1));
 
+		var lootTables = new JsonObject();
 		for (var entry : map1.entrySet()) {
 			try {
 				action.accept(entry.getKey(), entry.getValue());
+				lootTables.add(entry.getKey().toString(), entry.getValue());
 			} catch (Exception ex) {
 				ConsoleJS.SERVER.error("Failed to load loot table " + entry.getKey() + ": " + ex + "\nJson: " + entry.getValue());
 			}
 		}
 
-		DataExport.exportData();
+		DataExport.exportData(lootTables);
 
 		if (UtilsJS.staticServer != null && CommonProperties.get().announceReload && !CommonProperties.get().hideServerScriptErrors) {
 			if (ScriptType.SERVER.errors.isEmpty()) {

--- a/common/src/main/java/dev/latvian/mods/kubejs/server/DataExport.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/server/DataExport.java
@@ -25,8 +25,9 @@ public class DataExport {
 	@HideFromJS
 	public static JsonObject dataExport;
 
-	public static void exportData() {
+	public static void exportData(JsonObject lootTables) {
 		if (dataExport != null) {
+			DataExport.dataExport.add("loot_tables", lootTables);
 			Util.ioPool().execute(DataExport::exportDataBlocking);
 		}
 	}


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->
# Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->
This PR adds parsed successfully loot tables to dataExport to allow exporting them with use of /kubejs export.

## Other details <!-- Any other important information, like if this is likely to break addons -->
Adds pull_request_template to Dev
~~Adds a fix of #533 to Dev~~
Tested export on Fabric/Forge Client and Server and on Enigmatica 9.
- [x] ToDo: Test on dev. -> Works on Fabric/Forge Client and Server on merged version.