### PR TITLE
Added entity to raytrace for 1.20

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/core/EntityKJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/core/EntityKJS.java
@@ -25,8 +25,10 @@ import net.minecraft.sounds.SoundEvent;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.MobCategory;
 import net.minecraft.world.entity.decoration.ItemFrame;
+import net.minecraft.world.entity.projectile.ProjectileUtil;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.scores.Team;
 import org.jetbrains.annotations.Nullable;
 
@@ -304,7 +306,21 @@ public interface EntityKJS extends WithPersistentData, MessageSenderKJS, ScriptT
 	}
 
 	default RayTraceResultJS kjs$rayTrace(double distance, boolean fluids) {
-		return new RayTraceResultJS(kjs$self(), kjs$self().pick(distance, 0F, fluids), distance);
+		var entity = kjs$self();
+		var hitResult = entity.pick(distance, 0F, fluids);
+		var eyePosition = entity.getEyePosition();
+		var lookVector = entity.getViewVector(1.0f);
+		var traceEnd = eyePosition.add(lookVector.x * distance, lookVector.y * distance, lookVector.z * distance);
+		var bound = entity.getBoundingBox().expandTowards(lookVector.scale(distance)).inflate(1.0, 1.0, 1.0);
+		var distanceSquared = hitResult.getType() != HitResult.Type.MISS ? hitResult.getLocation().distanceToSqr(eyePosition) : distance * distance;
+		var entityHitResult = ProjectileUtil.getEntityHitResult(entity, eyePosition, traceEnd, bound, ent -> !ent.isSpectator() && ent.isPickable(), distanceSquared);
+		if (entityHitResult != null) {
+			var entityDistanceSquared = eyePosition.distanceToSqr(entityHitResult.getLocation());
+			if (entityDistanceSquared < distanceSquared || hitResult.getType() == HitResult.Type.MISS) {
+				hitResult = entityHitResult;
+			}
+		}
+		return new RayTraceResultJS(entity, hitResult, distance);
 	}
 
 	default RayTraceResultJS kjs$rayTrace(double distance) {

--- a/fabric/src/main/java/dev/latvian/mods/kubejs/platform/fabric/LevelFabricHelper.java
+++ b/fabric/src/main/java/dev/latvian/mods/kubejs/platform/fabric/LevelFabricHelper.java
@@ -7,6 +7,7 @@ import dev.latvian.mods.kubejs.platform.LevelPlatformHelper;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
@@ -26,6 +27,9 @@ public class LevelFabricHelper implements LevelPlatformHelper {
 
 	@Override
 	public double getReachDistance(LivingEntity livingEntity) {
+		if (livingEntity instanceof Player player){
+			if (!player.isCreative()) return 4.5;
+		}
 		return 5;
 	}
 


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->
### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->

Same as 
- #737 

Turns out the BrushItem implementation had a very bad accuracy for entities, so I went for the GameRenderer implementation.