### PR TITLE
Throw an informative error about null item stacks as recipe results

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/recipe/JsonRecipeJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/recipe/JsonRecipeJS.java
@@ -35,6 +35,8 @@ public class JsonRecipeJS extends RecipeJS {
 	public boolean hasOutput(ReplacementMatch match) {
 		if (CommonProperties.get().matchJsonRecipes && match instanceof ItemMatch m && getOriginalRecipe() != null) {
 			var r = getOriginalRecipe().getResultItem();
+			//noinspection ConstantValue
+			if (r == null) throw new NullPointerException("ItemStack should never be null, but recipe " + getId() + " returned null as the output!");
 			return r != ItemStack.EMPTY && m.contains(r);
 		}
 

--- a/common/src/main/java/dev/latvian/mods/kubejs/recipe/JsonRecipeJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/recipe/JsonRecipeJS.java
@@ -36,7 +36,7 @@ public class JsonRecipeJS extends RecipeJS {
 		if (CommonProperties.get().matchJsonRecipes && match instanceof ItemMatch m && getOriginalRecipe() != null) {
 			var r = getOriginalRecipe().getResultItem();
 			//noinspection ConstantValue
-			if (r == null) throw new NullPointerException("ItemStack should never be null, but recipe " + getId() + " returned null as the output!");
+			if (r == null) throw new NullPointerException("ItemStack should never be null, but recipe " + this + " returned null as the output!");
 			return r != ItemStack.EMPTY && m.contains(r);
 		}
 


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->
### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->
ItemStacks should never be null, but some people are not aware of that. If someone does return null from `getResultItem` in a recipe then the [resulting error](https://gnomebot.dev/paste/1134361831868219452#L19) says nothing about the recipe that causes it. This fixes that by throwing earlier and including the recipe id.


#### Example Script <!-- Please provide an example script showing that the bug is fixed, or how the feature is used, if applicable -->
```js
//requires: butchercraft
// specifically version 2.2.1 or lower, they have fixed it in newer versions
SeverEvents.recipes(event => {
  event.remove({output: 'minecraft:stick'}) // any filter that includes butchercrafts meat_hook recipes causes it
})
```