### PR TITLE
Fix a NPE issue with ConsoleJS

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/util/ConsoleJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/util/ConsoleJS.java
@@ -33,7 +33,7 @@ public class ConsoleJS {
 	public static ConsoleJS getCurrent(ConsoleJS def) {
 		Context cx = Context.getCurrentContext();
 
-		if (cx != null && cx.sharedContextData.getExtraProperty("Console") instanceof ConsoleJS c) {
+		if (cx != null && cx.sharedContextData != null && cx.sharedContextData.getExtraProperty("Console") instanceof ConsoleJS c) {
 			return c;
 		}
 


### PR DESCRIPTION
On rare occasions, SharedContextData is gone from Rhino Context objects, this check should resolve any NPE issues that occur as a result.

<!-- These comments won't appear in the final PR, so you can just leave them here -->
### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->
On some occasions when requesting the line number of where a script was called from the Java side, it would trigger this method to throw an NPE. As such I added a quick check to ensure that the shared context data is present before it is used to grab the console object.

#### Other details <!-- Any other important information, like if this is likely to break addons -->
I found this issue while creating an addon that does debug logging.