### PR TITLE
Implemented `StagePredicate` for more complex stage condition check

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/BuiltinKubeJSPlugin.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/BuiltinKubeJSPlugin.java
@@ -93,6 +93,7 @@ import dev.latvian.mods.kubejs.script.BindingsEvent;
 import dev.latvian.mods.kubejs.script.CustomJavaToJsWrappersEvent;
 import dev.latvian.mods.kubejs.script.PlatformWrapper;
 import dev.latvian.mods.kubejs.script.ScriptType;
+import dev.latvian.mods.kubejs.stages.predicate.StagePredicate;
 import dev.latvian.mods.kubejs.util.ClassFilter;
 import dev.latvian.mods.kubejs.util.FluidAmounts;
 import dev.latvian.mods.kubejs.util.JsonIO;
@@ -447,6 +448,7 @@ public class BuiltinKubeJSPlugin extends KubeJSPlugin {
 		typeWrappers.registerSimple(ReplacementMatch.class, ReplacementMatch::of);
 		typeWrappers.registerSimple(Stat.class, PlayerStatsJS::statOf);
 		typeWrappers.register(NotificationBuilder.class, NotificationBuilder::of);
+		typeWrappers.registerSimple(StagePredicate.class, StagePredicate::of);
 
 		// components //
 		typeWrappers.registerSimple(Component.class, TextWrapper::of);

--- a/common/src/main/java/dev/latvian/mods/kubejs/recipe/RecipeJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/recipe/RecipeJS.java
@@ -22,6 +22,7 @@ import dev.latvian.mods.kubejs.recipe.ingredientaction.IngredientActionFilter;
 import dev.latvian.mods.kubejs.recipe.ingredientaction.KeepAction;
 import dev.latvian.mods.kubejs.recipe.ingredientaction.ReplaceAction;
 import dev.latvian.mods.kubejs.recipe.schema.RecipeSchema;
+import dev.latvian.mods.kubejs.stages.predicate.StagePredicate;
 import dev.latvian.mods.kubejs.util.ConsoleJS;
 import dev.latvian.mods.kubejs.util.UtilsJS;
 import dev.latvian.mods.rhino.Context;
@@ -458,8 +459,8 @@ public class RecipeJS implements RecipeKJS, CustomJavaToJsWrapper {
 		}
 	}
 
