### PR TITLE
Fix GameStages events not working due to not supporting extra ids

### DIFF
--- a/forge/src/main/java/dev/latvian/mods/kubejs/integration/forge/gamestages/GameStagesIntegration.java
+++ b/forge/src/main/java/dev/latvian/mods/kubejs/integration/forge/gamestages/GameStagesIntegration.java
@@ -3,6 +3,7 @@ package dev.latvian.mods.kubejs.integration.forge.gamestages;
 import dev.latvian.mods.kubejs.KubeJSPlugin;
 import dev.latvian.mods.kubejs.event.EventGroup;
 import dev.latvian.mods.kubejs.event.EventHandler;
+import dev.latvian.mods.kubejs.event.Extra;
 import dev.latvian.mods.kubejs.stages.StageCreationEvent;
 import dev.latvian.mods.kubejs.stages.Stages;
 import net.darkhax.gamestages.event.GameStageEvent;
@@ -12,8 +13,8 @@ public class GameStagesIntegration extends KubeJSPlugin {
 
 	public static final EventGroup GROUP = EventGroup.of("GameStageEvents");
 
-	public static final EventHandler STAGE_ADDED = GROUP.common("stageAdded", () -> GameStageEventJS.class);
-	public static final EventHandler STAGE_REMOVED = GROUP.common("stageRemoved", () -> GameStageEventJS.class);
+	public static final EventHandler STAGE_ADDED = GROUP.common("stageAdded", () -> GameStageEventJS.class).extra(Extra.STRING);
+	public static final EventHandler STAGE_REMOVED = GROUP.common("stageRemoved", () -> GameStageEventJS.class).extra(Extra.STRING);
 
 	@Override
 	public void init() {


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->
### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->
Fixes the error of `Event handlers 'GameStageEvents.stageAdded' doesn't support extra id create!`
Report in Discord by @generikb https://discord.com/channels/303440391124942858/1146302676926210058

#### Other details <!-- Any other important information, like if this is likely to break addons -->
This is why we test!