### PR TITLE
Add minRolls and maxRolls to OutputItem

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/core/ItemStackKJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/core/ItemStackKJS.java
@@ -328,6 +328,14 @@ public interface ItemStackKJS extends SpecialEquality, NBTSerializable, JsonSeri
 	}
 
 	default OutputItem kjs$withChance(double chance) {
-		return OutputItem.of(kjs$self(), chance);
+		return OutputItem.of(kjs$self(), chance, 0,0);
+	}
+
+	default OutputItem kjs$minRolls(int minRolls) {
+		return OutputItem.of(kjs$self(), Double.NaN, minRolls,0);
+	}
+
+	default OutputItem kjs$maxRolls(int maxRolls) {
+		return OutputItem.of(kjs$self(), Double.NaN, 0, maxRolls);
 	}
 }

--- a/common/src/main/java/dev/latvian/mods/kubejs/item/OutputItem.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/item/OutputItem.java
@@ -9,36 +9,48 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.item.ItemStack;
 
 public class OutputItem implements OutputReplacement {
-	public static final OutputItem EMPTY = new OutputItem(ItemStack.EMPTY, Double.NaN);
+	public static final OutputItem EMPTY = new OutputItem(ItemStack.EMPTY, Double.NaN, 0, 0);
 
-	public static OutputItem of(ItemStack item, double chance) {
-		return item.isEmpty() ? EMPTY : new OutputItem(item, chance);
+	public static OutputItem of(ItemStack item, double chance, int minRolls, int maxRolls) {
+		return item.isEmpty() ? EMPTY : new OutputItem(item, chance, minRolls, maxRolls);
 	}
 
 	public static OutputItem of(Object o) {
 		if (o instanceof OutputItem out) {
 			return out;
 		} else if (o instanceof ItemStack stack) {
-			return of(stack, Double.NaN);
+			return of(stack, Double.NaN, 0, 0);
 		}
 
-		return of(ItemStackJS.of(o), Double.NaN);
+		return of(ItemStackJS.of(o), Double.NaN, 0, 0);
 	}
 
 	public final ItemStack item;
 	public final double chance;
+	public final int minRolls;
+	public final int maxRolls;
 
-	protected OutputItem(ItemStack item, double chance) {
+	protected OutputItem(ItemStack item, double chance, int minRolls, int maxRolls) {
 		this.item = item;
 		this.chance = chance;
+		this.minRolls = minRolls;
+		this.maxRolls = maxRolls;
 	}
 
 	public OutputItem withCount(int count) {
-		return new OutputItem(item.kjs$withCount(count), chance);
+		return new OutputItem(item.kjs$withCount(count), chance, minRolls, maxRolls);
 	}
 
 	public OutputItem withChance(double chance) {
-		return new OutputItem(item, chance);
+		return new OutputItem(item, chance, minRolls, maxRolls);
+	}
+
+	public OutputItem minRolls(int minRolls) {
+		return new OutputItem(item, chance, minRolls, maxRolls);
+	}
+
+	public OutputItem maxRolls(int maxRolls) {
+		return new OutputItem(item, chance, minRolls, maxRolls);
 	}
 
 	public boolean hasChance() {
@@ -69,12 +81,12 @@ public class OutputItem implements OutputReplacement {
 	@Override
 	public Object replaceOutput(RecipeJS recipe, ReplacementMatch match, OutputReplacement original) {
 		if (original instanceof OutputItem o) {
-			var replacement = new OutputItem(item.copy(), o.chance);
+			var replacement = new OutputItem(item.copy(), o.chance, o.minRolls, o.maxRolls);
 			replacement.item.setCount(o.getCount());
 			return replacement;
 		}
 
-		return new OutputItem(item.copy(), Double.NaN);
+		return new OutputItem(item.copy(), Double.NaN, 0, 0);
 	}
 
 	@Deprecated

--- a/common/src/main/java/dev/latvian/mods/kubejs/item/OutputItem.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/item/OutputItem.java
@@ -14,6 +14,9 @@ public class OutputItem implements OutputReplacement {
 	public static OutputItem of(ItemStack item, double chance, int minRolls, int maxRolls) {
 		return item.isEmpty() ? EMPTY : new OutputItem(item, chance, minRolls, maxRolls);
 	}
+	public static OutputItem of(ItemStack item, double chance) {
+		return OutputItem.of(item, chance, 0, 0);
+	}
 
 	public static OutputItem of(Object o) {
 		if (o instanceof OutputItem out) {
@@ -35,6 +38,13 @@ public class OutputItem implements OutputReplacement {
 		this.chance = chance;
 		this.minRolls = minRolls;
 		this.maxRolls = maxRolls;
+	}
+
+	protected OutputItem(ItemStack item, double chance) {
+		this.item = item;
+		this.chance = chance;
+		this.minRolls = 0;
+		this.maxRolls = 0;
 	}
 
 	public OutputItem withCount(int count) {

--- a/common/src/main/java/dev/latvian/mods/kubejs/recipe/RecipeJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/recipe/RecipeJS.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import com.mojang.util.UUIDTypeAdapter;
+import dev.latvian.mods.kubejs.DevProperties;
 import dev.latvian.mods.kubejs.core.RecipeKJS;
 import dev.latvian.mods.kubejs.fluid.FluidStackJS;
 import dev.latvian.mods.kubejs.fluid.InputFluid;
@@ -426,8 +427,16 @@ public class RecipeJS implements RecipeKJS, CustomJavaToJsWrapper {
 		return UtilsJS.getUniqueId(json);
 	}
 
-	public void remove() {
-		removed = true;
+	public final void remove() {
+		if (!removed) {
+			removed = true;
+
+			if (DevProperties.get().logRemovedRecipes) {
+				ConsoleJS.SERVER.info("- " + this + ": " + getFromToString());
+			} else if (ConsoleJS.SERVER.shouldPrintDebug()) {
+				ConsoleJS.SERVER.debug("- " + this + ": " + getFromToString());
+			}
+		}
 	}
 
 	public RecipeJS stage(String s) {

--- a/common/src/main/java/dev/latvian/mods/kubejs/recipe/component/ItemComponents.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/recipe/component/ItemComponents.java
@@ -160,14 +160,31 @@ public interface ItemComponents {
 		public void writeToJson(RecipeJS recipe, RecipeComponentValue<OutputItem> cv, JsonObject json) {
 			json.addProperty(cv.key.name, cv.value.item.kjs$getId());
 			json.addProperty("count", cv.value.item.getCount());
+			if (!Double.isNaN(cv.value.chance)) json.addProperty("chance", cv.value.chance);
+			if (cv.value.minRolls != 0) json.addProperty("minRolls", cv.value.minRolls);
+			if (cv.value.maxRolls != 0) json.addProperty("maxRolls", cv.value.maxRolls);
 		}
 
 		@Override
 		public void readFromJson(RecipeJS recipe, RecipeComponentValue<OutputItem> cv, JsonObject json) {
 			RecipeComponentWithParent.super.readFromJson(recipe, cv, json);
 
-			if (cv.value != null && json.has("count")) {
+			if (cv.value == null) return;
+
+			if (json.has("count")) {
 				cv.value.item.setCount(json.get("count").getAsInt());
+			}
+
+			if (json.has("chance")) {
+				cv.value = cv.value.withChance(json.get("chance").getAsDouble());
+			}
+
+			if (json.has("minRolls")) {
+				cv.value = cv.value.minRolls(json.get("minRolls").getAsInt());
+			}
+
+			if (json.has("maxRolls")) {
+				cv.value = cv.value.maxRolls(json.get("maxRolls").getAsInt());
 			}
 		}
 
@@ -177,6 +194,18 @@ public interface ItemComponents {
 
 			if (cv.value != null && map.containsKey("count")) {
 				cv.value.item.setCount(((Number) map.get("count")).intValue());
+			}
+
+			if (cv.value != null && map.containsKey("chance")) {
+				cv.value = cv.value.withChance(((Number) map.get("chance")).doubleValue());
+			}
+
+			if (cv.value != null && map.containsKey("minRolls")) {
+				cv.value = cv.value.minRolls(((Number) map.get("minRolls")).intValue());
+			}
+
+			if (cv.value != null && map.containsKey("maxRolls")) {
+				cv.value = cv.value.maxRolls(((Number) map.get("maxRolls")).intValue());
 			}
 		}
 


### PR DESCRIPTION
These come up in addons quite a bit, and they shouldn't change anything output wise. Just for new mods, it lets them do this in a prettier way.

Before
```js
event.mod.recipe("input_item", [
  {
    item: Item.of("dirt").withChance(0.5),
    minRolls: 1,
    maxRolls: 5
  }
])
```

After:
```js
event.mod.recipe("input_item", [
  Item.of("dirt")
    .withChance(0.5)
    .minRolls(1)
    .maxRolls(5)
])
```