-	public RecipeJS stage(String s) {
-		json.addProperty("kubejs:stage", s);
+	public RecipeJS stage(StagePredicate s) {
+		json.add("kubejs:stage", s.toJson());
 		save();
 		return this;
 	}

--- a/common/src/main/java/dev/latvian/mods/kubejs/recipe/RecipesEventJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/recipe/RecipesEventJS.java
@@ -27,6 +27,7 @@ import dev.latvian.mods.kubejs.registry.KubeJSRegistries;
 import dev.latvian.mods.kubejs.script.ScriptType;
 import dev.latvian.mods.kubejs.server.DataExport;
 import dev.latvian.mods.kubejs.server.KubeJSReloadListener;
+import dev.latvian.mods.kubejs.stages.predicate.StagePredicate;
 import dev.latvian.mods.kubejs.util.ConsoleJS;
 import dev.latvian.mods.kubejs.util.JsonIO;
 import dev.latvian.mods.kubejs.util.UtilsJS;
@@ -618,7 +619,7 @@ public class RecipesEventJS extends EventJS {
 		RecipeJS.itemErrors = b;
 	}
 
-	public void stage(RecipeFilter filter, String stage) {
+	public void stage(RecipeFilter filter, StagePredicate stage) {
 		forEachRecipeAsync(filter, r -> r.stage(stage));
 	}
 

--- a/common/src/main/java/dev/latvian/mods/kubejs/recipe/special/KubeJSCraftingRecipe.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/recipe/special/KubeJSCraftingRecipe.java
@@ -4,6 +4,7 @@ import dev.architectury.utils.GameInstance;
 import dev.latvian.mods.kubejs.recipe.ModifyRecipeCraftingGrid;
 import dev.latvian.mods.kubejs.recipe.ModifyRecipeResultCallback;
 import dev.latvian.mods.kubejs.recipe.ingredientaction.IngredientAction;
+import dev.latvian.mods.kubejs.stages.predicate.StagePredicate;
 import net.minecraft.core.NonNullList;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
@@ -22,7 +23,8 @@ public interface KubeJSCraftingRecipe extends CraftingRecipe {
 	@Nullable
 	ModifyRecipeResultCallback kjs$getModifyResult();
 
-	String kjs$getStage();
+	@Nullable
+	StagePredicate kjs$getStage();
 
 	default NonNullList<ItemStack> kjs$getRemainingItems(CraftingContainer container) {
 		var list = NonNullList.withSize(container.getContainerSize(), ItemStack.EMPTY);
@@ -35,10 +37,11 @@ public interface KubeJSCraftingRecipe extends CraftingRecipe {
 	}
 
 	default ItemStack kjs$assemble(CraftingContainer container) {
-		if (!kjs$getStage().isEmpty()) {
+		StagePredicate predicate = kjs$getStage();
+		if (predicate != null) {
 			var player = getPlayer(container.menu);
 
-			if (player == null || !player.kjs$getStages().has(kjs$getStage())) {
+			if (player == null || !predicate.test(player.kjs$getStages())) {
 				return ItemStack.EMPTY;
 			}
 		}

--- a/common/src/main/java/dev/latvian/mods/kubejs/stages/predicate/AndPredicate.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/stages/predicate/AndPredicate.java
@@ -1,0 +1,45 @@
+package dev.latvian.mods.kubejs.stages.predicate;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import dev.latvian.mods.kubejs.stages.Stages;
+import net.minecraft.network.FriendlyByteBuf;
+
+import java.util.List;
+
+public class AndPredicate implements StagePredicate {
+	final List<StagePredicate> predicates;
+
+	public AndPredicate(List<StagePredicate> predicates) {
+		this.predicates = predicates;
+	}
+
+	@Override
+	public boolean test(Stages stages) {
+		for (StagePredicate predicate : predicates) {
+			if (!predicate.test(stages)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	@Override
+	public JsonElement toJson() {
+		JsonObject object = new JsonObject();
+		object.addProperty("type", "and");
+		JsonArray predicates = new JsonArray();
+		for (StagePredicate predicate : this.predicates) {
+			predicates.add(predicate.toJson());
+		}
+		object.add("predicates", predicates);
+		return object;
+	}
+
+	@Override
+	public void toNetwork(FriendlyByteBuf buf) {
+		buf.writeInt(AND_PREDICATE);
+		buf.writeCollection(predicates, (buf1, predicate) -> predicate.toNetwork(buf1));
+	}
+}

--- a/common/src/main/java/dev/latvian/mods/kubejs/stages/predicate/ExactPredicate.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/stages/predicate/ExactPredicate.java
@@ -1,0 +1,30 @@
+package dev.latvian.mods.kubejs.stages.predicate;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+import dev.latvian.mods.kubejs.stages.Stages;
+import net.minecraft.network.FriendlyByteBuf;
+
+public class ExactPredicate implements StagePredicate {
+	final String stage;
+
+	public ExactPredicate(String stage) {
+		this.stage = stage;
+	}
+
+	@Override
+	public boolean test(Stages stages) {
+		return stages.has(stage);
+	}
+
+	@Override
+	public JsonElement toJson() {
+		return new JsonPrimitive(stage);
+	}
+
+	@Override
+	public void toNetwork(FriendlyByteBuf buf) {
+		buf.writeInt(EXACT_PREDICATE);
+		buf.writeUtf(stage);
+	}
+}

--- a/common/src/main/java/dev/latvian/mods/kubejs/stages/predicate/NotPredicate.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/stages/predicate/NotPredicate.java
@@ -1,0 +1,33 @@
+package dev.latvian.mods.kubejs.stages.predicate;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import dev.latvian.mods.kubejs.stages.Stages;
+import net.minecraft.network.FriendlyByteBuf;
+
+public class NotPredicate implements StagePredicate {
+	final StagePredicate predicate;
+
+	public NotPredicate(StagePredicate predicate) {
+		this.predicate = predicate;
+	}
+
+	@Override
+	public boolean test(Stages stages) {
+		return !predicate.test(stages);
+	}
+
+	@Override
+	public JsonElement toJson() {
+		JsonObject object = new JsonObject();
+		object.addProperty("type", "not");
+		object.add("predicate", predicate.toJson());
+		return object;
+	}
+
+	@Override
+	public void toNetwork(FriendlyByteBuf buf) {
+		buf.writeInt(NOT_PREDICATE);
+		predicate.toNetwork(buf);
+	}
+}

--- a/common/src/main/java/dev/latvian/mods/kubejs/stages/predicate/OrPredicate.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/stages/predicate/OrPredicate.java
@@ -1,0 +1,46 @@
+package dev.latvian.mods.kubejs.stages.predicate;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import dev.latvian.mods.kubejs.stages.Stages;
+import net.minecraft.network.FriendlyByteBuf;
+
+import java.util.List;
+
+public class OrPredicate implements StagePredicate {
+	final List<StagePredicate> predicates;
+
+	public OrPredicate(List<StagePredicate> predicates) {
+		this.predicates = predicates;
+	}
+
+
+	@Override
+	public boolean test(Stages stages) {
+		for (StagePredicate predicate : predicates) {
+			if (predicate.test(stages)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public JsonElement toJson() {
+		JsonObject object = new JsonObject();
+		object.addProperty("type", "or");
+		JsonArray predicates = new JsonArray();
+		for (StagePredicate predicate : this.predicates) {
+			predicates.add(predicate.toJson());
+		}
+		object.add("predicates", predicates);
+		return object;
+	}
+
+	@Override
+	public void toNetwork(FriendlyByteBuf buf) {
+		buf.writeInt(OR_PREDICATE);
+		buf.writeCollection(predicates, (buf1, predicate) -> predicate.toNetwork(buf1));
+	}
+}

--- a/common/src/main/java/dev/latvian/mods/kubejs/stages/predicate/StagePredicate.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/stages/predicate/StagePredicate.java
@@ -1,0 +1,89 @@
+package dev.latvian.mods.kubejs.stages.predicate;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import dev.latvian.mods.kubejs.stages.Stages;
+import dev.latvian.mods.kubejs.util.ListJS;
+import dev.latvian.mods.kubejs.util.MapJS;
+import net.minecraft.network.FriendlyByteBuf;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+public interface StagePredicate extends Predicate<Stages> {
+	int AND_PREDICATE = 0;
+	int OR_PREDICATE = 1;
+	int NOT_PREDICATE = 2;
+	int EXACT_PREDICATE = 3;
+
+	JsonElement toJson();
+
+	void toNetwork(FriendlyByteBuf buf);
+
+	static StagePredicate of(Object o) {
+		if (o instanceof StagePredicate p) {
+			return p;
+		} else if (o instanceof CharSequence s) {
+			return new ExactPredicate(s.toString());
+		}
+		List<?> list = ListJS.of(o);
+		if (list != null) {
+			return new AndPredicate(list.stream().map(StagePredicate::of).collect(Collectors.toList()));
+		}
+		Map<?, ?> map = MapJS.of(o);
+		if (map != null) {
+			if (map.containsKey("and")) {
+				List<?> l = ListJS.of(map.get("and"));
+				if (l != null) return new AndPredicate(l.stream().map(StagePredicate::of).collect(Collectors.toList()));
+			} else if (map.containsKey("or")) {
+				List<?> l = ListJS.of(map.get("or"));
+				if (l != null) return new OrPredicate(l.stream().map(StagePredicate::of).collect(Collectors.toList()));
+			} else if (map.containsKey("not")) {
+				return new NotPredicate(of(map.get("not")));
+			}
+		}
+		throw new IllegalArgumentException("Unknown predicate: " + o);
+	}
+
+	static StagePredicate fromNetwork(FriendlyByteBuf buf) {
+		int type = buf.readInt();
+		return switch (type) {
+			case AND_PREDICATE -> new AndPredicate(buf.readCollection(ArrayList::new, StagePredicate::fromNetwork));
+			case OR_PREDICATE -> new OrPredicate(buf.readCollection(ArrayList::new, StagePredicate::fromNetwork));
+			case NOT_PREDICATE -> new NotPredicate(fromNetwork(buf));
+			case EXACT_PREDICATE -> new ExactPredicate(buf.readUtf());
+			default -> throw new IllegalArgumentException("Unknown predicate type: " + type);
+		};
+	}
+
+	static StagePredicate fromJson(JsonElement json) {
+		if (json.isJsonPrimitive()) {
+			return new ExactPredicate(json.getAsString());
+		} else if (json instanceof JsonObject object && object.has("type")) {
+			switch (object.get("type").getAsString()) {
+				case "and" -> {
+					List<StagePredicate> predicates = new ArrayList<>();
+					for (JsonElement element : object.getAsJsonArray("predicates")) {
+						predicates.add(fromJson(element));
+					}
+					return new AndPredicate(predicates);
+				}
+				case "or" -> {
+					List<StagePredicate> predicates = new ArrayList<>();
+					for (JsonElement element : object.getAsJsonArray("predicates")) {
+						predicates.add(fromJson(element));
+					}
+					return new OrPredicate(predicates);
+				}
+				case "not" -> {
+					return new NotPredicate(fromJson(object.get("predicate")));
+				}
+				default -> throw new IllegalArgumentException("Unknown stage predicate type: " + object.get("type"));
+			}
+		}
+		throw new IllegalArgumentException("Unknown stage predicate: " + json);
+	}
+}


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->
### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->

Changed the plain string in `stage` for `RecipeJS` with the `StagePredicate`. `StagePredicate` now supports `and`, `or` and `not` beside the exact match of the stage.

Different stage predicates can be combined to create more complex logic for stage checking.

This might also be good for future stage supports, like items or blocks.

#### Example Script <!-- Please provide an example script showing that the bug is fixed, or how the feature is used, if applicable -->
```js
ServerEvents.recipes(event => {
    let { minecraft, kubejs } = event.recipes
    kubejs.shaped("sugar", [
        "AAA",
        "AAA",
        "AAA"
    ], {
        A: "minecraft:stone"
    })
          // available when player has the stage "foobar"
         .stage("foobar")
          // available when player does not have the stage "foobar"
         .stage({ not: "foobar" })
          // available when player has all of the stages "foobar" and "baz"
         .stage(["foobar", "baz"])
          // available when player has any of the stages "foobar" and "baz"
         .stage({ or: ["foobar", "baz"] })
})
```

#### Other details <!-- Any other important information, like if this is likely to break addons -->