### PR TITLE
Fix default tags not being added

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/core/TagLoaderKJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/core/TagLoaderKJS.java
@@ -2,6 +2,7 @@ package dev.latvian.mods.kubejs.core;
 
 import dev.latvian.mods.kubejs.bindings.event.ServerEvents;
 import dev.latvian.mods.kubejs.item.ingredient.TagContext;
+import dev.latvian.mods.kubejs.registry.RegistryInfo;
 import dev.latvian.mods.kubejs.server.TagEventJS;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceLocation;
@@ -16,7 +17,10 @@ public interface TagLoaderKJS<T> {
 		TagContext.INSTANCE.setValue(TagContext.EMPTY);
 		var reg = kjs$getRegistry();
 
-		if (reg != null && ServerEvents.TAGS.hasListeners(reg.key())) {
+		if (reg == null) return;
+		var regInfo = RegistryInfo.MAP.get(reg.key());
+
+		if ((regInfo != null && regInfo.hasDefaultTags) || ServerEvents.TAGS.hasListeners(reg.key())) {
 			var dir = kjs$getDirectory();
 			new TagEventJS<>(dir, map, reg).post();
 		}

--- a/common/src/main/java/dev/latvian/mods/kubejs/registry/BuilderBase.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/registry/BuilderBase.java
@@ -69,6 +69,7 @@ public abstract class BuilderBase<T> implements Supplier<T> {
 
 	public BuilderBase<T> tag(ResourceLocation tag) {
 		defaultTags.add(tag);
+		getRegistryType().hasDefaultTags = true;
 		return this;
 	}
 

--- a/common/src/main/java/dev/latvian/mods/kubejs/registry/RegistryInfo.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/registry/RegistryInfo.java
@@ -193,6 +193,7 @@ public final class RegistryInfo implements Iterable<BuilderBase<?>> {
 	public Class<?> objectBaseClass;
 	public final Map<String, BuilderType> types;
 	public final Map<ResourceLocation, BuilderBase<?>> objects;
+	public boolean hasDefaultTags = false;
 	private BuilderType defaultType;
 	public boolean bypassServerOnly;
 


### PR DESCRIPTION
Fixes #647 
This probably isn't the cleanest fix, but it isn't that messy either.

Example for testing (make sure to not have any item tag events!)
```js
StartupEvents.registry('item', event => {
	event.create('test_mc_testface').texture('minecraft:item/iron_nugget').tag('foobar')
})
```