### PR TITLE
Added Entity to RayTrace Result

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/core/EntityKJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/core/EntityKJS.java
@@ -304,7 +304,13 @@ public interface EntityKJS extends WithPersistentData, MessageSenderKJS, ScriptT
 	}
 
 	default RayTraceResultJS kjs$rayTrace(double distance, boolean fluids) {
-		return new RayTraceResultJS(kjs$self(), kjs$self().pick(distance, 0F, fluids), distance);
+		var blockResult = kjs$self().pick(distance, 0.0F, fluids);
+		var traceResult = new RayTraceResultJS(kjs$self(), blockResult, distance);
+		var entityResult = ProjectileUtil.getHitResultOnViewVector(kjs$self(), entity -> !entity.isSpectator() && entity.isPickable(), distance);
+		if (entityResult.getType() == HitResult.Type.ENTITY) {
+			traceResult = new RayTraceResultJS(kjs$self(), entityResult, distance);
+		}
+		return traceResult;
 	}
 
 	default RayTraceResultJS kjs$rayTrace(double distance) {

--- a/common/src/main/java/dev/latvian/mods/kubejs/core/EntityKJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/core/EntityKJS.java
@@ -25,8 +25,10 @@ import net.minecraft.sounds.SoundEvent;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.MobCategory;
 import net.minecraft.world.entity.decoration.ItemFrame;
+import net.minecraft.world.entity.projectile.ProjectileUtil;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.scores.Team;
 import org.jetbrains.annotations.Nullable;
 


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->
### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->

`kjs$self().pick` returns HitResult, which calls `level().clip` that returns BlockHitResult, so it was never possible to get an Entity.

#### Example Script <!-- Please provide an example script showing that the bug is fixed, or how the feature is used, if applicable -->
```js
ItemEvents.firstLeftClicked(event => {
  Platform.breakpoint(Object.entries(event.target))
})
```
just punch a Cow
#### Other details <!-- Any other important information, like if this is likely to break addons -->