### PR TITLE
Fixed issue where fluid render types only applied to source block.

### DIFF
--- a/fabric/src/main/java/dev/latvian/mods/kubejs/fabric/KubeJSFabricClient.java
+++ b/fabric/src/main/java/dev/latvian/mods/kubejs/fabric/KubeJSFabricClient.java
@@ -30,9 +30,9 @@ public class KubeJSFabricClient {
 		for (var builder : RegistryInfo.FLUID) {
 			if (builder instanceof FluidBuilder b) {
 				switch (b.renderType) {
-					case "cutout" -> BlockRenderLayerMap.INSTANCE.putFluids(RenderType.cutout(), b.get());
-					case "cutout_mipped" -> BlockRenderLayerMap.INSTANCE.putFluids(RenderType.cutoutMipped(), b.get());
-					case "translucent" -> BlockRenderLayerMap.INSTANCE.putFluids(RenderType.translucent(), b.get());
+					case "cutout" -> BlockRenderLayerMap.INSTANCE.putFluids(RenderType.cutout(), b.get().getSource(), b.get().getFlowing());
+					case "cutout_mipped" -> BlockRenderLayerMap.INSTANCE.putFluids(RenderType.cutoutMipped(), b.get().getSource(), b.get().getFlowing());
+					case "translucent" -> BlockRenderLayerMap.INSTANCE.putFluids(RenderType.translucent(), b.get().getSource(), b.get().getFlowing());
 				}
 			}
 		}

--- a/forge/src/main/java/dev/latvian/mods/kubejs/forge/KubeJSForgeClient.java
+++ b/forge/src/main/java/dev/latvian/mods/kubejs/forge/KubeJSForgeClient.java
@@ -40,9 +40,18 @@ public class KubeJSForgeClient {
 		for (var builder : RegistryInfo.FLUID) {
 			if (builder instanceof FluidBuilder b) {
 				switch (b.renderType) {
-					case "cutout" -> ItemBlockRenderTypes.setRenderLayer(b.get(), RenderType.cutout());
-					case "cutout_mipped" -> ItemBlockRenderTypes.setRenderLayer(b.get(), RenderType.cutoutMipped());
-					case "translucent" -> ItemBlockRenderTypes.setRenderLayer(b.get(), RenderType.translucent());
+					case "cutout" -> {
+						ItemBlockRenderTypes.setRenderLayer(b.get().getSource(), RenderType.cutout());
+						ItemBlockRenderTypes.setRenderLayer(b.get().getFlowing(), RenderType.cutout());
+					}
+					case "cutout_mipped" -> {
+						ItemBlockRenderTypes.setRenderLayer(b.get().getSource(), RenderType.cutoutMipped());
+						ItemBlockRenderTypes.setRenderLayer(b.get().getFlowing(), RenderType.cutoutMipped());
+					}
+					case "translucent" -> {
+						ItemBlockRenderTypes.setRenderLayer(b.get().getSource(), RenderType.translucent());
+						ItemBlockRenderTypes.setRenderLayer(b.get().getFlowing(), RenderType.translucent());
+					}
 				}
 			}
 		}


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->
### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->
This fixes an issue where setting `translucent()` on any fluid only changed the render type on the source block. There are bound to be some issue with this implementation, and it does have a limitation of being unable to mix and match RenderTypes in the same fluid.


#### Example Script <!-- Please provide an example script showing that the bug is fixed, or how the feature is used, if applicable -->
```js
StartupEvents.registry("fluid", event => {
    event.create("translucent_fluid")
        .stillTexture("kubejs:block/translucent_fluid_still")
        .flowingTexture("kubejs:block/translucent_fluid_flow")
        .bucketColor(0xFFFFFF)
        .translucent()
        .displayName("Translucent Fluid");
});
```

#### Other details <!-- Any other important information, like if this is likely to break addons -->