### PR TITLE
Add ForgeEvents#onModEvent and ForgeEvents#onGenericModEvent

### DIFF
--- a/forge/src/main/java/dev/latvian/mods/kubejs/forge/ForgeEventWrapper.java
+++ b/forge/src/main/java/dev/latvian/mods/kubejs/forge/ForgeEventWrapper.java
@@ -4,7 +4,9 @@ import dev.latvian.mods.kubejs.KubeJS;
 import dev.latvian.mods.kubejs.util.ConsoleJS;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.EventPriority;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 
+@SuppressWarnings({"unused", "SameReturnValue", "rawtypes", "unchecked"}) // this is fine
 public class ForgeEventWrapper {
 	public static Object onEvent(Object eventClass, ForgeEventConsumer consumer) {
 		if (!(eventClass instanceof CharSequence || eventClass instanceof Class)) {
@@ -36,6 +38,47 @@ public class ForgeEventWrapper {
 			Class type = eventClass instanceof Class<?> c ? c : Class.forName(eventClass.toString());
 			Class genericType = genericClass instanceof Class<?> c ? c : Class.forName(genericClass.toString());
 			MinecraftForge.EVENT_BUS.addGenericListener(genericType, EventPriority.NORMAL, false, type, consumer);
+		} catch (Exception ex) {
+			throw new RuntimeException(ex);
+		}
+
+		return null;
+	}
+
+	public static Object onModEvent(Object eventClass, ForgeEventConsumer consumer) {
+		if (!(eventClass instanceof CharSequence || eventClass instanceof Class)) {
+			throw new RuntimeException("Invalid syntax! ForgeEvents.onModEvent(eventType, function) requires event class and handler");
+		} else if (!KubeJS.getStartupScriptManager().firstLoad) {
+			ConsoleJS.STARTUP.warn("ForgeEvents.onModEvent() can't be reloaded! You will have to restart the game for changes to take effect.");
+			return null;
+		}
+
+		try {
+			Class type = eventClass instanceof Class<?> c ? c : Class.forName(eventClass.toString());
+			FMLJavaModLoadingContext mlCtx = FMLJavaModLoadingContext.get();
+			if (mlCtx == null) throw new IllegalStateException("Cannot register forge mod event. Mods aren't loading?");
+			mlCtx.getModEventBus().addListener(EventPriority.NORMAL, false, type, consumer);
+		} catch (Exception ex) {
+			throw new RuntimeException(ex);
+		}
+
+		return null;
+	}
+
+	public static Object onGenericModEvent(Object eventClass, Object genericClass, GenericForgeEventConsumer consumer) {
+		if (!(eventClass instanceof CharSequence || eventClass instanceof Class) || !(genericClass instanceof CharSequence || genericClass instanceof Class)) {
+			throw new RuntimeException("Invalid syntax! ForgeEvents.onGenericModEvent(eventType, genericType, function) requires event class, generic class and handler");
+		} else if (!KubeJS.getStartupScriptManager().firstLoad) {
+			ConsoleJS.STARTUP.warn("ForgeEvents.onGenericModEvent() can't be reloaded! You will have to restart the game for changes to take effect.");
+			return null;
+		}
+
+		try {
+			Class type = eventClass instanceof Class<?> c ? c : Class.forName(eventClass.toString());
+			Class genericType = genericClass instanceof Class<?> c ? c : Class.forName(genericClass.toString());
+			FMLJavaModLoadingContext mlCtx = FMLJavaModLoadingContext.get();
+			if (mlCtx == null) throw new IllegalStateException("Cannot register forge mod event. Mods aren't loading?");
+			mlCtx.getModEventBus().addGenericListener(genericType, EventPriority.NORMAL, false, type, consumer);
 		} catch (Exception ex) {
 			throw new RuntimeException(ex);
 		}


### PR DESCRIPTION
Adds onModEvent and onGenericModEvent to ForgeEvents, for listening to Forge events on the modbus.

Example: 
```js
ForgeEvents.onModEvent("net.minecraftforge.client.event.EntityRenderersEvent$RegisterRenderers", event => {
	const $HuskRenderer = Java.loadClass('net.minecraft.client.renderer.entity.HuskRenderer')
	const $ZombieRenderer = Java.loadClass('net.minecraft.client.renderer.entity.ZombieRenderer')

	event.registerEntityRenderer("zombie", context => new $HuskRenderer(context))
	event.registerEntityRenderer("husk", context => new $ZombieRenderer(context))
})
```
Yes this does exactly what you think it does. Cursed zombies (or are they husks??) anyone?
![image](https://github.com/KubeJS-Mods/KubeJS/assets/73862885/8a7cac54-3f2e-4fe3-9182-b67fe7b26368)


Note there are currently no generic mod bus events, however I added that method anyway cause why not.