### PR TITLE
Finally remove fullNBT methods.

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/core/EntityKJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/core/EntityKJS.java
@@ -5,10 +5,8 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import dev.latvian.mods.kubejs.entity.RayTraceResultJS;
 import dev.latvian.mods.kubejs.level.BlockContainerJS;
 import dev.latvian.mods.kubejs.player.EntityArrayList;
-import dev.latvian.mods.kubejs.script.ScriptManager;
 import dev.latvian.mods.kubejs.script.ScriptType;
 import dev.latvian.mods.kubejs.script.ScriptTypeHolder;
-import dev.latvian.mods.kubejs.util.ConsoleJS;
 import dev.latvian.mods.rhino.util.HideFromJS;
 import dev.latvian.mods.rhino.util.RemapPrefixForJS;
 import net.minecraft.core.BlockPos;
@@ -242,24 +240,6 @@ public interface EntityKJS extends WithPersistentData, MessageSenderKJS, ScriptT
 
 	default BlockContainerJS kjs$getBlock() {
 		return new BlockContainerJS(kjs$getLevel(), kjs$self().blockPosition());
-	}
-
-	@Deprecated
-	default CompoundTag kjs$getFullNBT() {
-		ConsoleJS.getCurrent(ScriptManager.getCurrentContext()).error("getFullNBT() and fullNBT are deprecated. Use getNbt() or nbt instead!");
-		return kjs$getNbt();
-	}
-
-	@Deprecated
-	default void kjs$setFullNBT(@Nullable CompoundTag nbt) {
-		ConsoleJS.getCurrent(ScriptManager.getCurrentContext()).error("setFullNBT() and fullNBT are deprecated. Use setNbt(CompoundTag) or nbt instead!");
-		kjs$setNbt(nbt);
-	}
-
-	@Deprecated
-	default Entity kjs$mergeFullNBT(@Nullable CompoundTag tag) {
-		ConsoleJS.getCurrent(ScriptManager.getCurrentContext()).error("mergeFullNBT() is deprecated. Use mergeNbt instead!");
-		return kjs$mergeNbt(tag);
 	}
 
 	default CompoundTag kjs$getNbt() {


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->
### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->
Follow up of https://github.com/KubeJS-Mods/KubeJS/pull/608

#### Other details <!-- Any other important information, like if this is likely to break addons -->
Due to the error that these methods have been throwing for months and the new MC version, no one should still be using this so they are safe to remove.