### PR TITLE
Rename variant(String key, String model) to simpleVariant(String key, String model)

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/block/BlockBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/BlockBuilder.java
@@ -235,7 +235,7 @@ public abstract class BlockBuilder extends BuilderBase<Block> {
 	}
 
 	protected void generateBlockStateJson(VariantBlockStateGenerator bs) {
-		bs.variant("", model.isEmpty() ? (id.getNamespace() + ":block/" + id.getPath()) : model);
+		bs.simpleVariant("", model.isEmpty() ? (id.getNamespace() + ":block/" + id.getPath()) : model);
 	}
 
 	public Map<ResourceLocation, JsonObject> generateBlockModels(BlockBuilder builder) {

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/DetectorBlock.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/DetectorBlock.java
@@ -45,8 +45,8 @@ public class DetectorBlock extends Block {
 		@Override
 		public void generateAssetJsons(AssetJsonGenerator generator) {
 			generator.blockState(id, bs -> {
-				bs.variant("powered=false", "kubejs:block/detector");
-				bs.variant("powered=true", "kubejs:block/detector_on");
+				bs.simpleVariant("powered=false", "kubejs:block/detector");
+				bs.simpleVariant("powered=true", "kubejs:block/detector_on");
 			});
 
 			generator.itemModel(id, m -> m.parent(KubeJS.MOD_ID + ":block/detector"));

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/custom/CropBlockBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/custom/CropBlockBuilder.java
@@ -201,7 +201,7 @@ public class CropBlockBuilder extends BlockBuilder {
 	@Override
 	protected void generateBlockStateJson(VariantBlockStateGenerator bs) {
 		for (int i = 0; i <= age; i++) {
-			bs.variant("age=%s".formatted(i), model.isEmpty() ? (id.getNamespace() + ":block/" + id.getPath() + i) : model);
+			bs.simpleVariant("age=%s".formatted(i), model.isEmpty() ? (id.getNamespace() + ":block/" + id.getPath() + i) : model);
 		}
 	}
 

--- a/common/src/main/java/dev/latvian/mods/kubejs/client/VariantBlockStateGenerator.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/client/VariantBlockStateGenerator.java
@@ -3,6 +3,7 @@ package dev.latvian.mods.kubejs.client;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import dev.latvian.mods.rhino.util.HideFromJS;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -88,6 +89,12 @@ public class VariantBlockStateGenerator {
 		v.key = key;
 		consumer.accept(v);
 		variants.add(v.key, v.toJson());
+	}
+
+	@HideFromJS
+	@Deprecated
+	public void variant(String key, String model) {
+		simpleVariant(key, model);
 	}
 
 	public void simpleVariant(String key, String model) {

--- a/common/src/main/java/dev/latvian/mods/kubejs/client/VariantBlockStateGenerator.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/client/VariantBlockStateGenerator.java
@@ -90,7 +90,7 @@ public class VariantBlockStateGenerator {
 		variants.add(v.key, v.toJson());
 	}
 
-	public void variant(String key, String model) {
+	public void simpleVariant(String key, String model) {
 		variant(key, v -> v.model(model));
 	}
 

--- a/common/src/main/java/dev/latvian/mods/kubejs/fluid/FluidBlockBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/fluid/FluidBlockBuilder.java
@@ -29,7 +29,7 @@ public class FluidBlockBuilder extends BlockBuilder {
 
 	@Override
 	public void generateAssetJsons(AssetJsonGenerator generator) {
-		generator.blockState(id, m -> m.variant("", id.getNamespace() + ":block/" + id.getPath()));
+		generator.blockState(id, m -> m.simpleVariant("", id.getNamespace() + ":block/" + id.getPath()));
 		generator.blockModel(id, m -> {
 			m.parent("");
 			m.texture("particle", fluidBuilder.stillTexture.toString());


### PR DESCRIPTION
This renames `variant(String key, String model)` to `simpleVariant(String key, String model)` in VariantBlockStateGenerator. Fixes #563.

Avoids breaking addons by keeping the original method, but deprecated and hidden from JS.

See issue for example script.