### PR TITLE
More block callbacks

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/block/BlockBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/BlockBuilder.java
@@ -680,8 +680,12 @@ public abstract class BlockBuilder extends BuilderBase<Block> {
 		return bounce(ctx -> ctx.bounce(-bounciness));
 	}
 
-	//TODO: is this too laggy? 1 tps isnt much...
-	@Info("Set how this block bounces/moves entities that land on top of this. Do not use this to modify the block, use fallOn instead!")
+	@Info("""
+		Set how this block bounces/moves entities that land on top of this. Do not use this to modify the block, use fallOn instead!
+		Use ctx.bounce(height) or ctx.setVelocity(x, y, z) to change the entities velocity.
+		
+		Warning: This can be called very often as it is a part of collision code. Be very careful with what you do here.
+		""")
 	public BlockBuilder bounce(Consumer<EntityBounceCallbackJS> callbackJS) {
 		bounceCallback = callbackJS;
 		return this;

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/BlockBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/BlockBuilder.java
@@ -78,6 +78,7 @@ public abstract class BlockBuilder extends BuilderBase<Block> {
 	public transient Consumer<BlockStateModifyCallbackJS> defaultStateModification;
 	public transient Consumer<BlockStateModifyPlacementCallbackJS> placementStateModification;
 	public transient Function<CanBeReplacedCallbackJS, Boolean> canBeReplacedFunction;
+	
 
 	public BlockBuilder(ResourceLocation i) {
 		super(i);

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/BlockBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/BlockBuilder.java
@@ -677,7 +677,7 @@ public abstract class BlockBuilder extends BuilderBase<Block> {
 
 	@Info("Bounces entities that land on this block by bounciness * their fall velocity")
 	public BlockBuilder bounceHeight(float bounciness) {
-		return bounce(ctx -> ctx.bounce(-bounciness));
+		return bounce(ctx -> ctx.bounce(bounciness));
 	}
 
 	@Info("""

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/BlockBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/BlockBuilder.java
@@ -2,6 +2,13 @@ package dev.latvian.mods.kubejs.block;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import dev.latvian.mods.kubejs.block.callbacks.BlockExplodedCallbackJS;
+import dev.latvian.mods.kubejs.block.callbacks.BlockStateModifyCallbackJS;
+import dev.latvian.mods.kubejs.block.callbacks.BlockStateModifyPlacementCallbackJS;
+import dev.latvian.mods.kubejs.block.callbacks.CanBeReplacedCallbackJS;
+import dev.latvian.mods.kubejs.block.callbacks.EntityBounceCallbackJS;
+import dev.latvian.mods.kubejs.block.callbacks.EntityFallOnBlockCallbackJS;
+import dev.latvian.mods.kubejs.block.callbacks.EntityStepOnBlockCallbackJS;
 import dev.latvian.mods.kubejs.client.ModelGenerator;
 import dev.latvian.mods.kubejs.client.VariantBlockStateGenerator;
 import dev.latvian.mods.kubejs.generator.AssetJsonGenerator;
@@ -78,6 +85,10 @@ public abstract class BlockBuilder extends BuilderBase<Block> {
 	public transient Consumer<BlockStateModifyCallbackJS> defaultStateModification;
 	public transient Consumer<BlockStateModifyPlacementCallbackJS> placementStateModification;
 	public transient Function<CanBeReplacedCallbackJS, Boolean> canBeReplacedFunction;
+	public transient Consumer<EntityStepOnBlockCallbackJS> stepOnCallback;
+	public transient Consumer<EntityFallOnBlockCallbackJS> fallOnCallback;
+	public transient Consumer<EntityBounceCallbackJS> bounceCallback;
+	public transient Consumer<BlockExplodedCallbackJS> explodedCallback;
 	
 
 	public BlockBuilder(ResourceLocation i) {
@@ -644,6 +655,29 @@ public abstract class BlockBuilder extends BuilderBase<Block> {
 	@Info("Set if the block can be replaced by something else.")
 	public BlockBuilder canBeReplaced(Function<CanBeReplacedCallbackJS, Boolean> callbackJS) {
 		canBeReplacedFunction = callbackJS;
+		return this;
+	}
+
+	@Info("Set what happens when an entity falls on the block. Do not use this for moving them, use bounce instead!")
+	public BlockBuilder onFall(Consumer<EntityFallOnBlockCallbackJS> callbackJS) {
+		fallOnCallback = callbackJS;
+		return this;
+	}
+
+	@Info("Bounces entities that land on this block by height * their fall velocity")
+	public BlockBuilder bounce(float height) {
+		return bounce(ctx -> ctx.bounce(height));
+	}
+
+	@Info("Set how this block bounces/moves entities that land on top of this. Do not use this to modify the block, use onFall isntead!")
+	public BlockBuilder bounce(Consumer<EntityBounceCallbackJS> callbackJS) {
+		bounceCallback = callbackJS;
+		return this;
+	}
+
+	@Info("Set how this block reacts after an explosion. Note the block has already been destroyed at this point")
+	public BlockBuilder exploded(Consumer<BlockExplodedCallbackJS> callbackJS) {
+		explodedCallback = callbackJS;
 		return this;
 	}
 

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/BlockBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/BlockBuilder.java
@@ -383,6 +383,11 @@ public abstract class BlockBuilder extends BuilderBase<Block> {
 		return this;
 	}
 
+	@Info("Makes the block require a tool to have drops when broken.")
+	public BlockBuilder requiresTool() {
+		return requiresTool(true);
+	}
+
 	@Info("""
 			Sets the render type of the block. Can be `cutout`, `cutout_mipped`, `translucent`, or `basic`.
 			""")

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/BlockBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/BlockBuilder.java
@@ -658,18 +658,25 @@ public abstract class BlockBuilder extends BuilderBase<Block> {
 		return this;
 	}
 
+	@Info("Set what happens when an entity steps on the block")
+	public BlockBuilder stepOn(Consumer<EntityStepOnBlockCallbackJS> callbackJS) {
+		stepOnCallback = callbackJS;
+		return this;
+	}
+
 	@Info("Set what happens when an entity falls on the block. Do not use this for moving them, use bounce instead!")
-	public BlockBuilder onFall(Consumer<EntityFallOnBlockCallbackJS> callbackJS) {
+	public BlockBuilder fallOn(Consumer<EntityFallOnBlockCallbackJS> callbackJS) {
 		fallOnCallback = callbackJS;
 		return this;
 	}
 
-	@Info("Bounces entities that land on this block by height * their fall velocity")
-	public BlockBuilder bounce(float height) {
-		return bounce(ctx -> ctx.bounce(height));
+	@Info("Bounces entities that land on this block by bounciness * their fall velocity")
+	public BlockBuilder bounceHeight(float bounciness) {
+		return bounce(ctx -> ctx.bounce(-bounciness));
 	}
 
-	@Info("Set how this block bounces/moves entities that land on top of this. Do not use this to modify the block, use onFall isntead!")
+	//TODO: is this too laggy? 1 tps isnt much...
+	@Info("Set how this block bounces/moves entities that land on top of this. Do not use this to modify the block, use fallOn instead!")
 	public BlockBuilder bounce(Consumer<EntityBounceCallbackJS> callbackJS) {
 		bounceCallback = callbackJS;
 		return this;

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/BlockBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/BlockBuilder.java
@@ -663,7 +663,10 @@ public abstract class BlockBuilder extends BuilderBase<Block> {
 		return this;
 	}
 
-	@Info("Set what happens when an entity steps on the block")
+	@Info("""
+		Set what happens when an entity steps on the block
+		This is called every tick for every entity standing on the block, so be careful what you do here.
+		""")
 	public BlockBuilder stepOn(Consumer<EntityStepOnBlockCallbackJS> callbackJS) {
 		stepOnCallback = callbackJS;
 		return this;
@@ -675,16 +678,17 @@ public abstract class BlockBuilder extends BuilderBase<Block> {
 		return this;
 	}
 
-	@Info("Bounces entities that land on this block by bounciness * their fall velocity")
-	public BlockBuilder bounceHeight(float bounciness) {
+	@Info("""
+		Bounces entities that land on this block by bounciness * their fall velocity.
+		Do not make bounciness negative, as that is a recipe for a long and laggy trip to the void
+		""")
+	public BlockBuilder bounciness(float bounciness) {
 		return bounce(ctx -> ctx.bounce(bounciness));
 	}
 
 	@Info("""
 		Set how this block bounces/moves entities that land on top of this. Do not use this to modify the block, use fallOn instead!
 		Use ctx.bounce(height) or ctx.setVelocity(x, y, z) to change the entities velocity.
-		
-		Warning: This can be called very often as it is a part of collision code. Be very careful with what you do here.
 		""")
 	public BlockBuilder bounce(Consumer<EntityBounceCallbackJS> callbackJS) {
 		bounceCallback = callbackJS;

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/callbacks/BlockExplodedCallbackJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/callbacks/BlockExplodedCallbackJS.java
@@ -1,0 +1,66 @@
+package dev.latvian.mods.kubejs.block.callbacks;
+
+import dev.latvian.mods.kubejs.level.BlockContainerJS;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Explosion;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+public class BlockExplodedCallbackJS {
+
+	protected final Level level;
+	protected final BlockContainerJS block;
+	protected final BlockState state;
+	protected final Explosion explosion;
+
+	public BlockExplodedCallbackJS(Level level, BlockPos pos, Explosion explosion) {
+		this.level = level;
+		this.block = new BlockContainerJS(level, pos);
+		this.state = level.getBlockState(pos);
+		this.explosion = explosion;
+	}
+
+	public Level getLevel() {
+		return level;
+	}
+
+	public BlockContainerJS getBlock() {
+		return block;
+	}
+
+	public BlockState getBlockState() {
+		return state;
+	}
+
+	public Explosion getExplosion() {
+		return explosion;
+	}
+
+	public Entity getCause() {
+		return explosion.source;
+	}
+
+	@Nullable
+	public LivingEntity getIgniter() {
+		return explosion.getSourceMob();
+	}
+
+	public float getRadius() {
+		return explosion.radius;
+	}
+
+	public DamageSource getDamageSource() {
+		return explosion.getDamageSource();
+	}
+
+	public List<Player> getAffectedPlayers() {
+		return explosion.getHitPlayers().keySet().stream().toList();
+	}
+}

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/callbacks/BlockStateModifyCallbackJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/callbacks/BlockStateModifyCallbackJS.java
@@ -1,4 +1,4 @@
-package dev.latvian.mods.kubejs.block;
+package dev.latvian.mods.kubejs.block.callbacks;
 
 import com.google.common.collect.ImmutableMap;
 import net.minecraft.core.BlockPos;

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/callbacks/CanBeReplacedCallbackJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/callbacks/CanBeReplacedCallbackJS.java
@@ -1,4 +1,4 @@
-package dev.latvian.mods.kubejs.block;
+package dev.latvian.mods.kubejs.block.callbacks;
 
 import dev.latvian.mods.kubejs.item.ItemStackJS;
 import dev.latvian.mods.kubejs.level.BlockContainerJS;
@@ -9,33 +9,18 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.FluidState;
-import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.Nullable;
 
-public class BlockStateModifyPlacementCallbackJS extends BlockStateModifyCallbackJS {
-	public final BlockPlaceContext context;
-	public final Block minecraftBlock;
-	public BlockContainerJS block;
+public class CanBeReplacedCallbackJS {
 
-	public BlockStateModifyPlacementCallbackJS(BlockPlaceContext context, Block block) {
-		super(getBlockStateToModify(context, block));
-		this.context = context;
-		this.minecraftBlock = block;
-		this.block = new BlockContainerJS(context.getLevel(), context.getClickedPos());
-	}
+	private final BlockPlaceContext context;
 
-	private static BlockState getBlockStateToModify(BlockPlaceContext context, Block block) {
-		BlockState previous = context.getLevel().getBlockState(context.getClickedPos());
-		if (previous.getBlock() == block) {
-			return previous;
-		}
-		return block.defaultBlockState();
+	public CanBeReplacedCallbackJS(BlockPlaceContext blockPlaceContext, BlockState state) {
+		context = blockPlaceContext;
 	}
 
 	public BlockPos getClickedPos() {
@@ -44,14 +29,6 @@ public class BlockStateModifyPlacementCallbackJS extends BlockStateModifyCallbac
 
 	public BlockContainerJS getClickedBlock() {
 		return new BlockContainerJS(getLevel(), getClickedPos());
-	}
-
-	public boolean canPlace() {
-		return context.canPlace();
-	}
-
-	public boolean replacingClickedOnBlock() {
-		return context.replacingClickedOnBlock();
 	}
 
 	public Direction getNearestLookingDirection() {
@@ -115,20 +92,7 @@ public class BlockStateModifyPlacementCallbackJS extends BlockStateModifyCallbac
 		return getFluidStateAtClickedPos().is(fluid);
 	}
 
-	public BlockStateModifyPlacementCallbackJS waterlogged(boolean waterlogged) {
-		setValue(BlockStateProperties.WATERLOGGED, waterlogged);
-		return this;
-	}
-
-	public BlockStateModifyPlacementCallbackJS waterlogged() {
-		return waterlogged(isInWater());
-	}
-
-	public boolean isInWater() {
-		return getFluidStateAtClickedPos().getType() == Fluids.WATER;
-	}
-
-	public boolean isReplacingSelf() {
-		return getLevel().getBlockState(getClickedPos()).getBlock() == minecraftBlock;
+	public boolean canMaterialBeReplaced() {
+		return getLevel().getBlockState(getClickedPos()).getMaterial().isReplaceable();
 	}
 }

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/callbacks/EntityBounceCallbackJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/callbacks/EntityBounceCallbackJS.java
@@ -15,12 +15,14 @@ public class EntityBounceCallbackJS extends EntityStepOnBlockCallbackJS {
 		this.hasChangedVelocity = false;
 	}
 
-
-	@Info("Bounce the entity upwards by multiplier their downwards velocity by the strength passed in")
-	public void bounce(float strength) {
+	@Info("""
+		Bounce the entity upwards by bounciness * their fall velocity.
+		Do not make bounciness negative, as that is a recipe for a long and laggy trip to the void
+		""")
+	public void bounce(float bounciness) {
 		Vec3 deltaMovement = entity.getDeltaMovement();
 		if (!isSuppressingBounce() && deltaMovement.y < 0.0) {
-			entity.setDeltaMovement(deltaMovement.x, -deltaMovement.y * strength, deltaMovement.z);
+			entity.setDeltaMovement(deltaMovement.x, -deltaMovement.y * bounciness, deltaMovement.z);
 			hasChangedVelocity = true;
 		}
 	}

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/callbacks/EntityBounceCallbackJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/callbacks/EntityBounceCallbackJS.java
@@ -6,23 +6,39 @@ import net.minecraft.world.phys.Vec3;
 
 public class EntityBounceCallbackJS extends EntityStepOnBlockCallbackJS {
 
-	public EntityBounceCallbackJS(BlockGetter blockGetter, Entity entity) {
+	private boolean hasChangedVelocity;
+
+	public 	EntityBounceCallbackJS(BlockGetter blockGetter, Entity entity) {
 		super(entity.level, entity, entity.getOnPos(), blockGetter.getBlockState(entity.getOnPos()));
+		this.hasChangedVelocity = false;
 	}
 
 	public boolean isSuppressingBounce() {
 		return entity.isSuppressingBounce();
 	}
 
-	public void bounce(float height) {
-		bounce(0, height,0, 0.1f);
+	public void bounce(float strength) {
+		Vec3 deltaMovement = entity.getDeltaMovement();
+		if (!entity.isSuppressingBounce() && deltaMovement.y < 0.0) {
+			entity.setDeltaMovement(deltaMovement.x, -deltaMovement.y * strength, deltaMovement.z);
+			hasChangedVelocity = true;
+		}
 	}
 
-	public void bounce(float x,float y, float z, float minHeight) {
-		Vec3 deltaMovement = entity.getDeltaMovement();
-		if (!entity.isSuppressingBounce() && deltaMovement.y < -minHeight) {
-			entity.setDeltaMovement(deltaMovement.x * x, -deltaMovement.y * y, deltaMovement.z * z);
-		}
-//		entity.hurtMarked = true;
+	public Vec3 getVelocity() {
+		return entity.getDeltaMovement();
+	}
+
+	public void setVelocity(Vec3 vec) {
+		entity.setDeltaMovement(vec);
+		hasChangedVelocity = true;
+	}
+
+	public void setVelocity(float x, float y, float z) {
+		setVelocity(new Vec3(x, y, z));
+	}
+
+	public boolean hasChangedVelocity() {
+		return hasChangedVelocity;
 	}
 }

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/callbacks/EntityBounceCallbackJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/callbacks/EntityBounceCallbackJS.java
@@ -1,0 +1,28 @@
+package dev.latvian.mods.kubejs.block.callbacks;
+
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.phys.Vec3;
+
+public class EntityBounceCallbackJS extends EntityStepOnBlockCallbackJS {
+
+	public EntityBounceCallbackJS(BlockGetter blockGetter, Entity entity) {
+		super(entity.level, entity, entity.getOnPos(), blockGetter.getBlockState(entity.getOnPos()));
+	}
+
+	public void bounce(float height) {
+		bounce(0, height,0);
+	}
+
+	public void bounce(float x,float y,float z) {
+		if (!entity.isSuppressingBounce()) {
+			Vec3 deltaMovement = entity.getDeltaMovement();
+			if (deltaMovement.y < 0.0) {
+				double d = entity instanceof LivingEntity ? 1.0 : 0.8;
+				entity.setDeltaMovement(deltaMovement.x * x, -deltaMovement.y * d, deltaMovement.z * z);
+			}
+		}
+//		entity.hurtMarked = true;
+	}
+}

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/callbacks/EntityBounceCallbackJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/callbacks/EntityBounceCallbackJS.java
@@ -1,5 +1,7 @@
 package dev.latvian.mods.kubejs.block.callbacks;
 
+import dev.latvian.mods.kubejs.typings.Info;
+import dev.latvian.mods.rhino.util.HideFromJS;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.phys.Vec3;
@@ -13,31 +15,33 @@ public class EntityBounceCallbackJS extends EntityStepOnBlockCallbackJS {
 		this.hasChangedVelocity = false;
 	}
 
-	public boolean isSuppressingBounce() {
-		return entity.isSuppressingBounce();
-	}
 
+	@Info("Bounce the entity upwards by multiplier their downwards velocity by the strength passed in")
 	public void bounce(float strength) {
 		Vec3 deltaMovement = entity.getDeltaMovement();
-		if (!entity.isSuppressingBounce() && deltaMovement.y < 0.0) {
+		if (!isSuppressingBounce() && deltaMovement.y < 0.0) {
 			entity.setDeltaMovement(deltaMovement.x, -deltaMovement.y * strength, deltaMovement.z);
 			hasChangedVelocity = true;
 		}
 	}
 
+	@Info("Returns the Vec3 of the entity's velocity. Use .x, .y and .z to get the respective components of that")
 	public Vec3 getVelocity() {
 		return entity.getDeltaMovement();
 	}
 
+	@Info("Sets the entity's velocity")
 	public void setVelocity(Vec3 vec) {
 		entity.setDeltaMovement(vec);
 		hasChangedVelocity = true;
 	}
 
+	@Info("Sets the entity's velocity")
 	public void setVelocity(float x, float y, float z) {
 		setVelocity(new Vec3(x, y, z));
 	}
 
+	@HideFromJS
 	public boolean hasChangedVelocity() {
 		return hasChangedVelocity;
 	}

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/callbacks/EntityBounceCallbackJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/callbacks/EntityBounceCallbackJS.java
@@ -1,7 +1,6 @@
 package dev.latvian.mods.kubejs.block.callbacks;
 
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.phys.Vec3;
 
@@ -11,17 +10,18 @@ public class EntityBounceCallbackJS extends EntityStepOnBlockCallbackJS {
 		super(entity.level, entity, entity.getOnPos(), blockGetter.getBlockState(entity.getOnPos()));
 	}
 
-	public void bounce(float height) {
-		bounce(0, height,0);
+	public boolean isSuppressingBounce() {
+		return entity.isSuppressingBounce();
 	}
 
-	public void bounce(float x,float y,float z) {
-		if (!entity.isSuppressingBounce()) {
-			Vec3 deltaMovement = entity.getDeltaMovement();
-			if (deltaMovement.y < 0.0) {
-				double d = entity instanceof LivingEntity ? 1.0 : 0.8;
-				entity.setDeltaMovement(deltaMovement.x * x, -deltaMovement.y * d, deltaMovement.z * z);
-			}
+	public void bounce(float height) {
+		bounce(0, height,0, 0.1f);
+	}
+
+	public void bounce(float x,float y, float z, float minHeight) {
+		Vec3 deltaMovement = entity.getDeltaMovement();
+		if (!entity.isSuppressingBounce() && deltaMovement.y < -minHeight) {
+			entity.setDeltaMovement(deltaMovement.x * x, -deltaMovement.y * y, deltaMovement.z * z);
 		}
 //		entity.hurtMarked = true;
 	}

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/callbacks/EntityFallOnBlockCallbackJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/callbacks/EntityFallOnBlockCallbackJS.java
@@ -1,0 +1,41 @@
+package dev.latvian.mods.kubejs.block.callbacks;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+
+public class EntityFallOnBlockCallbackJS extends EntityStepOnBlockCallbackJS {
+
+	private final float fallHeight;
+
+	public EntityFallOnBlockCallbackJS(Level level, Entity entity, BlockPos pos, BlockState state, float fallHeight) {
+		super(level, entity, pos, state);
+		this.fallHeight = fallHeight;
+	}
+
+	public boolean isSuppressingBounce() {
+		return entity.isSuppressingBounce();
+	}
+
+	public float getFallHeight() {
+		return fallHeight;
+	}
+
+	public boolean applyFallDamage() {
+		return applyFallDamage(1);
+	}
+
+	public boolean applyFallDamage(float multiplier) {
+		return applyFallDamage(fallHeight, multiplier);
+	}
+
+	public boolean applyFallDamage(float fallHeight, float multiplier) {
+		return applyFallDamage(fallHeight, multiplier, DamageSource.FALL);
+	}
+
+	public boolean applyFallDamage(float fallHeight, float multiplier, DamageSource damageSource) {
+		return entity.causeFallDamage(fallHeight, multiplier, damageSource);
+	}
+}

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/callbacks/EntityFallOnBlockCallbackJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/callbacks/EntityFallOnBlockCallbackJS.java
@@ -1,5 +1,6 @@
 package dev.latvian.mods.kubejs.block.callbacks;
 
+import dev.latvian.mods.kubejs.typings.Info;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.Entity;
@@ -15,26 +16,39 @@ public class EntityFallOnBlockCallbackJS extends EntityStepOnBlockCallbackJS {
 		this.fallHeight = fallHeight;
 	}
 
-	public boolean isSuppressingBounce() {
-		return entity.isSuppressingBounce();
-	}
-
+	@Info("Get the height the entity has fallen")
 	public float getFallHeight() {
 		return fallHeight;
 	}
 
+	@Info("""
+		Applies default fall damage to the entity.
+		Note this does not force it, so entities that do not take fall damage are not affected.
+		""")
 	public boolean applyFallDamage() {
 		return applyFallDamage(1);
 	}
 
+	@Info("""
+		Applies fall damage to the entity, multiplier by the multiplier.
+		Note this does not force it, so entities that do not take fall damage are not affected.
+		""")
 	public boolean applyFallDamage(float multiplier) {
 		return applyFallDamage(fallHeight, multiplier);
 	}
 
+	@Info("""
+		Applies fall damage to the entity as if they had fallen from the provided height, and multiplies it by the provided multiplier.
+		Note this does not force it, so entities that do not take fall damage are not affected.
+		""")
 	public boolean applyFallDamage(float fallHeight, float multiplier) {
 		return applyFallDamage(fallHeight, multiplier, DamageSource.FALL);
 	}
 
+	@Info("""
+		Damages the entity using the provided damage source, using the fall height and multiplier to calculate the damage amount.
+		Note this does not force the damage, so entities that do not take fall damage are not affected.
+		""")
 	public boolean applyFallDamage(float fallHeight, float multiplier, DamageSource damageSource) {
 		return entity.causeFallDamage(fallHeight, multiplier, damageSource);
 	}

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/callbacks/EntityStepOnBlockCallbackJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/callbacks/EntityStepOnBlockCallbackJS.java
@@ -1,0 +1,42 @@
+package dev.latvian.mods.kubejs.block.callbacks;
+
+import dev.latvian.mods.kubejs.level.BlockContainerJS;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+
+public class EntityStepOnBlockCallbackJS {
+
+	protected final Level level;
+	protected final Entity entity;
+	protected final BlockContainerJS block;
+	protected final BlockState state;
+
+	public EntityStepOnBlockCallbackJS(Level level, Entity entity, BlockPos pos, BlockState state) {
+		this.level = level;
+		this.entity = entity;
+		this.block = new BlockContainerJS(level, pos);
+		this.state = state;
+	}
+
+	public Level getLevel() {
+		return level;
+	}
+
+	public Entity getEntity() {
+		return entity;
+	}
+
+	public BlockContainerJS getBlock() {
+		return block;
+	}
+
+	public BlockState getState() {
+		return state;
+	}
+
+	public BlockPos getPos() {
+		return block.getPos();
+	}
+}

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/callbacks/EntityStepOnBlockCallbackJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/callbacks/EntityStepOnBlockCallbackJS.java
@@ -1,6 +1,7 @@
 package dev.latvian.mods.kubejs.block.callbacks;
 
 import dev.latvian.mods.kubejs.level.BlockContainerJS;
+import dev.latvian.mods.kubejs.typings.Info;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.Level;
@@ -20,23 +21,33 @@ public class EntityStepOnBlockCallbackJS {
 		this.state = state;
 	}
 
+	@Info("Returns the level")
 	public Level getLevel() {
 		return level;
 	}
 
+	@Info("Returns the entity")
 	public Entity getEntity() {
 		return entity;
 	}
 
+	@Info("Returns the block")
 	public BlockContainerJS getBlock() {
 		return block;
 	}
 
+	@Info("Returns the BlockState")
 	public BlockState getState() {
 		return state;
 	}
 
+	@Info("Returns the block's position")
 	public BlockPos getPos() {
 		return block.getPos();
+	}
+
+	@Info("Returns if the entity is suppressing bouncing (for players this is true if the player is crouching)")
+	public boolean isSuppressingBounce() {
+		return entity.isSuppressingBounce();
 	}
 }

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/custom/BasicBlockJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/custom/BasicBlockJS.java
@@ -264,6 +264,12 @@ public class BasicBlockJS extends Block implements EntityBlockKJS, SimpleWaterlo
 		if (blockBuilder.bounceCallback != null) {
 			var callbackJS = new EntityBounceCallbackJS(blockGetter, entity);
 			safeCallback(blockBuilder.bounceCallback, callbackJS, "Error while bouncing entity from custom block ");
+			// if they did not change the entity's velocity, then use the default method to reset the velocity.
+			if (!callbackJS.hasChangedVelocity()) {
+				super.updateEntityAfterFallOn(blockGetter, entity);
+			}
+		} else {
+			super.updateEntityAfterFallOn(blockGetter, entity);
 		}
 	}
 

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/custom/BasicBlockJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/custom/BasicBlockJS.java
@@ -69,7 +69,7 @@ public class BasicBlockJS extends Block implements EntityBlockKJS, SimpleWaterlo
 		var blockState = stateDefinition.any();
 		if (blockBuilder.defaultStateModification != null) {
 			var callbackJS = new BlockStateModifyCallbackJS(blockState);
-			if (safeCallback(blockBuilder.defaultStateModification, callbackJS, "Error while creating default blockState for block " + p.id)) {
+			if (safeCallback(blockBuilder.defaultStateModification, callbackJS, "Error while creating default blockState for block ")) {
 				registerDefaultState(callbackJS.getState());
 			}
 		} else if (blockBuilder.canBeWaterlogged()) {
@@ -121,7 +121,7 @@ public class BasicBlockJS extends Block implements EntityBlockKJS, SimpleWaterlo
 	public BlockState getStateForPlacement(BlockPlaceContext context) {
 		if (blockBuilder.placementStateModification != null) {
 			var callbackJS = new BlockStateModifyPlacementCallbackJS(context, this);
-			if (safeCallback(blockBuilder.placementStateModification, callbackJS, "Error while modifying BlockState placement of " + blockBuilder.id)) {
+			if (safeCallback(blockBuilder.placementStateModification, callbackJS, "Error while modifying BlockState placement of ")) {
 				return callbackJS.getState();
 			}
 		}
@@ -162,7 +162,7 @@ public class BasicBlockJS extends Block implements EntityBlockKJS, SimpleWaterlo
 	public void randomTick(BlockState state, ServerLevel level, BlockPos pos, RandomSource random) {
 		if (blockBuilder.randomTickCallback != null) {
 			var callback = new RandomTickCallbackJS(new BlockContainerJS(level, pos), random);
-			safeCallback(blockBuilder.randomTickCallback, callback, "Error while random ticking custom block " + this);
+			safeCallback(blockBuilder.randomTickCallback, callback, "Error while random ticking custom block ");
 		}
 	}
 
@@ -194,7 +194,7 @@ public class BasicBlockJS extends Block implements EntityBlockKJS, SimpleWaterlo
 		try {
 			consumer.accept(value);
 		} catch (Throwable e) {
-			ScriptType.STARTUP.console.error(errorMessage, e);
+			ScriptType.STARTUP.console.error(errorMessage + blockBuilder.id, e);
 			return false;
 		}
 
@@ -241,7 +241,7 @@ public class BasicBlockJS extends Block implements EntityBlockKJS, SimpleWaterlo
 	public void stepOn(Level level, BlockPos blockPos, BlockState blockState, Entity entity) {
 		if (blockBuilder.stepOnCallback != null) {
 			var callbackJS = new EntityStepOnBlockCallbackJS(level, entity, blockPos, blockState);
-			safeCallback(blockBuilder.stepOnCallback, callbackJS, "Error while an entity stepped on custom block: " + this);
+			safeCallback(blockBuilder.stepOnCallback, callbackJS, "Error while an entity stepped on custom block ");
 		}
 	}
 
@@ -249,7 +249,7 @@ public class BasicBlockJS extends Block implements EntityBlockKJS, SimpleWaterlo
 	public void fallOn(Level level, BlockState blockState, BlockPos blockPos, Entity entity, float f) {
 		if (blockBuilder.fallOnCallback != null) {
 			var callbackJS = new EntityFallOnBlockCallbackJS(level, entity, blockPos, blockState, f);
-			safeCallback(blockBuilder.fallOnCallback, callbackJS,"Error while an entity fell on custom block: " + this);
+			safeCallback(blockBuilder.fallOnCallback, callbackJS,"Error while an entity fell on custom block ");
 		}
 	}
 
@@ -257,7 +257,7 @@ public class BasicBlockJS extends Block implements EntityBlockKJS, SimpleWaterlo
 	public void updateEntityAfterFallOn(BlockGetter blockGetter, Entity entity) {
 		if (blockBuilder.bounceCallback != null) {
 			var callbackJS = new EntityBounceCallbackJS(blockGetter, entity);
-			safeCallback(blockBuilder.bounceCallback, callbackJS, "Error while bouncing entity from custom block: " + this);
+			safeCallback(blockBuilder.bounceCallback, callbackJS, "Error while bouncing entity from custom block ");
 		}
 	}
 
@@ -265,7 +265,7 @@ public class BasicBlockJS extends Block implements EntityBlockKJS, SimpleWaterlo
 	public void wasExploded(Level level, BlockPos blockPos, Explosion explosion) {
 		if (blockBuilder.explodedCallback != null) {
 			var callbackJS = new BlockExplodedCallbackJS(level, blockPos, explosion);
-			safeCallback(blockBuilder.explodedCallback, callbackJS, "Error while exploding custom block: " + this);
+			safeCallback(blockBuilder.explodedCallback, callbackJS, "Error while exploding custom block ");
 		}
 	}
 }

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/custom/BasicBlockJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/custom/BasicBlockJS.java
@@ -163,6 +163,8 @@ public class BasicBlockJS extends Block implements EntityBlockKJS, SimpleWaterlo
 		if (blockBuilder.randomTickCallback != null) {
 			var callback = new RandomTickCallbackJS(new BlockContainerJS(level, pos), random);
 			safeCallback(blockBuilder.randomTickCallback, callback, "Error while random ticking custom block ");
+		} else {
+			super.randomTick(state, level, pos, random);
 		}
 	}
 
@@ -242,6 +244,8 @@ public class BasicBlockJS extends Block implements EntityBlockKJS, SimpleWaterlo
 		if (blockBuilder.stepOnCallback != null) {
 			var callbackJS = new EntityStepOnBlockCallbackJS(level, entity, blockPos, blockState);
 			safeCallback(blockBuilder.stepOnCallback, callbackJS, "Error while an entity stepped on custom block ");
+		} else {
+			super.stepOn(level, blockPos, blockState, entity);
 		}
 	}
 
@@ -250,6 +254,8 @@ public class BasicBlockJS extends Block implements EntityBlockKJS, SimpleWaterlo
 		if (blockBuilder.fallOnCallback != null) {
 			var callbackJS = new EntityFallOnBlockCallbackJS(level, entity, blockPos, blockState, f);
 			safeCallback(blockBuilder.fallOnCallback, callbackJS,"Error while an entity fell on custom block ");
+		} else {
+			super.fallOn(level, blockState, blockPos, entity, f);
 		}
 	}
 
@@ -266,6 +272,8 @@ public class BasicBlockJS extends Block implements EntityBlockKJS, SimpleWaterlo
 		if (blockBuilder.explodedCallback != null) {
 			var callbackJS = new BlockExplodedCallbackJS(level, blockPos, explosion);
 			safeCallback(blockBuilder.explodedCallback, callbackJS, "Error while exploding custom block ");
+		} else {
+			super.wasExploded(level, blockPos, explosion);
 		}
 	}
 }

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/custom/BasicBlockJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/custom/BasicBlockJS.java
@@ -1,12 +1,16 @@
 package dev.latvian.mods.kubejs.block.custom;
 
 import dev.latvian.mods.kubejs.block.BlockBuilder;
-import dev.latvian.mods.kubejs.block.BlockStateModifyCallbackJS;
-import dev.latvian.mods.kubejs.block.BlockStateModifyPlacementCallbackJS;
-import dev.latvian.mods.kubejs.block.CanBeReplacedCallbackJS;
 import dev.latvian.mods.kubejs.block.EntityBlockKJS;
 import dev.latvian.mods.kubejs.block.KubeJSBlockProperties;
 import dev.latvian.mods.kubejs.block.RandomTickCallbackJS;
+import dev.latvian.mods.kubejs.block.callbacks.BlockExplodedCallbackJS;
+import dev.latvian.mods.kubejs.block.callbacks.BlockStateModifyCallbackJS;
+import dev.latvian.mods.kubejs.block.callbacks.BlockStateModifyPlacementCallbackJS;
+import dev.latvian.mods.kubejs.block.callbacks.CanBeReplacedCallbackJS;
+import dev.latvian.mods.kubejs.block.callbacks.EntityBounceCallbackJS;
+import dev.latvian.mods.kubejs.block.callbacks.EntityFallOnBlockCallbackJS;
+import dev.latvian.mods.kubejs.block.callbacks.EntityStepOnBlockCallbackJS;
 import dev.latvian.mods.kubejs.level.BlockContainerJS;
 import dev.latvian.mods.kubejs.script.ScriptType;
 import net.minecraft.core.BlockPos;
@@ -235,33 +239,33 @@ public class BasicBlockJS extends Block implements EntityBlockKJS, SimpleWaterlo
 
 	@Override
 	public void stepOn(Level level, BlockPos blockPos, BlockState blockState, Entity entity) {
-		if (blockBuilder.canBeReplacedFunction != null) {
-			var callbackJS = new CanBeReplacedCallbackJS(context, blockState);
-			return blockBuilder.canBeReplacedFunction.apply(callbackJS);
+		if (blockBuilder.stepOnCallback != null) {
+			var callbackJS = new EntityStepOnBlockCallbackJS(level, entity, blockPos, blockState);
+			safeCallback(blockBuilder.stepOnCallback, callbackJS, "Error while an entity stepped on custom block: " + this);
 		}
 	}
 
 	@Override
 	public void fallOn(Level level, BlockState blockState, BlockPos blockPos, Entity entity, float f) {
-		if (blockBuilder.fallOnBeforeCallback != null) {
-			var callbackJS = new CanBeReplacedCallbackJS(context, blockState);
-			return blockBuilder.fallOnConsumer.apply(callbackJS);
+		if (blockBuilder.fallOnCallback != null) {
+			var callbackJS = new EntityFallOnBlockCallbackJS(level, entity, blockPos, blockState, f);
+			safeCallback(blockBuilder.fallOnCallback, callbackJS,"Error while an entity fell on custom block: " + this);
 		}
 	}
 
 	@Override
 	public void updateEntityAfterFallOn(BlockGetter blockGetter, Entity entity) {
-		if (blockBuilder.fallOnAfterCallback != null) {
-			var callbackJS = new CanBeReplacedCallbackJS(context, blockState);
-			return blockBuilder.canBeReplacedFunction.apply(callbackJS);
+		if (blockBuilder.bounceCallback != null) {
+			var callbackJS = new EntityBounceCallbackJS(blockGetter, entity);
+			safeCallback(blockBuilder.bounceCallback, callbackJS, "Error while bouncing entity from custom block: " + this);
 		}
 	}
 
 	@Override
 	public void wasExploded(Level level, BlockPos blockPos, Explosion explosion) {
 		if (blockBuilder.explodedCallback != null) {
-			var callbackJS = new CanBeReplacedCallbackJS(context, blockState);
-			return blockBuilder.canBeReplacedFunction.apply(callbackJS);
+			var callbackJS = new BlockExplodedCallbackJS(level, blockPos, explosion);
+			safeCallback(blockBuilder.explodedCallback, callbackJS, "Error while exploding custom block: " + this);
 		}
 	}
 }

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/custom/BasicBlockJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/custom/BasicBlockJS.java
@@ -15,9 +15,11 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.util.RandomSource;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.Explosion;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.Block;
@@ -229,5 +231,37 @@ public class BasicBlockJS extends Block implements EntityBlockKJS, SimpleWaterlo
 		}
 
 		return Optional.empty();
+	}
+
+	@Override
+	public void stepOn(Level level, BlockPos blockPos, BlockState blockState, Entity entity) {
+		if (blockBuilder.canBeReplacedFunction != null) {
+			var callbackJS = new CanBeReplacedCallbackJS(context, blockState);
+			return blockBuilder.canBeReplacedFunction.apply(callbackJS);
+		}
+	}
+
+	@Override
+	public void fallOn(Level level, BlockState blockState, BlockPos blockPos, Entity entity, float f) {
+		if (blockBuilder.fallOnBeforeCallback != null) {
+			var callbackJS = new CanBeReplacedCallbackJS(context, blockState);
+			return blockBuilder.fallOnConsumer.apply(callbackJS);
+		}
+	}
+
+	@Override
+	public void updateEntityAfterFallOn(BlockGetter blockGetter, Entity entity) {
+		if (blockBuilder.fallOnAfterCallback != null) {
+			var callbackJS = new CanBeReplacedCallbackJS(context, blockState);
+			return blockBuilder.canBeReplacedFunction.apply(callbackJS);
+		}
+	}
+
+	@Override
+	public void wasExploded(Level level, BlockPos blockPos, Explosion explosion) {
+		if (blockBuilder.explodedCallback != null) {
+			var callbackJS = new CanBeReplacedCallbackJS(context, blockState);
+			return blockBuilder.canBeReplacedFunction.apply(callbackJS);
+		}
 	}
 }


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->
### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->
I looked through the remaining overrides for BasicBlockJS and these are the ones that were left and made sense to me.

Also includes some slightly related changes, like a default value override for requiresTool() and making safeCallback not concat the string till the error is actually thrown (this was done because bounce is relatively hot code and i felt like mirco-optimising. and it does save a whole registry lookup)

#### Example Script <!-- Please provide an example script showing that the bug is fixed, or how the feature is used, if applicable -->
```js
StartupEvents.registry('block', event => {
    event.create('double_slime')
        .bounciness(2)
        .exploded(ctx => {
            ctx.block.set('slime_block')
        })
        .stepOn(ctx => {
            if (ctx.entity.player)
                ctx.entity.playSound("block.slime_block.step", 0.8, 2.0)
        })

    event.create('flinger')
        .bounce(ctx => {
            ctx.bounce(2 * JavaMath.random())
        })
        .fallOn(ctx => {
            if (ctx.suppressingBounce) ctx.applyFallDamage()
        })

    event.create('slime_block') // bouncier slime
        .model('block/slime_block').defaultTranslucent().material("slime")
        .bounce(ctx => ctx.bounce(3))


    event.create('minecraft:coal_block') //registry replace coal so it can compact into diamonds
        .hardness(5).resistance(6).material("stone").requiresTool()
        .fallOn(ctx => {
            if (ctx.fallHeight > 20) {
                ctx.block.set('diamond_block')
            } else if (!ctx.level.clientSide) {
                ctx.entity.tell("There wasn't enough force! Try falling from higher")
                ctx.noBounce()
            }
        })
})
```

#### Other details <!-- Any other important information, like if this is likely to break addons -->
As part of this I moved the block callbacks to their own package (it was getting crowded in the block package), so any addons using those classes will break. I have not checked if there are any.