### PR TITLE
add a test for TagKey in IngredientJS

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/item/ingredient/IngredientJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/item/ingredient/IngredientJS.java
@@ -14,8 +14,12 @@ import dev.latvian.mods.kubejs.util.UtilsJS;
 import dev.latvian.mods.rhino.Wrapper;
 import dev.latvian.mods.rhino.mod.util.NBTUtils;
 import dev.latvian.mods.rhino.regexp.NativeRegExp;
+import net.minecraft.core.Registry;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.Ingredient;
@@ -35,6 +39,8 @@ public interface IngredientJS {
 			return Ingredient.EMPTY;
 		} else if (o instanceof IngredientSupplierKJS ingr) {
 			return ingr.kjs$asIngredient();
+		} else if (o instanceof TagKey<?> tag) {
+			return Ingredient.of(TagKey.create(Registries.ITEM, tag.location()));
 		} else if (o instanceof Pattern || o instanceof NativeRegExp) {
 			var reg = UtilsJS.parseRegex(o);
 


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->
### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->
currently, IngredientJS didn't test for raw `TagKey`s being passed into it. this fixes that.


#### Example Script <!-- Please provide an example script showing that the bug is fixed, or how the feature is used, if applicable -->
```js
const $TagKey = Java.loadClass('net.minecraft.tags.TagKey')
const $Registries = Java.loadClass('net.minecraft.core.registries.Registries')

ServerEvents.recipes(event => {
    event.shaped('minecraft:dirt', ["AAA", "AAA", "AAA"], { A: $TagKey.create($Registries.ITEM, new ResourceLocation("c:glass_blocks"))})
})
```

#### Other details <!-- Any other important information, like if this is likely to break addons -->
none