### PR TITLE
Fix reloading startup scripts not working due to no mod loading context

### DIFF
--- a/forge/src/main/java/dev/latvian/mods/kubejs/forge/BuiltinKubeJSForgePlugin.java
+++ b/forge/src/main/java/dev/latvian/mods/kubejs/forge/BuiltinKubeJSForgePlugin.java
@@ -43,7 +43,7 @@ public class BuiltinKubeJSForgePlugin extends BuiltinKubeJSPlugin {
 
 		if (event.getType().isStartup()) {
 			event.add("ForgeEvents", new ForgeEventWrapper("ForgeEvents", MinecraftForge.EVENT_BUS));
-			event.add("ForgeModEvents", new ForgeEventWrapper("ForgeModEvents", FMLJavaModLoadingContext.get().getModEventBus()));
+			event.add("ForgeModEvents", new ForgeEventWrapper("ForgeModEvents", FMLJavaModLoadingContext.get() == null ? null : FMLJavaModLoadingContext.get().getModEventBus()));
 			event.add("onForgeEvent", new LegacyCodeHandler("onForgeEvent()"));
 		}
 	}


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->
### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->
There was a sneaky bug introduced in 56751b429ee50ab05cf6a308f4646a67f5c3e1bb where reloading startup scripts doesnt work on forge because the modloading context is null, so registering bindings fails.

This fixes that by passing `null` for the bus if modloading context is null. This doesn't cause any problems at the moment as it is only null if it is not the first load, and nothing is called on the event bus object unless it is the first load.


Reported in Discord: [`/kubejs reload startup_scripts` command has an "unexpected error"](https://discord.com/channels/303440391124942858/1134679313610965142/1134679313610965142)