### PR TITLE
Fix items with subtypes being put into all tabs

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/item/custom/BasicItemJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/item/custom/BasicItemJS.java
@@ -40,7 +40,7 @@ public class BasicItemJS extends Item {
 
 	@Override
 	public void fillItemCategory(CreativeModeTab category, NonNullList<ItemStack> stacks) {
-		if (kjs$getItemBuilder().subtypes != null) {
+		if (kjs$getItemBuilder().subtypes != null && category.equals(kjs$getItemBuilder().group)) {
 			stacks.addAll(kjs$getItemBuilder().subtypes.apply(new ItemStack(this)));
 		} else {
 			super.fillItemCategory(category, stacks);


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->
### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->
Figured out here: https://discord.com/channels/303440391124942858/1165201311457890364
Subtypes fill item category method doesn't filter the tabs, so ends up adding it to all tabs...

#### Other details <!-- Any other important information, like if this is likely to break addons -->
Seems like this has been a bug for a while, but gone unreported cause no one uses subtypes. This cannot be ported to 1.20 due to 1.19.3+ changing creative tabs majorly.