### PR TITLE
Fix script files without a packmode not loading when packmode is not default

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/script/ScriptFileInfo.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/script/ScriptFileInfo.java
@@ -70,7 +70,7 @@ public class ScriptFileInfo {
 
 			priority = Integer.parseInt(getProperty("priority", "0"));
 			ignored = getProperty("ignored", "false").equals("true") || getProperty("ignore", "false").equals("true");
-			packMode = getProperty("packmode", "default");
+			packMode = getProperty("packmode", "");
 			requiredMods.addAll(getProperties("requires"));
 			return null;
 		} catch (Throwable ex) {


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->
### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->
By default the system treated script files without a `//packmode:` header to have a packmode of `default`, so when the packmode changed to something other than `default` those scripts didnt load.
This fixes that by defaulting to an empty string, which is already checked for later on and ignored for packmode checks (so it will load no matter the packmode).


#### Example Script <!-- Please provide an example script showing that the bug is fixed, or how the feature is used, if applicable -->
```js
console.log('hello. i will be printed with this pr applied and packmode set to something otehr than default.')
```

#### Other details <!-- Any other important information, like if this is likely to break addons -->
The only pack I know of using a packmode system is Enigmatica, and they *made their own*, likely because this didn't work. They can now use this system (cc @MuteTiefling).