### PR TITLE
Fix the regex ingredient being incredibly borked

### DIFF
--- a/forge/src/main/java/dev/latvian/mods/kubejs/platform/forge/ingredient/RegExIngredient.java
+++ b/forge/src/main/java/dev/latvian/mods/kubejs/platform/forge/ingredient/RegExIngredient.java
@@ -16,6 +16,7 @@ public class RegExIngredient extends KubeJSIngredient {
 	public final Pattern pattern;
 
 	public RegExIngredient(Pattern pattern) {
+		if (pattern == null) throw new IllegalArgumentException("Pattern for a RegExIngredient cannot be null! Check your pattern format");
 		this.pattern = pattern;
 	}
 
@@ -39,7 +40,7 @@ public class RegExIngredient extends KubeJSIngredient {
 
 	@Override
 	public void toJson(JsonObject json) {
-		json.addProperty("regex", pattern.toString());
+		json.addProperty("pattern", UtilsJS.toRegexString(pattern));
 	}
 
 	@Override


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->
### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->
It will now actually serialize and deserialize using the same key, and it will actually serialize the full pattern and flags, instead of just the pattern (which before this couldn't be understood by the method used to parse it so would always be null).

I have no idea how no one has noticed this being broken yet.


#### Example Script <!-- Please provide an example script showing that the bug is fixed, or how the feature is used, if applicable -->
```js
ServerEvents.recipes(event => {
	event.shapeless('apple', [/oak/])
})
```