### PR TITLE
Fix items not in a creative tab not being included in certain checks

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/bindings/ItemWrapper.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/bindings/ItemWrapper.java
@@ -3,6 +3,7 @@ package dev.latvian.mods.kubejs.bindings;
 import dev.latvian.mods.kubejs.item.ItemStackJS;
 import dev.latvian.mods.kubejs.level.FireworksJS;
 import dev.latvian.mods.kubejs.registry.KubeJSRegistries;
+import net.minecraft.core.NonNullList;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
@@ -46,6 +47,14 @@ public interface ItemWrapper {
 
 	static List<String> getTypeList() {
 		return ItemStackJS.getTypeList();
+	}
+
+	static Map<ResourceLocation, NonNullList<ItemStack>> getTypeToStackMap() {
+		return ItemStackJS.getTypeToStacks();
+	}
+
+	static List<ItemStack> getVariants(ItemStack item) {
+		return getTypeToStackMap().get(item.kjs$getIdLocation());
 	}
 
 	static ItemStack getEmpty() {


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->
### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->
Fixes https://github.com/KubeJS-Mods/KubeJS/issues/677 and https://github.com/KubeJS-Mods/KubeJS/issues/550. Also fixes `Item#getAll` not returning any items not in creative tabs.


#### Example Script <!-- Please provide an example script showing that the bug is fixed, or how the feature is used, if applicable -->
```js
REIEvents.hide('item', event => {
    event.hide('barrier')
    event.hide('stick')
    event.hide('potion')
})
```

#### Other details <!-- Any other important information, like if this is likely to break addons -->
Also adds `ItemWrapper#getTypeToStackMap` and `ItemWrapper#getVariants` for using the map I used to implement this to get all 'variants' of an item (ie all potions).