### PR TITLE
1902 docs

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/block/BlockBrokenEventJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/BlockBrokenEventJS.java
@@ -3,12 +3,17 @@ package dev.latvian.mods.kubejs.block;
 import dev.architectury.utils.value.IntValue;
 import dev.latvian.mods.kubejs.level.BlockContainerJS;
 import dev.latvian.mods.kubejs.player.PlayerEventJS;
+import dev.latvian.mods.kubejs.typings.JsInfo;
+import dev.latvian.mods.kubejs.typings.JsParam;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.Nullable;
 
+@JsInfo(value = """
+		Invoked when a block is destroyed by a player.
+		""")
 public class BlockBrokenEventJS extends PlayerEventJS {
 	private final ServerPlayer entity;
 	private final Level level;
@@ -26,10 +31,12 @@ public class BlockBrokenEventJS extends PlayerEventJS {
 	}
 
 	@Override
+	@JsInfo("The player that broke the block.")
 	public ServerPlayer getEntity() {
 		return entity;
 	}
 
+	@JsInfo("The block that was broken.")
 	public BlockContainerJS getBlock() {
 		return new BlockContainerJS(level, pos) {
 			@Override
@@ -39,6 +46,7 @@ public class BlockBrokenEventJS extends PlayerEventJS {
 		};
 	}
 
+	@JsInfo("The experience dropped by the block. Always `0` on Fabric.")
 	public int getXp() {
 		if (xp == null) {
 			return 0;
@@ -46,6 +54,7 @@ public class BlockBrokenEventJS extends PlayerEventJS {
 		return xp.getAsInt();
 	}
 
+	@JsInfo("Sets the experience dropped by the block. Only works on Forge.")
 	public void setXp(int xp) {
 		if (this.xp != null) {
 			this.xp.accept(xp);

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/BlockBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/BlockBuilder.java
@@ -10,6 +10,7 @@ import dev.latvian.mods.kubejs.loot.LootBuilder;
 import dev.latvian.mods.kubejs.registry.BuilderBase;
 import dev.latvian.mods.kubejs.registry.RegistryInfo;
 import dev.latvian.mods.kubejs.script.ScriptType;
+import dev.latvian.mods.kubejs.typings.JsInfo;
 import dev.latvian.mods.kubejs.util.UtilsJS;
 import dev.latvian.mods.rhino.mod.util.color.Color;
 import dev.latvian.mods.rhino.util.HideFromJS;
@@ -132,6 +133,11 @@ public abstract class BlockBuilder extends BuilderBase<Block> {
 	}
 
 	@Override
+	@JsInfo("""
+			Sets the display name for this object, e.g. `Stone`.
+
+			This will be overridden by a lang file if it exists.
+			""")
 	public BuilderBase<Block> displayName(String name) {
 		if (itemBuilder != null) {
 			itemBuilder.displayName(name);
@@ -310,47 +316,64 @@ public abstract class BlockBuilder extends BuilderBase<Block> {
 		}
 	}
 
+	@JsInfo("Sets the block's material. Defaults to wood.")
 	public BlockBuilder material(MaterialJS m) {
 		material = m;
 		return this;
 	}
 
+	@JsInfo("""
+			Sets the hardness of the block. Defaults to 1.5.
+						
+			Setting this to -1 will make the block unbreakable like bedrock.
+			""")
 	public BlockBuilder hardness(float h) {
 		hardness = h;
 		return this;
 	}
 
+	@JsInfo("""
+			Sets the blast resistance of the block. Defaults to 3.
+			""")
 	public BlockBuilder resistance(float r) {
 		resistance = r;
 		return this;
 	}
 
+	@JsInfo("Makes the block unbreakable.")
 	public BlockBuilder unbreakable() {
 		hardness = -1F;
 		resistance = Float.MAX_VALUE;
 		return this;
 	}
 
+	@JsInfo("Sets the light level of the block. Defaults to 0 (no light).")
 	public BlockBuilder lightLevel(float light) {
 		lightLevel = light;
 		return this;
 	}
 
+	@JsInfo("Sets the opacity of the block. Opaque blocks do not let light through.")
 	public BlockBuilder opaque(boolean o) {
 		opaque = o;
 		return this;
 	}
 
+	@JsInfo("Sets the block should be a full block or not, like cactus or doors.")
 	public BlockBuilder fullBlock(boolean f) {
 		fullBlock = f;
 		return this;
 	}
 
+	@JsInfo("Makes the block require a tool to have drops when broken.")
 	public BlockBuilder requiresTool(boolean f) {
 		requiresTool = f;
 		return this;
 	}
 
+	@JsInfo("""
+			Sets the render type of the block. Can be `cutout`, `cutout_mipped`, `translucent`, or `basic`.
+			""")
 	public BlockBuilder renderType(String l) {
 		renderType = l;
 		return this;

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/BlockBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/BlockBuilder.java
@@ -379,11 +379,17 @@ public abstract class BlockBuilder extends BuilderBase<Block> {
 		return this;
 	}
 
+	@JsInfo("""
+			Set the color of a specific layer of the block.
+			""")
 	public BlockBuilder color(int index, Color c) {
 		color.put(index, c.getArgbJS());
 		return this;
 	}
 
+	@JsInfo("""
+			Texture the block on all sides with the same texture.
+			""")
 	public BlockBuilder textureAll(String tex) {
 		for (var direction : Direction.values()) {
 			textureSide(direction, tex);
@@ -393,15 +399,24 @@ public abstract class BlockBuilder extends BuilderBase<Block> {
 		return this;
 	}
 
+	@JsInfo("""
+			Texture a specific side of the block.
+			""")
 	public BlockBuilder textureSide(Direction direction, String tex) {
 		return texture(direction.getSerializedName(), tex);
 	}
 
+	@JsInfo("""
+			Texture a specific texture key of the block.
+			""")
 	public BlockBuilder texture(String id, String tex) {
 		textures.addProperty(id, tex);
 		return this;
 	}
 
+	@JsInfo("""
+			Set the block's model.
+			""")
 	public BlockBuilder model(String m) {
 		model = m;
 		if (itemBuilder != null) {
@@ -410,6 +425,9 @@ public abstract class BlockBuilder extends BuilderBase<Block> {
 		return this;
 	}
 
+	@JsInfo("""
+			Modifies the block's item representation.
+			""")
 	public BlockBuilder item(@Nullable Consumer<BlockItemBuilder> i) {
 		if (i == null) {
 			itemBuilder = null;
@@ -426,10 +444,14 @@ public abstract class BlockBuilder extends BuilderBase<Block> {
 		return itemBuilder == null ? (itemBuilder = new BlockItemBuilder(id)) : itemBuilder;
 	}
 
+	@JsInfo("""
+			Set the block to have no corresponding item.
+			""")
 	public BlockBuilder noItem() {
 		return item(null);
 	}
 
+	@JsInfo("Set the shape of the block.")
 	public BlockBuilder box(double x0, double y0, double z0, double x1, double y1, double z1, boolean scale16) {
 		if (scale16) {
 			customShape.add(new AABB(x0 / 16D, y0 / 16D, z0 / 16D, x1 / 16D, y1 / 16D, z1 / 16D));
@@ -440,6 +462,7 @@ public abstract class BlockBuilder extends BuilderBase<Block> {
 		return this;
 	}
 
+	@JsInfo("Set the shape of the block.")
 	public BlockBuilder box(double x0, double y0, double z0, double x1, double y1, double z1) {
 		return box(x0, y0, z0, x1, y1, z1, true);
 	}
@@ -458,11 +481,13 @@ public abstract class BlockBuilder extends BuilderBase<Block> {
 		return shape;
 	}
 
+	@JsInfo("Makes the block not collide with entities.")
 	public BlockBuilder noCollision() {
 		noCollision = true;
 		return this;
 	}
 
+	@JsInfo("Makes the block not be solid.")
 	public BlockBuilder notSolid() {
 		notSolid = true;
 		return this;
@@ -483,29 +508,41 @@ public abstract class BlockBuilder extends BuilderBase<Block> {
 		return canBeWaterlogged();
 	}
 
+	@JsInfo("Makes the block can be waterlogged.")
 	public BlockBuilder waterlogged() {
 		return property(BlockStateProperties.WATERLOGGED);
 	}
 
+	@JsInfo("Checks if the block can be waterlogged.")
 	public boolean canBeWaterlogged() {
 		return blockStateProperties.contains(BlockStateProperties.WATERLOGGED);
 	}
 
+	@JsInfo("Clears all drops for the block.")
 	public BlockBuilder noDrops() {
 		lootTable = EMPTY;
 		return this;
 	}
 
+	@JsInfo("Set how slippery the block is.")
 	public BlockBuilder slipperiness(float f) {
 		slipperiness = f;
 		return this;
 	}
 
+	@JsInfo("""
+			Set how fast you can walk on the block.
+						
+			Any value above 1 will make you walk insanely fast as your speed is multiplied by this value each tick.
+						
+			Recommended values are between 0.1 and 1, useful for mimicking soul sand or ice.
+			""")
 	public BlockBuilder speedFactor(float f) {
 		speedFactor = f;
 		return this;
 	}
 
+	@JsInfo("Set how high you can jump on the block.")
 	public BlockBuilder jumpFactor(float f) {
 		jumpFactor = f;
 		return this;
@@ -516,60 +553,72 @@ public abstract class BlockBuilder extends BuilderBase<Block> {
 	 *
 	 * @param randomTickCallback A callback using a block container and a random.
 	 */
+	@JsInfo("Sets random tick callback for this black.")
 	public BlockBuilder randomTick(@Nullable Consumer<RandomTickCallbackJS> randomTickCallback) {
 		this.randomTickCallback = randomTickCallback;
 		return this;
 	}
 
+	@JsInfo("Makes mobs not spawn on the block.")
 	public BlockBuilder noValidSpawns(boolean b) {
 		noValidSpawns = b;
 		return this;
 	}
 
+	@JsInfo("Makes the block suffocating.")
 	public BlockBuilder suffocating(boolean b) {
 		suffocating = b;
 		return this;
 	}
 
+	@JsInfo("Makes the block view blocking.")
 	public BlockBuilder viewBlocking(boolean b) {
 		viewBlocking = b;
 		return this;
 	}
 
+	@JsInfo("Makes the block a redstone conductor.")
 	public BlockBuilder redstoneConductor(boolean b) {
 		redstoneConductor = b;
 		return this;
 	}
 
+	@JsInfo("Makes the block transparent.")
 	public BlockBuilder transparent(boolean b) {
 		transparent = b;
 		return this;
 	}
 
+	@JsInfo("Helper method for setting the render type of the block to `cutout` correctly.")
 	public BlockBuilder defaultCutout() {
 		return renderType("cutout").notSolid().noValidSpawns(true).suffocating(false).viewBlocking(false).redstoneConductor(false).transparent(true);
 	}
 
+	@JsInfo("Helper method for setting the render type of the block to `translucent` correctly.")
 	public BlockBuilder defaultTranslucent() {
 		return defaultCutout().renderType("translucent");
 	}
 
 	@Override
+	@JsInfo("Tags both the block and the item with the given tag.")
 	public BlockBuilder tag(ResourceLocation tag) {
 		return tagBoth(tag);
 	}
 
+	@JsInfo("Tags both the block and the item with the given tag.")
 	public BlockBuilder tagBoth(ResourceLocation tag) {
 		tagBlock(tag);
 		tagItem(tag);
 		return this;
 	}
 
+	@JsInfo("Tags the block with the given tag.")
 	public BlockBuilder tagBlock(ResourceLocation tag) {
 		defaultTags.add(tag);
 		return this;
 	}
 
+	@JsInfo("Tags the item with the given tag.")
 	public BlockBuilder tagItem(ResourceLocation tag) {
 		itemBuilder.defaultTags.add(tag);
 		return this;
@@ -579,21 +628,29 @@ public abstract class BlockBuilder extends BuilderBase<Block> {
 		return material.getMinecraftMaterial().getColor();
 	}
 
+	@JsInfo("Set the default state of the block.")
 	public BlockBuilder defaultState(Consumer<BlockStateModifyCallbackJS> callbackJS) {
 		defaultStateModification = callbackJS;
 		return this;
 	}
 
+	@JsInfo("Set the placement state of the block.")
 	public BlockBuilder placementState(Consumer<BlockStateModifyPlacementCallbackJS> callbackJS) {
 		placementStateModification = callbackJS;
 		return this;
 	}
 
+	@JsInfo("Set if the block can be replaced by something else.")
 	public BlockBuilder canBeReplaced(Function<CanBeReplacedCallbackJS, Boolean> callbackJS) {
 		canBeReplacedFunction = callbackJS;
 		return this;
 	}
 
+	@JsInfo("""
+			Add a blockstate property to the block.
+						
+			For example, facing, lit, etc.
+			""")
 	public BlockBuilder property(Property<?> property) {
 		if (property.getPossibleValues().size() <= 1) {
 			throw new IllegalArgumentException(String.format("Block \"%s\" has an illegal Blockstate Property \"%s\" which has <= 1 possible values. (%d possible values)", id, property.getName(), property.getPossibleValues().size()));

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/BlockLeftClickedEventJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/BlockLeftClickedEventJS.java
@@ -2,6 +2,8 @@ package dev.latvian.mods.kubejs.block;
 
 import dev.latvian.mods.kubejs.level.BlockContainerJS;
 import dev.latvian.mods.kubejs.player.PlayerEventJS;
+import dev.latvian.mods.kubejs.typings.JsInfo;
+import dev.latvian.mods.kubejs.typings.JsParam;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.InteractionHand;
@@ -9,6 +11,9 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.Nullable;
 
+@JsInfo(value = """
+		Invoked when a player left clicks on a block.
+		""")
 public class BlockLeftClickedEventJS extends PlayerEventJS {
 	private final Player player;
 	private final InteractionHand hand;
@@ -23,18 +28,22 @@ public class BlockLeftClickedEventJS extends PlayerEventJS {
 	}
 
 	@Override
+	@JsInfo("The player that left clicked the block.")
 	public Player getEntity() {
 		return player;
 	}
 
+	@JsInfo("The block that was left clicked.")
 	public BlockContainerJS getBlock() {
 		return new BlockContainerJS(player.level, pos);
 	}
 
+	@JsInfo("The item that was used to left click the block.")
 	public ItemStack getItem() {
 		return player.getItemInHand(hand);
 	}
 
+	@JsInfo("The face of the block that was left clicked.")
 	@Nullable
 	public Direction getFacing() {
 		return direction;

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/BlockModificationEventJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/BlockModificationEventJS.java
@@ -2,11 +2,18 @@ package dev.latvian.mods.kubejs.block;
 
 import dev.latvian.mods.kubejs.block.state.BlockStatePredicate;
 import dev.latvian.mods.kubejs.event.EventJS;
+import dev.latvian.mods.kubejs.typings.JsInfo;
 import net.minecraft.world.level.block.Block;
 
 import java.util.function.Consumer;
 
 public class BlockModificationEventJS extends EventJS {
+
+	@JsInfo("""
+			Modifies blocks that match the given predicate.
+						
+			**NOTE**: tag predicates are not supported at this time.
+			""")
 	public void modify(BlockStatePredicate predicate, Consumer<Block> c) {
 		for (var block : predicate.getBlocks()) {
 			c.accept(block);

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/BlockPlacedEventJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/BlockPlacedEventJS.java
@@ -2,12 +2,17 @@ package dev.latvian.mods.kubejs.block;
 
 import dev.latvian.mods.kubejs.entity.EntityEventJS;
 import dev.latvian.mods.kubejs.level.BlockContainerJS;
+import dev.latvian.mods.kubejs.typings.JsInfo;
+import dev.latvian.mods.kubejs.typings.JsParam;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.Nullable;
 
+@JsInfo(value = """
+		Invoked when a block is placed.
+		""")
 public class BlockPlacedEventJS extends EntityEventJS {
 	private final Entity entity;
 	private final Level level;
@@ -22,15 +27,18 @@ public class BlockPlacedEventJS extends EntityEventJS {
 	}
 
 	@Override
+	@JsInfo("The level of the block that was placed.")
 	public Level getLevel() {
 		return level;
 	}
 
 	@Override
+	@JsInfo("The entity that placed the block. Can be `null`, e.g. when a block is placed by a dispenser.")
 	public Entity getEntity() {
 		return entity;
 	}
 
+	@JsInfo("The block that is placed.")
 	public BlockContainerJS getBlock() {
 		return new BlockContainerJS(level, pos) {
 			@Override

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/BlockRightClickedEventJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/BlockRightClickedEventJS.java
@@ -2,12 +2,17 @@ package dev.latvian.mods.kubejs.block;
 
 import dev.latvian.mods.kubejs.level.BlockContainerJS;
 import dev.latvian.mods.kubejs.player.PlayerEventJS;
+import dev.latvian.mods.kubejs.typings.JsInfo;
+import dev.latvian.mods.kubejs.typings.JsParam;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 
+@JsInfo("""
+		Invoked when a player right clicks on a block.
+		""")
 public class BlockRightClickedEventJS extends PlayerEventJS {
 	private final Player player;
 	private final InteractionHand hand;
@@ -24,10 +29,12 @@ public class BlockRightClickedEventJS extends PlayerEventJS {
 	}
 
 	@Override
+	@JsInfo("The player that right clicked the block.")
 	public Player getEntity() {
 		return player;
 	}
 
+	@JsInfo("The block that was right clicked.")
 	public BlockContainerJS getBlock() {
 		if (block == null) {
 			block = new BlockContainerJS(player.level, pos);
@@ -36,10 +43,12 @@ public class BlockRightClickedEventJS extends PlayerEventJS {
 		return block;
 	}
 
+	@JsInfo("The hand that was used to right click the block.")
 	public InteractionHand getHand() {
 		return hand;
 	}
 
+	@JsInfo("The position of the block that was right clicked.")
 	public ItemStack getItem() {
 		if (item == null) {
 			item = player.getItemInHand(hand);
@@ -48,6 +57,7 @@ public class BlockRightClickedEventJS extends PlayerEventJS {
 		return item;
 	}
 
+	@JsInfo("The face of the block being right clicked.")
 	public Direction getFacing() {
 		return direction;
 	}

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/DetectorBlockEventJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/DetectorBlockEventJS.java
@@ -2,9 +2,16 @@ package dev.latvian.mods.kubejs.block;
 
 import dev.latvian.mods.kubejs.level.BlockContainerJS;
 import dev.latvian.mods.kubejs.level.LevelEventJS;
+import dev.latvian.mods.kubejs.typings.JsInfo;
+import dev.latvian.mods.kubejs.typings.JsParam;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
 
+@JsInfo(value = """
+		Invoked when a detector block registered in KubeJS receives a block update.
+				
+		`Powered`/`Unpowered` event will be fired when the detector block is powered/unpowered.
+		""")
 public class DetectorBlockEventJS extends LevelEventJS {
 	private final String detectorId;
 	private final Level level;
@@ -20,19 +27,23 @@ public class DetectorBlockEventJS extends LevelEventJS {
 		block = new BlockContainerJS(level, pos);
 	}
 
+	@JsInfo("The id of the detector block when it was registered.")
 	public String getDetectorId() {
 		return detectorId;
 	}
 
 	@Override
+	@JsInfo("The level where the detector block is located.")
 	public Level getLevel() {
 		return level;
 	}
 
+	@JsInfo("If the detector block is powered.")
 	public boolean isPowered() {
 		return powered;
 	}
 
+	@JsInfo("The detector block.")
 	public BlockContainerJS getBlock() {
 		return block;
 	}

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/FarmlandTrampledEventJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/FarmlandTrampledEventJS.java
@@ -2,11 +2,16 @@ package dev.latvian.mods.kubejs.block;
 
 import dev.latvian.mods.kubejs.entity.EntityEventJS;
 import dev.latvian.mods.kubejs.level.BlockContainerJS;
+import dev.latvian.mods.kubejs.typings.JsInfo;
+import dev.latvian.mods.kubejs.typings.JsParam;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 
+@JsInfo(value = """
+		Invoked when an entity attempts to trample farmland.
+		""")
 public class FarmlandTrampledEventJS extends EntityEventJS {
 	private final Level level;
 	private final BlockContainerJS block;
@@ -21,20 +26,24 @@ public class FarmlandTrampledEventJS extends EntityEventJS {
 		entity = e;
 	}
 
+	@JsInfo("The distance of the entity from the block.")
 	public float getDistance() {
 		return distance;
 	}
 
 	@Override
+	@JsInfo("The entity that is attempting to trample the farmland.")
 	public Entity getEntity() {
 		return entity;
 	}
 
 	@Override
+	@JsInfo("The level that the farmland and the entity are in.")
 	public Level getLevel() {
 		return level;
 	}
 
+	@JsInfo("The farmland block.")
 	public BlockContainerJS getBlock() {
 		return block;
 	}

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/custom/CropBlockBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/custom/CropBlockBuilder.java
@@ -12,6 +12,7 @@ import dev.latvian.mods.kubejs.client.VariantBlockStateGenerator;
 import dev.latvian.mods.kubejs.generator.AssetJsonGenerator;
 import dev.latvian.mods.kubejs.item.ItemStackJS;
 import dev.latvian.mods.kubejs.level.BlockContainerJS;
+import dev.latvian.mods.kubejs.typings.JsInfo;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
@@ -48,6 +49,11 @@ public class CropBlockBuilder extends BlockBuilder {
 			this.shapes = new ArrayList<>(Collections.nCopies(age + 1, Block.box(0.0d, 0.0d, 0.0d, 16.0d, 16.0d, 16.0d)));
 		}
 
+		@JsInfo("""
+				Describe the shape of the crop at a specific age.
+								
+				min/max coordinates are double values between 0 and 16.
+				""")
 		public ShapeBuilder shape(int age, double minX, double minY, double minZ, double maxX, double maxY, double maxZ) {
 			shapes.set(age, Block.box(minX, minY, minZ, maxX, maxY, maxZ));
 			return this;
@@ -135,27 +141,32 @@ public class CropBlockBuilder extends BlockBuilder {
 		}
 	}
 
+	@JsInfo("Add a crop output with a 100% chance.")
 	public CropBlockBuilder crop(Object output) {
 		crop(output, 1.0);
 		return this;
 	}
 
+	@JsInfo("Add a crop output with a specific chance.")
 	public CropBlockBuilder crop(Object output, double chance) {
 		outputs.add(new Pair<>(output, chance));
 		return this;
 	}
 
+	@JsInfo("Set the age of the crop. Note that the box will be the same for all ages (A full block size).")
 	public CropBlockBuilder age(int age) {
 		age(age, (builder) -> {
 		});
 		return this;
 	}
 
+	@JsInfo("Set if the crop should drop seeds when harvested.")
 	public CropBlockBuilder dropSeed(boolean dropSeed) {
 		this.dropSeed = dropSeed;
 		return this;
 	}
 
+	@JsInfo("Set the age of the crop and the shape of the crop at that age.")
 	public CropBlockBuilder age(int age, Consumer<ShapeBuilder> builder) {
 		this.age = age;
 		ShapeBuilder shapes = new ShapeBuilder(age);

--- a/common/src/main/java/dev/latvian/mods/kubejs/client/DebugInfoEventJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/client/DebugInfoEventJS.java
@@ -1,9 +1,13 @@
 package dev.latvian.mods.kubejs.client;
 
+import dev.latvian.mods.kubejs.typings.JsInfo;
 import net.minecraft.client.Minecraft;
 
 import java.util.List;
 
+@JsInfo("""
+		Invoked when the debug info is rendered.
+		""")
 public class DebugInfoEventJS extends ClientEventJS {
 	private final List<String> lines;
 
@@ -11,10 +15,12 @@ public class DebugInfoEventJS extends ClientEventJS {
 		lines = l;
 	}
 
+	@JsInfo("Whether the debug info should be rendered.")
 	public boolean getShowDebug() {
 		return Minecraft.getInstance().options.renderDebug;
 	}
 
+	@JsInfo("The lines of debug info. Mutating this list will change the debug info.")
 	public List<String> getLines() {
 		return lines;
 	}

--- a/common/src/main/java/dev/latvian/mods/kubejs/entity/CheckLivingEntitySpawnEventJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/entity/CheckLivingEntitySpawnEventJS.java
@@ -1,11 +1,17 @@
 package dev.latvian.mods.kubejs.entity;
 
 import dev.latvian.mods.kubejs.level.BlockContainerJS;
+import dev.latvian.mods.kubejs.typings.JsInfo;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.MobSpawnType;
 import net.minecraft.world.level.Level;
 
+@JsInfo("""
+		Invoked before an entity is spawned into the world.
+				
+		Only entities from a `BaseSpawner` or world generation will trigger this event.
+		""")
 public class CheckLivingEntitySpawnEventJS extends LivingEntityEventJS {
 	private final LivingEntity entity;
 	private final Level level;
@@ -23,19 +29,23 @@ public class CheckLivingEntitySpawnEventJS extends LivingEntityEventJS {
 	}
 
 	@Override
+	@JsInfo("The level the entity is being spawned into.")
 	public Level getLevel() {
 		return level;
 	}
 
 	@Override
+	@JsInfo("The entity being spawned.")
 	public LivingEntity getEntity() {
 		return entity;
 	}
 
+	@JsInfo("The block the entity is being spawned on.")
 	public BlockContainerJS getBlock() {
 		return new BlockContainerJS(level, new BlockPos(x, y, z));
 	}
 
+	@JsInfo("The type of spawn.")
 	public MobSpawnType getType() {
 		return type;
 	}

--- a/common/src/main/java/dev/latvian/mods/kubejs/entity/EntitySpawnedEventJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/entity/EntitySpawnedEventJS.java
@@ -1,8 +1,14 @@
 package dev.latvian.mods.kubejs.entity;
 
+import dev.latvian.mods.kubejs.typings.JsInfo;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.Level;
 
+@JsInfo("""
+		Invoked when an entity is about to be added to the world.
+				
+		This event also fires for existing entities when they are loaded from a save.
+		""")
 public class EntitySpawnedEventJS extends EntityEventJS {
 	private final Entity entity;
 	private final Level level;
@@ -13,11 +19,13 @@ public class EntitySpawnedEventJS extends EntityEventJS {
 	}
 
 	@Override
+	@JsInfo("The level the entity is being added to.")
 	public Level getLevel() {
 		return level;
 	}
 
 	@Override
+	@JsInfo("The entity being added to the world.")
 	public Entity getEntity() {
 		return entity;
 	}

--- a/common/src/main/java/dev/latvian/mods/kubejs/entity/LivingEntityDeathEventJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/entity/LivingEntityDeathEventJS.java
@@ -1,8 +1,14 @@
 package dev.latvian.mods.kubejs.entity;
 
+import dev.latvian.mods.kubejs.typings.JsInfo;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.LivingEntity;
 
+@JsInfo("""
+		Invoked before a living entity dies.
+				
+		**NOTE**: You need to set hp to > 0 besides cancelling the event to prevent the entity from dying.
+		""")
 public class LivingEntityDeathEventJS extends LivingEntityEventJS {
 	private final LivingEntity entity;
 	private final DamageSource source;
@@ -13,10 +19,12 @@ public class LivingEntityDeathEventJS extends LivingEntityEventJS {
 	}
 
 	@Override
+	@JsInfo("The entity that dies.")
 	public LivingEntity getEntity() {
 		return entity;
 	}
 
+	@JsInfo("The damage source that triggers the death.")
 	public DamageSource getSource() {
 		return source;
 	}

--- a/common/src/main/java/dev/latvian/mods/kubejs/entity/LivingEntityHurtEventJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/entity/LivingEntityHurtEventJS.java
@@ -1,8 +1,12 @@
 package dev.latvian.mods.kubejs.entity;
 
+import dev.latvian.mods.kubejs.typings.JsInfo;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.LivingEntity;
 
+@JsInfo("""
+		Invoked before an entity is hurt by a damage source.
+		""")
 public class LivingEntityHurtEventJS extends LivingEntityEventJS {
 	private final LivingEntity entity;
 	private final DamageSource source;
@@ -15,14 +19,17 @@ public class LivingEntityHurtEventJS extends LivingEntityEventJS {
 	}
 
 	@Override
+	@JsInfo("The entity that was hurt.")
 	public LivingEntity getEntity() {
 		return entity;
 	}
 
+	@JsInfo("The damage source.")
 	public DamageSource getSource() {
 		return source;
 	}
 
+	@JsInfo("The amount of damage.")
 	public float getDamage() {
 		return amount;
 	}

--- a/common/src/main/java/dev/latvian/mods/kubejs/event/EventJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/event/EventJS.java
@@ -1,5 +1,6 @@
 package dev.latvian.mods.kubejs.event;
 
+import dev.latvian.mods.kubejs.typings.JsInfo;
 import org.jetbrains.annotations.Nullable;
 
 public class EventJS {
@@ -13,26 +14,56 @@ public class EventJS {
 		return value;
 	}
 
+	@JsInfo("""
+			Cancels the event with default exit value. Execution will be stopped **immediately**.
+						
+			`cancel` denotes a `false` outcome.
+			""")
 	public Object cancel() throws EventExit {
 		return cancel(defaultExitValue());
 	}
 
+	@JsInfo("""
+			Stops the event with default exit value. Execution will be stopped **immediately**.
+						
+			`success` denotes a `true` outcome.
+			""")
 	public Object success() throws EventExit {
 		return success(defaultExitValue());
 	}
 
+	@JsInfo("""
+			Stops the event with default exit value. Execution will be stopped **immediately**.
+						
+			`exit` denotes a `default` outcome.
+			""")
 	public Object exit() throws EventExit {
 		return exit(defaultExitValue());
 	}
 
+	@JsInfo("""
+			Cancels the event with the given exit value. Execution will be stopped **immediately**.
+						
+			`cancel` denotes a `false` outcome.
+			""")
 	public Object cancel(@Nullable Object value) throws EventExit {
 		throw EventResult.Type.INTERRUPT_FALSE.exit(mapExitValue(value));
 	}
 
+	@JsInfo("""
+			Stops the event with the given exit value. Execution will be stopped **immediately**.
+						
+			`success` denotes a `true` outcome.
+			""")
 	public Object success(@Nullable Object value) throws EventExit {
 		throw EventResult.Type.INTERRUPT_TRUE.exit(mapExitValue(value));
 	}
 
+	@JsInfo("""
+			Stops the event with the given exit value. Execution will be stopped **immediately**.
+						
+			`exit` denotes a `default` outcome.
+			""")
 	public Object exit(@Nullable Object value) throws EventExit {
 		throw EventResult.Type.INTERRUPT_DEFAULT.exit(mapExitValue(value));
 	}

--- a/common/src/main/java/dev/latvian/mods/kubejs/item/FoodBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/item/FoodBuilder.java
@@ -3,6 +3,8 @@ package dev.latvian.mods.kubejs.item;
 import com.google.common.collect.Lists;
 import dev.architectury.hooks.item.food.FoodPropertiesHooks;
 import dev.latvian.mods.kubejs.registry.KubeJSRegistries;
+import dev.latvian.mods.kubejs.typings.JsInfo;
+import dev.latvian.mods.kubejs.typings.JsParam;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.effect.MobEffectInstance;
@@ -38,48 +40,66 @@ public class FoodBuilder {
 		});
 	}
 
+	@JsInfo("Sets the hunger restored.")
 	public FoodBuilder hunger(int h) {
 		hunger = h;
 		return this;
 	}
 
+	@JsInfo("Sets the saturation modifier. Note that the saturation restored is hunger * saturation.")
 	public FoodBuilder saturation(float s) {
 		saturation = s;
 		return this;
 	}
 
+	@JsInfo("Sets whether the food is meat.")
 	public FoodBuilder meat(boolean flag) {
 		meat = flag;
 		return this;
 	}
 
+	@JsInfo("Sets the food is meat.")
 	public FoodBuilder meat() {
 		return meat(true);
 	}
 
+	@JsInfo("Sets whether the food is always edible.")
 	public FoodBuilder alwaysEdible(boolean flag) {
 		alwaysEdible = flag;
 		return this;
 	}
 
+	@JsInfo("Sets the food is always edible.")
 	public FoodBuilder alwaysEdible() {
 		return alwaysEdible(true);
 	}
 
+	@JsInfo("Sets whether the food is fast to eat (having half of the eating time).")
 	public FoodBuilder fastToEat(boolean flag) {
 		fastToEat = flag;
 		return this;
 	}
 
+	@JsInfo("Sets the food is fast to eat (having half of the eating time).")
 	public FoodBuilder fastToEat() {
 		return fastToEat(true);
 	}
 
+	@JsInfo(value = """
+			Adds an effect to the food. Note that the effect duration is in ticks (20 ticks = 1 second).
+			""",
+			params = {
+					@JsParam(name = "mobEffectId", value = "The id of the effect. Can be either a string or a ResourceLocation."),
+					@JsParam(name = "duration", value = "The duration of the effect in ticks."),
+					@JsParam(name = "amplifier", value = "The amplifier of the effect. 0 means level 1, 1 means level 2, etc."),
+					@JsParam(name = "probability", value = "The probability of the effect being applied. 1 = 100%.")
+			})
 	public FoodBuilder effect(ResourceLocation mobEffectId, int duration, int amplifier, float probability) {
 		effects.add(Pair.of(new EffectSupplier(mobEffectId, duration, amplifier), probability));
 		return this;
 	}
 
+	@JsInfo("Removes an effect from the food.")
 	public FoodBuilder removeEffect(MobEffect mobEffect) {
 		if (mobEffect == null) {
 			return this;
@@ -93,6 +113,12 @@ public class FoodBuilder {
 		return this;
 	}
 
+	@JsInfo("""
+			Sets a callback that is called when the food is eaten.
+						
+			Note: This is currently not having effect in `ItemEvents.modification`,
+			as firing this callback requires an `ItemBuilder` instance in the `Item`.
+			""")
 	public FoodBuilder eaten(Consumer<FoodEatenEventJS> e) {
 		eaten = e;
 		return this;

--- a/common/src/main/java/dev/latvian/mods/kubejs/item/FoodEatenEventJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/item/FoodEatenEventJS.java
@@ -1,10 +1,14 @@
 package dev.latvian.mods.kubejs.item;
 
 import dev.latvian.mods.kubejs.entity.EntityEventJS;
+import dev.latvian.mods.kubejs.typings.JsInfo;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
 
+@JsInfo("""
+		Invoked when an entity eats food.
+		""")
 public class FoodEatenEventJS extends EntityEventJS {
 	private final Entity entity;
 	private final ItemStack item;
@@ -15,10 +19,12 @@ public class FoodEatenEventJS extends EntityEventJS {
 	}
 
 	@Override
+	@JsInfo("The entity that ate the food.")
 	public Entity getEntity() {
 		return entity;
 	}
 
+	@JsInfo("The food that was eaten.")
 	public ItemStack getItem() {
 		return item;
 	}

--- a/common/src/main/java/dev/latvian/mods/kubejs/item/ItemBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/item/ItemBuilder.java
@@ -9,6 +9,8 @@ import dev.latvian.mods.kubejs.generator.AssetJsonGenerator;
 import dev.latvian.mods.kubejs.generator.DataJsonGenerator;
 import dev.latvian.mods.kubejs.registry.BuilderBase;
 import dev.latvian.mods.kubejs.registry.RegistryInfo;
+import dev.latvian.mods.kubejs.typings.JsInfo;
+import dev.latvian.mods.kubejs.typings.JsParam;
 import dev.latvian.mods.kubejs.util.ConsoleJS;
 import dev.latvian.mods.rhino.mod.util.color.Color;
 import dev.latvian.mods.rhino.mod.wrapper.ColorWrapper;
@@ -179,50 +181,64 @@ public abstract class ItemBuilder extends BuilderBase<Item> {
 		});
 	}
 
+	@JsInfo("Sets the item's max stack size. Default is 64.")
 	public ItemBuilder maxStackSize(int v) {
 		maxStackSize = v;
 		return this;
 	}
 
+	@JsInfo("Makes the item not stackable, equivalent to setting the item's max stack size to 1.")
 	public ItemBuilder unstackable() {
 		return maxStackSize(1);
 	}
 
+	@JsInfo("Sets the item's max damage. Default is 0 (No durability).")
 	public ItemBuilder maxDamage(int v) {
 		maxDamage = v;
 		return this;
 	}
 
+	@JsInfo("Sets the item's burn time. Default is 0 (Not a fuel).")
 	public ItemBuilder burnTime(int v) {
 		burnTime = v;
 		return this;
 	}
 
+	@JsInfo("Sets the item's container item, e.g. a bucket for a milk bucket.")
 	public ItemBuilder containerItem(ResourceLocation id) {
 		containerItem = id;
 		return this;
 	}
 
+	@JsInfo("""
+			Adds subtypes to the item. The function should return a collection of item stacks, each with a different subtype.
+						
+			Each subtype will appear as a separate item in JEI and the creative inventory.
+			""")
 	public ItemBuilder subtypes(Function<ItemStack, Collection<ItemStack>> fn) {
 		subtypes = fn;
 		return this;
 	}
 
+	@JsInfo("Sets the item's rarity.")
 	public ItemBuilder rarity(Rarity v) {
 		rarity = v;
 		return this;
 	}
 
+	@JsInfo("Makes the item glow like enchanted, even if it's not enchanted.")
 	public ItemBuilder glow(boolean v) {
 		glow = v;
 		return this;
 	}
 
+	@JsInfo("Adds a tooltip to the item.")
 	public ItemBuilder tooltip(Component text) {
 		tooltip.add(text);
 		return this;
 	}
 
+	@JsInfo("Sets the group of the item, e.g. 'building_blocks' for the 'Blocks' tab.")
 	public ItemBuilder group(@Nullable String g) {
 		if (g == null) {
 			group = null;
@@ -239,6 +255,7 @@ public abstract class ItemBuilder extends BuilderBase<Item> {
 		return this;
 	}
 
+	@JsInfo("Colorizes item's texture of the given index.")
 	public ItemBuilder color(int index, Color c) {
 		if (!(colorCallback instanceof IndexedItemColor indexed)) {
 			if (colorCallback != null) {
@@ -251,63 +268,83 @@ public abstract class ItemBuilder extends BuilderBase<Item> {
 		return this;
 	}
 
+	@JsInfo("Colorizes item's texture of the given index. Useful for coloring items, like GT ores ore dusts")
 	public ItemBuilder color(ItemColorJS callback) {
 		colorCallback = callback;
 		return this;
 	}
 
+	@JsInfo("Sets the item's texture (layer0).")
 	public ItemBuilder texture(String tex) {
 		textureJson.addProperty("layer0", tex);
 		return this;
 	}
 
+	@JsInfo("Sets the item's texture by given key.")
 	public ItemBuilder texture(String key, String tex) {
 		textureJson.addProperty(key, tex);
 		return this;
 	}
 
+	@JsInfo("Directlys set the item's texture json.")
 	public ItemBuilder textureJson(JsonObject json) {
 		textureJson = json;
 		return this;
 	}
 
+	@JsInfo("Directly set the item's model json.")
 	public ItemBuilder modelJson(JsonObject json) {
 		modelJson = json;
 		return this;
 	}
 
+	@JsInfo("Sets the item's model (parent).")
 	public ItemBuilder parentModel(String m) {
 		parentModel = m;
 		return this;
 	}
 
+	@JsInfo("Determines the color of the item's durability bar. Defaulted to vanilla behavior.")
 	public ItemBuilder barColor(Function<ItemStack, Color> barColor) {
 		this.barColor = barColor;
 		return this;
 	}
 
+	@JsInfo("""
+			Determines the width of the item's durability bar. Defaulted to vanilla behavior.
+						
+			The function should return a value between 0 and 13 (max width of the bar).
+			""")
 	public ItemBuilder barWidth(ToIntFunction<ItemStack> barWidth) {
 		this.barWidth = barWidth;
 		return this;
 	}
 
+	@JsInfo("""
+			Sets the item's name dynamically.
+			""")
 	public ItemBuilder name(NameCallback name) {
 		this.nameGetter = name;
 		return this;
 	}
 
+	@JsInfo("""
+			Set the food properties of the item.
+			""")
 	public ItemBuilder food(Consumer<FoodBuilder> b) {
 		foodBuilder = new FoodBuilder();
 		b.accept(foodBuilder);
 		return this;
 	}
 
+	@JsInfo("Makes the item fire resistant like netherite tools (or not).")
 	public ItemBuilder fireResistant(boolean isFireResistant) {
 		fireResistant = isFireResistant;
 		return this;
 	}
 
 
+	@JsInfo("Makes the item fire resistant like netherite tools.")
 	public ItemBuilder fireResistant() {
 		return fireResistant(true);
 	}
@@ -344,31 +381,70 @@ public abstract class ItemBuilder extends BuilderBase<Item> {
 		return properties;
 	}
 
+	@JsInfo(value = """
+			Adds an attribute modifier to the item.
+						
+			An attribute modifier is something like a damage boost or a speed boost.
+			On tools, they're applied when the item is held, on armor, they're
+			applied when the item is worn.
+			""",
+			params = {
+					@JsParam(name = "attribute", value = "The resource location of the attribute, e.g. 'generic.attack_damage'"),
+					@JsParam(name = "identifier", value = "A unique identifier for the modifier. Modifiers are considered the same if they have the same identifier."),
+					@JsParam(name = "d", value = "The amount of the modifier."),
+					@JsParam(name = "operation", value = "The operation to apply the modifier with. Can be ADDITION, MULTIPLY_BASE, or MULTIPLY_TOTAL.")
+			})
 	public ItemBuilder modifyAttribute(ResourceLocation attribute, String identifier, double d, AttributeModifier.Operation operation) {
 		attributes.put(attribute, new AttributeModifier(new UUID(identifier.hashCode(), identifier.hashCode()), identifier, d, operation));
 		return this;
 	}
 
+	@JsInfo("Determines the animation of the item when used, e.g. eating food.")
 	public ItemBuilder useAnimation(UseAnim animation) {
 		this.anim = animation;
 		return this;
 	}
 
+	@JsInfo("""
+			The duration when the item is used.
+						
+			For example, when eating food, this is the time it takes to eat the food.
+			This can change the eating speed, or be used for other things (like making a custom bow).
+			""")
 	public ItemBuilder useDuration(ToIntFunction<ItemStack> useDuration) {
 		this.useDuration = useDuration;
 		return this;
 	}
 
+	@JsInfo("""
+			Determines if player will start using the item.
+						
+			For example, when eating food, returning true will make the player start eating the food.
+			""")
 	public ItemBuilder use(UseCallback use) {
 		this.use = use;
 		return this;
 	}
 
+	@JsInfo("""
+			When players finish using the item.
+						
+			This is called only when `useDuration` ticks have passed.
+						
+			For example, when eating food, this is called when the player has finished eating the food, so hunger is restored.
+			""")
 	public ItemBuilder finishUsing(FinishUsingCallback finishUsing) {
 		this.finishUsing = finishUsing;
 		return this;
 	}
 
+	@JsInfo("""
+			When players did not finish using the item but released the right mouse button halfway through.
+						
+			An example is the bow, where the arrow is shot when the player releases the right mouse button.
+						
+			To ensure the bow won't finish using, Minecraft sets the `useDuration` to a very high number (1h).
+			""")
 	public ItemBuilder releaseUsing(ReleaseUsingCallback releaseUsing) {
 		this.releaseUsing = releaseUsing;
 		return this;

--- a/common/src/main/java/dev/latvian/mods/kubejs/item/ItemBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/item/ItemBuilder.java
@@ -255,7 +255,7 @@ public abstract class ItemBuilder extends BuilderBase<Item> {
 		return this;
 	}
 
-	@JsInfo("Colorizes item's texture of the given index.")
+	@JsInfo("Colorizes item's texture of the given index. Index is used when you have multiple layers, e.g. a crushed ore (of rock + ore).")
 	public ItemBuilder color(int index, Color c) {
 		if (!(colorCallback instanceof IndexedItemColor indexed)) {
 			if (colorCallback != null) {

--- a/common/src/main/java/dev/latvian/mods/kubejs/item/ItemClickedEventJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/item/ItemClickedEventJS.java
@@ -2,11 +2,19 @@ package dev.latvian.mods.kubejs.item;
 
 import dev.latvian.mods.kubejs.entity.RayTraceResultJS;
 import dev.latvian.mods.kubejs.player.PlayerEventJS;
+import dev.latvian.mods.kubejs.typings.JsInfo;
+import dev.latvian.mods.kubejs.typings.JsParam;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.Nullable;
 
+@JsInfo(value = """
+		Invoked when a player right clicks with an item **without targeting anything**.
+				
+		Not to be confused with `BlockEvents.rightClick` or `ItemEvents.entityInteracted`.
+		"""
+)
 public class ItemClickedEventJS extends PlayerEventJS {
 	private final Player player;
 	private final InteractionHand hand;
@@ -20,18 +28,22 @@ public class ItemClickedEventJS extends PlayerEventJS {
 	}
 
 	@Override
+	@JsInfo("The player that clicked with the item.")
 	public Player getEntity() {
 		return player;
 	}
 
+	@JsInfo("The hand that the item was clicked with.")
 	public InteractionHand getHand() {
 		return hand;
 	}
 
+	@JsInfo("The item that was clicked with.")
 	public ItemStack getItem() {
 		return item;
 	}
 
+	@JsInfo("The ray trace result of the click.")
 	public RayTraceResultJS getTarget() {
 		if (target == null) {
 			target = player.kjs$rayTrace();

--- a/common/src/main/java/dev/latvian/mods/kubejs/item/ItemCraftedEventJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/item/ItemCraftedEventJS.java
@@ -2,10 +2,14 @@ package dev.latvian.mods.kubejs.item;
 
 import dev.latvian.mods.kubejs.core.InventoryKJS;
 import dev.latvian.mods.kubejs.player.PlayerEventJS;
+import dev.latvian.mods.kubejs.typings.JsInfo;
 import net.minecraft.world.Container;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 
+@JsInfo("""
+		Invoked when a player crafts an item.
+		""")
 public class ItemCraftedEventJS extends PlayerEventJS {
 	private final Player player;
 	private final ItemStack crafted;
@@ -18,14 +22,17 @@ public class ItemCraftedEventJS extends PlayerEventJS {
 	}
 
 	@Override
+	@JsInfo("The player that crafted the item.")
 	public Player getEntity() {
 		return player;
 	}
 
+	@JsInfo("The item that was crafted.")
 	public ItemStack getItem() {
 		return crafted;
 	}
 
+	@JsInfo("The inventory that the item was crafted in.")
 	public InventoryKJS getInventory() {
 		return container;
 	}

--- a/common/src/main/java/dev/latvian/mods/kubejs/item/ItemDroppedEventJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/item/ItemDroppedEventJS.java
@@ -1,10 +1,15 @@
 package dev.latvian.mods.kubejs.item;
 
 import dev.latvian.mods.kubejs.player.PlayerEventJS;
+import dev.latvian.mods.kubejs.typings.JsInfo;
+import dev.latvian.mods.kubejs.typings.JsParam;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 
+@JsInfo(value = """
+		Invoked when a player drops an item.
+		""")
 public class ItemDroppedEventJS extends PlayerEventJS {
 	private final Player player;
 	private final ItemEntity entity;
@@ -15,14 +20,17 @@ public class ItemDroppedEventJS extends PlayerEventJS {
 	}
 
 	@Override
+	@JsInfo("The player that dropped the item.")
 	public Player getEntity() {
 		return player;
 	}
 
+	@JsInfo("The item entity that was spawned when dropping.")
 	public ItemEntity getItemEntity() {
 		return entity;
 	}
 
+	@JsInfo("The item that was dropped.")
 	public ItemStack getItem() {
 		return entity.getItem();
 	}

--- a/common/src/main/java/dev/latvian/mods/kubejs/item/ItemEntityInteractedEventJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/item/ItemEntityInteractedEventJS.java
@@ -1,11 +1,16 @@
 package dev.latvian.mods.kubejs.item;
 
 import dev.latvian.mods.kubejs.player.PlayerEventJS;
+import dev.latvian.mods.kubejs.typings.JsInfo;
+import dev.latvian.mods.kubejs.typings.JsParam;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 
+@JsInfo(value = """
+		Invoked when a player right clicks on an entity.
+		""")
 public class ItemEntityInteractedEventJS extends PlayerEventJS {
 	private final Player player;
 	private final Entity entity;
@@ -19,18 +24,22 @@ public class ItemEntityInteractedEventJS extends PlayerEventJS {
 	}
 
 	@Override
+	@JsInfo("The player that interacted with the entity.")
 	public Player getEntity() {
 		return player;
 	}
 
+	@JsInfo("The hand that was used to interact with the entity.")
 	public InteractionHand getHand() {
 		return hand;
 	}
 
+	@JsInfo("The item that was used to interact with the entity.")
 	public ItemStack getItem() {
 		return player.getItemInHand(hand);
 	}
 
+	@JsInfo("The entity that was interacted with.")
 	public Entity getTarget() {
 		return entity;
 	}

--- a/common/src/main/java/dev/latvian/mods/kubejs/item/ItemModelPropertiesEventJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/item/ItemModelPropertiesEventJS.java
@@ -3,11 +3,18 @@ package dev.latvian.mods.kubejs.item;
 import dev.architectury.registry.item.ItemPropertiesRegistry;
 import dev.latvian.mods.kubejs.KubeJS;
 import dev.latvian.mods.kubejs.event.StartupEventJS;
+import dev.latvian.mods.kubejs.typings.JsInfo;
 import net.minecraft.client.renderer.item.ClampedItemPropertyFunction;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.crafting.Ingredient;
 
 public class ItemModelPropertiesEventJS extends StartupEventJS {
+
+	@JsInfo("""
+			Register a model property for an item. Model properties are used to change the appearance of an item in the world.
+						
+			More about model properties: https://minecraft.fandom.com/wiki/Model#Item_predicates
+			""")
 	public void register(Ingredient ingredient, String overwriteId, ClampedItemPropertyFunction callback) {
 		if (ingredient.kjs$isWildcard()) {
 			registerAll(overwriteId, callback);
@@ -18,6 +25,7 @@ public class ItemModelPropertiesEventJS extends StartupEventJS {
 		}
 	}
 
+	@JsInfo("Register a model property for all items.")
 	public void registerAll(String overwriteId, ClampedItemPropertyFunction callback) {
 		ItemPropertiesRegistry.registerGeneric(new ResourceLocation(KubeJS.appendModId(overwriteId)), callback);
 	}

--- a/common/src/main/java/dev/latvian/mods/kubejs/item/ItemModificationEventJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/item/ItemModificationEventJS.java
@@ -1,12 +1,22 @@
 package dev.latvian.mods.kubejs.item;
 
 import dev.latvian.mods.kubejs.event.EventJS;
+import dev.latvian.mods.kubejs.typings.JsInfo;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.crafting.Ingredient;
 
 import java.util.function.Consumer;
 
+@JsInfo("""
+		Invoked after all items are registered to modify them.
+		""")
 public class ItemModificationEventJS extends EventJS {
+
+	@JsInfo("""
+			Modifies items matching the given ingredient.
+						
+			**NOTE**: tag ingredients are not supported at this time.
+			""")
 	public void modify(Ingredient in, Consumer<Item> c) {
 		for (var item : in.kjs$getItemTypes()) {
 			c.accept(item);

--- a/common/src/main/java/dev/latvian/mods/kubejs/item/ItemPickedUpEventJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/item/ItemPickedUpEventJS.java
@@ -1,10 +1,15 @@
 package dev.latvian.mods.kubejs.item;
 
 import dev.latvian.mods.kubejs.player.PlayerEventJS;
+import dev.latvian.mods.kubejs.typings.JsInfo;
+import dev.latvian.mods.kubejs.typings.JsParam;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 
+@JsInfo("""
+		Invoked when a player picks up an item. Cancelling (in `ItemEvents.canPickUp`) will prevent the item from being picked up.
+		""")
 public class ItemPickedUpEventJS extends PlayerEventJS {
 	private final Player player;
 	private final ItemEntity entity;
@@ -17,14 +22,17 @@ public class ItemPickedUpEventJS extends PlayerEventJS {
 	}
 
 	@Override
+	@JsInfo("The player that picked up the item.")
 	public Player getEntity() {
 		return player;
 	}
 
+	@JsInfo("The item entity that was picked up.")
 	public ItemEntity getItemEntity() {
 		return entity;
 	}
 
+	@JsInfo("The item that was picked up.")
 	public ItemStack getItem() {
 		return stack;
 	}

--- a/common/src/main/java/dev/latvian/mods/kubejs/item/ItemSmeltedEventJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/item/ItemSmeltedEventJS.java
@@ -1,9 +1,13 @@
 package dev.latvian.mods.kubejs.item;
 
 import dev.latvian.mods.kubejs.player.PlayerEventJS;
+import dev.latvian.mods.kubejs.typings.JsInfo;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 
+@JsInfo("""
+		Invoked when an item is smelted by a player.
+		""")
 public class ItemSmeltedEventJS extends PlayerEventJS {
 	private final Player player;
 	private final ItemStack smelted;
@@ -14,10 +18,12 @@ public class ItemSmeltedEventJS extends PlayerEventJS {
 	}
 
 	@Override
+	@JsInfo("The player that smelted the item.")
 	public Player getEntity() {
 		return player;
 	}
 
+	@JsInfo("The item that was smelted.")
 	public ItemStack getItem() {
 		return smelted;
 	}

--- a/common/src/main/java/dev/latvian/mods/kubejs/item/ItemTooltipEventJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/item/ItemTooltipEventJS.java
@@ -2,6 +2,7 @@ package dev.latvian.mods.kubejs.item;
 
 import dev.latvian.mods.kubejs.bindings.TextWrapper;
 import dev.latvian.mods.kubejs.event.EventJS;
+import dev.latvian.mods.kubejs.typings.JsInfo;
 import dev.latvian.mods.kubejs.util.ConsoleJS;
 import dev.latvian.mods.kubejs.util.ListJS;
 import net.minecraft.client.gui.screens.Screen;
@@ -15,6 +16,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+@JsInfo("""
+		Invoked when registering handlers for item tooltips.
+				
+		`text` can be a component or a list of components.
+		""")
 public class ItemTooltipEventJS extends EventJS {
 	@FunctionalInterface
 	public interface StaticTooltipHandler {
@@ -84,6 +90,7 @@ public class ItemTooltipEventJS extends EventJS {
 		map = m;
 	}
 
+	@JsInfo("Adds text to all items matching the ingredient.")
 	public void add(Ingredient item, Object text) {
 		if (item.kjs$isWildcard()) {
 			addToAll(text);
@@ -101,6 +108,7 @@ public class ItemTooltipEventJS extends EventJS {
 		}
 	}
 
+	@JsInfo("Adds text to all items.")
 	public void addToAll(Object text) {
 		var l = new StaticTooltipHandlerFromLines(text);
 
@@ -109,6 +117,7 @@ public class ItemTooltipEventJS extends EventJS {
 		}
 	}
 
+	@JsInfo("Adds a dynamic tooltip handler to all items matching the ingredient.")
 	public void addAdvanced(Ingredient item, StaticTooltipHandlerFromJS handler) {
 		if (item.kjs$isWildcard()) {
 			addAdvancedToAll(handler);
@@ -124,18 +133,22 @@ public class ItemTooltipEventJS extends EventJS {
 		}
 	}
 
+	@JsInfo("Adds a dynamic tooltip handler to all items.")
 	public void addAdvancedToAll(StaticTooltipHandlerFromJS handler) {
 		map.computeIfAbsent(Items.AIR, k -> new ArrayList<>()).add(new StaticTooltipHandlerFromJSWrapper(handler));
 	}
 
+	@JsInfo("Is shift key pressed.")
 	public boolean isShift() {
 		return Screen.hasShiftDown();
 	}
 
+	@JsInfo("Is control key pressed.")
 	public boolean isCtrl() {
 		return Screen.hasControlDown();
 	}
 
+	@JsInfo("Is alt key pressed.")
 	public boolean isAlt() {
 		return Screen.hasAltDown();
 	}

--- a/common/src/main/java/dev/latvian/mods/kubejs/item/custom/HandheldItemBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/item/custom/HandheldItemBuilder.java
@@ -2,6 +2,7 @@ package dev.latvian.mods.kubejs.item.custom;
 
 import dev.latvian.mods.kubejs.item.ItemBuilder;
 import dev.latvian.mods.kubejs.item.MutableToolTier;
+import dev.latvian.mods.kubejs.typings.JsInfo;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Tier;
 import net.minecraft.world.item.Tiers;
@@ -27,26 +28,43 @@ public abstract class HandheldItemBuilder extends ItemBuilder {
 		return this;
 	}
 
+	@JsInfo("""
+			Sets the base attack damage of the tool. Different tools have different baselines.
+						
+			For example, a sword has a baseline of 3, while an axe has a baseline of 6.
+						
+			The actual damage is the sum of the baseline and the attackDamageBonus from tier.
+			""")
 	public HandheldItemBuilder attackDamageBaseline(float f) {
 		attackDamageBaseline = f;
 		return this;
 	}
 
+	@JsInfo("""
+			Sets the base attack speed of the tool. Different tools have different baselines.
+						
+			For example, a sword has a baseline of -2.4, while an axe has a baseline of -3.1.
+						
+			The actual speed is the sum of the baseline and the speed from tier + 4 (bare hand).
+			""")
 	public HandheldItemBuilder speedBaseline(float f) {
 		speedBaseline = f;
 		return this;
 	}
 
+	@JsInfo("Modifies the tool tier.")
 	public HandheldItemBuilder modifyTier(Consumer<MutableToolTier> callback) {
 		callback.accept(toolTier);
 		return this;
 	}
 
+	@JsInfo("Sets the attack damage bonus of the tool.")
 	public HandheldItemBuilder attackDamageBonus(float f) {
 		toolTier.setAttackDamageBonus(f);
 		return this;
 	}
 
+	@JsInfo("Sets the attack speed of the tool.")
 	public HandheldItemBuilder speed(float f) {
 		toolTier.setSpeed(f);
 		return this;

--- a/common/src/main/java/dev/latvian/mods/kubejs/item/custom/ItemArmorTierRegistryEventJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/item/custom/ItemArmorTierRegistryEventJS.java
@@ -4,10 +4,16 @@ import dev.latvian.mods.kubejs.KubeJS;
 import dev.latvian.mods.kubejs.event.StartupEventJS;
 import dev.latvian.mods.kubejs.item.ItemBuilder;
 import dev.latvian.mods.kubejs.item.MutableArmorTier;
+import dev.latvian.mods.kubejs.typings.JsInfo;
 
 import java.util.function.Consumer;
 
+@JsInfo("""
+		Invoked when the game is starting up and the armor tier registry is being built.
+		""")
 public class ItemArmorTierRegistryEventJS extends StartupEventJS {
+
+	@JsInfo("Adds a new armor tier with a parent tier specified by string.")
 	public void add(String id, String parent, Consumer<MutableArmorTier> tier) {
 		var material = ItemBuilder.toArmorMaterial(parent);
 		var fullId = KubeJS.appendModId(id);
@@ -16,6 +22,7 @@ public class ItemArmorTierRegistryEventJS extends StartupEventJS {
 		ItemBuilder.ARMOR_TIERS.put(fullId, t);
 	}
 
+	@JsInfo("Adds a new armor tier.")
 	public void add(String id, Consumer<MutableArmorTier> tier) {
 		add(id, "iron", tier);
 	}

--- a/common/src/main/java/dev/latvian/mods/kubejs/item/custom/ItemToolTierRegistryEventJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/item/custom/ItemToolTierRegistryEventJS.java
@@ -3,11 +3,17 @@ package dev.latvian.mods.kubejs.item.custom;
 import dev.latvian.mods.kubejs.event.StartupEventJS;
 import dev.latvian.mods.kubejs.item.ItemBuilder;
 import dev.latvian.mods.kubejs.item.MutableToolTier;
+import dev.latvian.mods.kubejs.typings.JsInfo;
 import net.minecraft.world.item.Tiers;
 
 import java.util.function.Consumer;
 
+@JsInfo("""
+		Invoked when the game is starting up and the item tool tiers are being registered.
+		""")
 public class ItemToolTierRegistryEventJS extends StartupEventJS {
+
+	@JsInfo("Adds a new tool tier.")
 	public void add(String id, Consumer<MutableToolTier> tier) {
 		var t = new MutableToolTier(Tiers.IRON);
 		tier.accept(t);

--- a/common/src/main/java/dev/latvian/mods/kubejs/item/custom/RecordItemJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/item/custom/RecordItemJS.java
@@ -2,6 +2,8 @@ package dev.latvian.mods.kubejs.item.custom;
 
 import dev.latvian.mods.kubejs.item.ItemBuilder;
 import dev.latvian.mods.kubejs.registry.KubeJSRegistries;
+import dev.latvian.mods.kubejs.typings.JsInfo;
+import dev.latvian.mods.kubejs.typings.JsParam;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.sounds.SoundEvents;
@@ -25,6 +27,13 @@ public class RecordItemJS extends RecordItem {
 			rarity(Rarity.RARE);
 		}
 
+		@JsInfo(value = """
+				Sets the song that will play when this record is played.
+				""",
+				params = {
+						@JsParam(name = "s", value = "The location of sound event."),
+						@JsParam(name = "seconds", value = "The length of the song in seconds.")
+				})
 		public Builder song(ResourceLocation s, int seconds) {
 			song = s;
 			length = seconds;
@@ -32,6 +41,7 @@ public class RecordItemJS extends RecordItem {
 			return this;
 		}
 
+		@JsInfo("Sets the redstone output of the jukebox when this record is played.")
 		public Builder analogOutput(int o) {
 			analogOutput = o;
 			return this;

--- a/common/src/main/java/dev/latvian/mods/kubejs/level/ExplosionEventJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/level/ExplosionEventJS.java
@@ -2,6 +2,7 @@ package dev.latvian.mods.kubejs.level;
 
 import dev.architectury.hooks.level.ExplosionHooks;
 import dev.latvian.mods.kubejs.player.EntityArrayList;
+import dev.latvian.mods.kubejs.typings.JsInfo;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
@@ -52,20 +53,28 @@ public abstract class ExplosionEventJS extends LevelEventJS {
 		return explosion.getSourceMob();
 	}
 
+	@JsInfo("""
+			Invoked right before an explosion happens.
+			""")
 	public static class Before extends ExplosionEventJS {
 		public Before(Level level, Explosion explosion) {
 			super(level, explosion);
 		}
 
+		@JsInfo("Returns the size of the explosion.")
 		public float getSize() {
 			return explosion.radius;
 		}
 
+		@JsInfo("Sets the size of the explosion.")
 		public void setSize(float s) {
 			explosion.radius = s;
 		}
 	}
 
+	@JsInfo("""
+			Invoked right after an explosion happens.
+			""")
 	public static class After extends ExplosionEventJS {
 		private final List<Entity> affectedEntities;
 
@@ -74,18 +83,22 @@ public abstract class ExplosionEventJS extends LevelEventJS {
 			this.affectedEntities = affectedEntities;
 		}
 
+		@JsInfo("Gets a list of all entities affected by the explosion.")
 		public EntityArrayList getAffectedEntities() {
 			return new EntityArrayList(level, affectedEntities);
 		}
 
+		@JsInfo("Remove an entity from the list of affected entities.")
 		public void removeAffectedEntity(Entity entity) {
 			affectedEntities.remove(entity);
 		}
 
+		@JsInfo("Remove all entities from the list of affected entities.")
 		public void removeAllAffectedEntities() {
 			affectedEntities.clear();
 		}
 
+		@JsInfo("Gets a list of all blocks affected by the explosion.")
 		public List<BlockContainerJS> getAffectedBlocks() {
 			List<BlockContainerJS> list = new ArrayList<>(explosion.getToBlow().size());
 
@@ -96,14 +109,17 @@ public abstract class ExplosionEventJS extends LevelEventJS {
 			return list;
 		}
 
+		@JsInfo("Remove a block from the list of affected blocks.")
 		public void removeAffectedBlock(BlockContainerJS block) {
 			explosion.getToBlow().remove(block.getPos());
 		}
 
+		@JsInfo("Remove all blocks from the list of affected blocks.")
 		public void removeAllAffectedBlocks() {
 			explosion.getToBlow().clear();
 		}
 
+		@JsInfo("Remove all knockback from all affected *players*.")
 		public void removeKnockback() {
 			explosion.getHitPlayers().clear();
 		}

--- a/common/src/main/java/dev/latvian/mods/kubejs/net/NetworkEventJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/net/NetworkEventJS.java
@@ -1,10 +1,20 @@
 package dev.latvian.mods.kubejs.net;
 
 import dev.latvian.mods.kubejs.player.PlayerEventJS;
+import dev.latvian.mods.kubejs.typings.JsInfo;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.entity.player.Player;
 import org.jetbrains.annotations.Nullable;
 
+@JsInfo("""
+		Invoked when a network packet is received.
+				
+		Note that the behaviour of this event is depending on the **script type**.
+				
+		In `server_scripts`, this event is invoked on the server side when a packet is received from a client.
+				
+		In `client_scripts`, this event is invoked on the client side when a packet is received from the server.
+		""")
 public class NetworkEventJS extends PlayerEventJS {
 	private final Player player;
 	private final String channel;
@@ -17,15 +27,18 @@ public class NetworkEventJS extends PlayerEventJS {
 	}
 
 	@Override
+	@JsInfo("The player that sent the packet. Always `Minecraft.player` in `client_scripts`.")
 	public Player getEntity() {
 		return player;
 	}
 
+	@JsInfo("The channel of the packet.")
 	public String getChannel() {
 		return channel;
 	}
 
 	@Nullable
+	@JsInfo("The data of the packet.")
 	public CompoundTag getData() {
 		return data;
 	}

--- a/common/src/main/java/dev/latvian/mods/kubejs/player/ChestEventJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/player/ChestEventJS.java
@@ -1,6 +1,7 @@
 package dev.latvian.mods.kubejs.player;
 
 import dev.latvian.mods.kubejs.level.BlockContainerJS;
+import dev.latvian.mods.kubejs.typings.JsInfo;
 import net.minecraft.world.Container;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
@@ -8,16 +9,23 @@ import net.minecraft.world.inventory.ChestMenu;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import org.jetbrains.annotations.Nullable;
 
+@JsInfo("""
+		Invoked when a player opens a chest.
+				
+		Same as `PlayerEvents.inventoryOpened`, but only for chests.
+		""")
 public class ChestEventJS extends InventoryEventJS {
 	public ChestEventJS(Player player, AbstractContainerMenu menu) {
 		super(player, menu);
 	}
 
+	@JsInfo("Gets the chest inventory.")
 	public Container getInventory() {
 		return ((ChestMenu) getInventoryContainer()).getContainer();
 	}
 
 	@Nullable
+	@JsInfo("Gets the chest block.")
 	public BlockContainerJS getBlock() {
 		if (getInventory() instanceof BlockEntity be) {
 			return getLevel().kjs$getBlock(be);

--- a/common/src/main/java/dev/latvian/mods/kubejs/player/InventoryChangedEventJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/player/InventoryChangedEventJS.java
@@ -1,8 +1,12 @@
 package dev.latvian.mods.kubejs.player;
 
+import dev.latvian.mods.kubejs.typings.JsInfo;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 
+@JsInfo("""
+		Invoked when a player's inventory changes.
+		""")
 public class InventoryChangedEventJS extends PlayerEventJS {
 	private final Player player;
 	private final ItemStack item;
@@ -15,14 +19,17 @@ public class InventoryChangedEventJS extends PlayerEventJS {
 	}
 
 	@Override
+	@JsInfo("Gets the player that changed their inventory.")
 	public Player getEntity() {
 		return player;
 	}
 
+	@JsInfo("Gets the item that was changed.")
 	public ItemStack getItem() {
 		return item;
 	}
 
+	@JsInfo("Gets the slot that was changed.")
 	public int getSlot() {
 		return slot;
 	}

--- a/common/src/main/java/dev/latvian/mods/kubejs/player/InventoryEventJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/player/InventoryEventJS.java
@@ -1,8 +1,12 @@
 package dev.latvian.mods.kubejs.player;
 
+import dev.latvian.mods.kubejs.typings.JsInfo;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 
+@JsInfo("""
+		Invoked when a player opens or closes a container.
+		""")
 public class InventoryEventJS extends PlayerEventJS {
 	private final Player player;
 	private final AbstractContainerMenu menu;
@@ -13,10 +17,12 @@ public class InventoryEventJS extends PlayerEventJS {
 	}
 
 	@Override
+	@JsInfo("Gets the player that opened or closed the container.")
 	public Player getEntity() {
 		return player;
 	}
 
+	@JsInfo("Gets the container that was opened or closed.")
 	public AbstractContainerMenu getInventoryContainer() {
 		return menu;
 	}

--- a/common/src/main/java/dev/latvian/mods/kubejs/player/PlayerAdvancementEventJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/player/PlayerAdvancementEventJS.java
@@ -1,8 +1,12 @@
 package dev.latvian.mods.kubejs.player;
 
+import dev.latvian.mods.kubejs.typings.JsInfo;
 import net.minecraft.advancements.Advancement;
 import net.minecraft.server.level.ServerPlayer;
 
+@JsInfo("""
+		Invoked when a player gets an advancement.
+		""")
 public class PlayerAdvancementEventJS extends PlayerEventJS {
 	private final ServerPlayer player;
 	private final Advancement advancement;
@@ -13,10 +17,12 @@ public class PlayerAdvancementEventJS extends PlayerEventJS {
 	}
 
 	@Override
+	@JsInfo("Returns the player that got the advancement.")
 	public ServerPlayer getEntity() {
 		return player;
 	}
 
+	@JsInfo("Returns the advancement that was obtained.")
 	public AdvancementJS getAdvancement() {
 		return new AdvancementJS(advancement);
 	}

--- a/common/src/main/java/dev/latvian/mods/kubejs/player/PlayerChatDecorateEventJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/player/PlayerChatDecorateEventJS.java
@@ -1,9 +1,15 @@
 package dev.latvian.mods.kubejs.player;
 
 import dev.architectury.event.events.common.ChatEvent;
+import dev.latvian.mods.kubejs.typings.JsInfo;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
 
+@JsInfo("""
+		Invoked when a player sends a chat message.
+				
+		If cancelled (`PlayerEvents.chat`), the message will not be sent.
+		""")
 public class PlayerChatDecorateEventJS extends PlayerEventJS {
 	private final ServerPlayer player;
 	public ChatEvent.ChatComponent chatComponent;
@@ -14,26 +20,32 @@ public class PlayerChatDecorateEventJS extends PlayerEventJS {
 	}
 
 	@Override
+	@JsInfo("Gets the player that sent the message.")
 	public ServerPlayer getEntity() {
 		return player;
 	}
 
+	@JsInfo("Gets the username of the player that sent the message.")
 	public String getUsername() {
 		return player.getGameProfile().getName();
 	}
 
+	@JsInfo("Gets the message that the player sent.")
 	public String getMessage() {
 		return chatComponent.get().getString();
 	}
 
+	@JsInfo("Gets the message that the player sent.")
 	public Component getComponent() {
 		return chatComponent.get();
 	}
 
+	@JsInfo("Sets the message that the player sent.")
 	public void setMessage(Component text) {
 		chatComponent.set(text);
 	}
 
+	@JsInfo("Sets the message that the player sent.")
 	public void setComponent(Component text) {
 		chatComponent.set(text);
 	}

--- a/common/src/main/java/dev/latvian/mods/kubejs/player/PlayerEventJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/player/PlayerEventJS.java
@@ -1,6 +1,7 @@
 package dev.latvian.mods.kubejs.player;
 
 import dev.latvian.mods.kubejs.entity.LivingEntityEventJS;
+import dev.latvian.mods.kubejs.typings.JsInfo;
 import net.minecraft.world.entity.player.Player;
 import org.jetbrains.annotations.Nullable;
 
@@ -14,14 +15,17 @@ public abstract class PlayerEventJS extends LivingEntityEventJS {
 		return getEntity();
 	}
 
+	@JsInfo("Checks if the player has the specified game stage")
 	public boolean hasGameStage(String stage) {
 		return getEntity().kjs$getStages().has(stage);
 	}
 
+	@JsInfo("Adds the specified game stage to the player")
 	public void addGameStage(String stage) {
 		getEntity().kjs$getStages().add(stage);
 	}
 
+	@JsInfo("Removes the specified game stage from the player")
 	public void removeGameStage(String stage) {
 		getEntity().kjs$getStages().remove(stage);
 	}

--- a/common/src/main/java/dev/latvian/mods/kubejs/player/PlayerRespawnedEventJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/player/PlayerRespawnedEventJS.java
@@ -1,7 +1,13 @@
 package dev.latvian.mods.kubejs.player;
 
+import dev.latvian.mods.kubejs.typings.JsInfo;
 import net.minecraft.server.level.ServerPlayer;
 
+@JsInfo("""
+		Invoked when a player respawns.
+				
+		The reason of respawn can be either death or returning from the end.
+		""")
 public class PlayerRespawnedEventJS extends PlayerEventJS {
 	private final ServerPlayer player;
 	private final ServerPlayer oldPlayer;
@@ -14,14 +20,17 @@ public class PlayerRespawnedEventJS extends PlayerEventJS {
 	}
 
 	@Override
+	@JsInfo("Gets the player that respawned.")
 	public ServerPlayer getEntity() {
 		return player;
 	}
 
+	@JsInfo("Gets the player that was before respawn. Note that this entity is already removed from the world.")
 	public ServerPlayer getOldPlayer() {
 		return oldPlayer;
 	}
 
+	@JsInfo("Gets whether the player's data was kept, e.g. when returning from the end.")
 	public boolean getKeepData() {
 		return keepData;
 	}

--- a/common/src/main/java/dev/latvian/mods/kubejs/registry/BuilderBase.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/registry/BuilderBase.java
@@ -2,6 +2,7 @@ package dev.latvian.mods.kubejs.registry;
 
 import dev.latvian.mods.kubejs.generator.AssetJsonGenerator;
 import dev.latvian.mods.kubejs.generator.DataJsonGenerator;
+import dev.latvian.mods.kubejs.typings.JsInfo;
 import dev.latvian.mods.kubejs.util.UtilsJS;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.PackType;
@@ -57,16 +58,27 @@ public abstract class BuilderBase<T> implements Supplier<T> {
 		return getRegistryType().key.location().getPath();
 	}
 
+	@JsInfo("""
+			Sets the translation key for this object, e.g. `block.minecraft.stone`.
+			""")
 	public BuilderBase<T> translationKey(String key) {
 		translationKey = key;
 		return this;
 	}
 
+	@JsInfo("""
+			Sets the display name for this object, e.g. `Stone`.
+
+			This will be overridden by a lang file if it exists.
+			""")
 	public BuilderBase<T> displayName(String name) {
 		displayName = name;
 		return this;
 	}
 
+	@JsInfo("""
+			Adds a tag to this object, e.g. `minecraft:stone`.
+			""")
 	public BuilderBase<T> tag(ResourceLocation tag) {
 		defaultTags.add(tag);
 		return this;


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->
### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->

Added runtime docs for KubeJS by using `@JsInfo` and `@JsParam`.

Currently added docs are:

- `ItemBuilder` and `BlockBuilder`
- All events of `EntityEvents`, `BlockEvents`, `PlayerEvents`, and `ItemEvents`

Other parts of the KubeJS are not added because I didn't really know that part of the code or I'm too busy with other developments.

#### Other details <!-- Any other important information, like if this is likely to break addons -->

Need more help to fully annotate the source of KubeJS.