### PR TITLE
Fix serverOnly mode not working due to registering the new menu type

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/client/KubeJSClient.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/client/KubeJSClient.java
@@ -3,6 +3,7 @@ package dev.latvian.mods.kubejs.client;
 import dev.architectury.hooks.PackRepositoryHooks;
 import dev.architectury.platform.Platform;
 import dev.architectury.registry.menu.MenuRegistry;
+import dev.latvian.mods.kubejs.CommonProperties;
 import dev.latvian.mods.kubejs.KubeJS;
 import dev.latvian.mods.kubejs.KubeJSCommon;
 import dev.latvian.mods.kubejs.KubeJSPaths;
@@ -118,7 +119,8 @@ public class KubeJSClient extends KubeJSCommon {
 			return null;
 		});
 
-		MenuRegistry.registerScreenFactory(KubeJSMenu.KUBEJS_MENU.get(), KubeJSScreen::new);
+		if (!CommonProperties.get().serverOnly)
+			MenuRegistry.registerScreenFactory(KubeJSMenu.KUBEJS_MENU.get(), KubeJSScreen::new);
 	}
 
 	@Override

--- a/common/src/main/java/dev/latvian/mods/kubejs/gui/KubeJSMenu.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/gui/KubeJSMenu.java
@@ -16,7 +16,7 @@ import java.util.function.Supplier;
 
 public class KubeJSMenu extends AbstractContainerMenu {
 	public static final DeferredRegister<MenuType<?>> MENU_TYPES = DeferredRegister.create("kubejs", Registries.MENU);
-	public static Supplier<MenuType<KubeJSMenu>> KUBEJS_MENU = MENU_TYPES.register("menu", () -> MiscPlatformHelper.get().createMenuType());
+	public static final Supplier<MenuType<KubeJSMenu>> KUBEJS_MENU = MENU_TYPES.register("menu", () -> MiscPlatformHelper.get().createMenuType());
 
 	public static void init() {
 		if (!CommonProperties.get().serverOnly) {

--- a/common/src/main/java/dev/latvian/mods/kubejs/gui/KubeJSMenu.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/gui/KubeJSMenu.java
@@ -1,6 +1,7 @@
 package dev.latvian.mods.kubejs.gui;
 
 import dev.architectury.registry.registries.DeferredRegister;
+import dev.latvian.mods.kubejs.CommonProperties;
 import dev.latvian.mods.kubejs.platform.MiscPlatformHelper;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.network.FriendlyByteBuf;
@@ -15,10 +16,12 @@ import java.util.function.Supplier;
 
 public class KubeJSMenu extends AbstractContainerMenu {
 	public static final DeferredRegister<MenuType<?>> MENU_TYPES = DeferredRegister.create("kubejs", Registries.MENU);
-	public static final Supplier<MenuType<KubeJSMenu>> KUBEJS_MENU = MENU_TYPES.register("menu", () -> MiscPlatformHelper.get().createMenuType());
+	public static Supplier<MenuType<KubeJSMenu>> KUBEJS_MENU = MENU_TYPES.register("menu", () -> MiscPlatformHelper.get().createMenuType());
 
 	public static void init() {
-		MENU_TYPES.register();
+		if (!CommonProperties.get().serverOnly) {
+			MENU_TYPES.register();
+		}
 	}
 
 	public final Player player;


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->
### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->
Fixes [KubeJS 2001.6.3-build50 | serverOnly=true | Still requires me to have kubejs on client (BC1A0B2D)](https://kubejs.com/support/tickets/BC1A0B2D), caused by KubeJS' menutype always registering, even if serverOnly is enabled.

#### Other details <!-- Any other important information, like if this is likely to break addons -->