### PR TITLE
Helpful RecipeComponent extras

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/BuiltinKubeJSPlugin.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/BuiltinKubeJSPlugin.java
@@ -592,6 +592,9 @@ public class BuiltinKubeJSPlugin extends KubeJSPlugin {
 		event.register("inputBlockState", BlockStateComponent.INPUT);
 		event.register("outputBlockState", BlockStateComponent.OUTPUT);
 		event.register("otherBlockState", BlockStateComponent.BLOCK);
+		event.register("inputBlockStateString", BlockStateComponent.INPUT_STRING);
+		event.register("outputBlockStateString", BlockStateComponent.OUTPUT_STRING);
+		event.register("otherBlockStateString", BlockStateComponent.BLOCK_STRING);
 
 		event.register("ticks", TimeComponent.TICKS);
 		event.register("seconds", TimeComponent.SECONDS);
@@ -600,6 +603,7 @@ public class BuiltinKubeJSPlugin extends KubeJSPlugin {
 
 		event.register("blockTag", TagKeyComponent.BLOCK);
 		event.register("itemTag", TagKeyComponent.ITEM);
+		event.register("fluidTag", TagKeyComponent.FLUID);
 		event.register("entityTypeTag", TagKeyComponent.ENTITY_TYPE);
 		event.register("biomeTag", TagKeyComponent.BIOME);
 		event.registerDynamic("tag", TagKeyComponent.DYNAMIC);

--- a/common/src/main/java/dev/latvian/mods/kubejs/BuiltinKubeJSPlugin.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/BuiltinKubeJSPlugin.java
@@ -86,9 +86,11 @@ import dev.latvian.mods.kubejs.recipe.ReplacementMatch;
 import dev.latvian.mods.kubejs.recipe.component.BlockComponent;
 import dev.latvian.mods.kubejs.recipe.component.BlockStateComponent;
 import dev.latvian.mods.kubejs.recipe.component.BooleanComponent;
+import dev.latvian.mods.kubejs.recipe.component.EnumComponent;
 import dev.latvian.mods.kubejs.recipe.component.FluidComponents;
 import dev.latvian.mods.kubejs.recipe.component.ItemComponents;
 import dev.latvian.mods.kubejs.recipe.component.NumberComponent;
+import dev.latvian.mods.kubejs.recipe.component.RegistryComponent;
 import dev.latvian.mods.kubejs.recipe.component.StringComponent;
 import dev.latvian.mods.kubejs.recipe.component.TagKeyComponent;
 import dev.latvian.mods.kubejs.recipe.component.TimeComponent;
@@ -601,6 +603,9 @@ public class BuiltinKubeJSPlugin extends KubeJSPlugin {
 		event.register("entityTypeTag", TagKeyComponent.ENTITY_TYPE);
 		event.register("biomeTag", TagKeyComponent.BIOME);
 		event.registerDynamic("tag", TagKeyComponent.DYNAMIC);
+
+		event.registerDynamic("registryObject", RegistryComponent.DYNAMIC);
+		event.registerDynamic("enum", EnumComponent.DYNAMIC);
 	}
 
 	@Override

--- a/common/src/main/java/dev/latvian/mods/kubejs/recipe/component/BlockStateComponent.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/recipe/component/BlockStateComponent.java
@@ -1,5 +1,6 @@
 package dev.latvian.mods.kubejs.recipe.component;
 
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import com.mojang.serialization.JsonOps;
@@ -8,16 +9,25 @@ import dev.latvian.mods.kubejs.recipe.RecipeExceptionJS;
 import dev.latvian.mods.kubejs.recipe.RecipeJS;
 import dev.latvian.mods.kubejs.recipe.RecipeKey;
 import dev.latvian.mods.kubejs.recipe.ReplacementMatch;
+import dev.latvian.mods.kubejs.util.MapJS;
 import dev.latvian.mods.kubejs.util.UtilsJS;
 import net.minecraft.commands.arguments.blocks.BlockStateParser;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 
-public record BlockStateComponent(ComponentRole crole) implements RecipeComponent<BlockState> {
-	public static final RecipeComponent<BlockState> 	INPUT = new BlockStateComponent(ComponentRole.INPUT);
-	public static final RecipeComponent<BlockState> OUTPUT = new BlockStateComponent(ComponentRole.OUTPUT);
-	public static final RecipeComponent<BlockState> BLOCK = new BlockStateComponent(ComponentRole.OTHER);
+import java.util.Map;
+
+import static dev.latvian.mods.kubejs.util.JsonIO.GSON;
+
+public record BlockStateComponent(ComponentRole crole, boolean preferObjectForm) implements RecipeComponent<BlockState> {
+	public static final RecipeComponent<BlockState> INPUT = new BlockStateComponent(ComponentRole.INPUT, true);
+	public static final RecipeComponent<BlockState> OUTPUT = new BlockStateComponent(ComponentRole.OUTPUT, true);
+	public static final RecipeComponent<BlockState> BLOCK = new BlockStateComponent(ComponentRole.OTHER, true);
+	public static final RecipeComponent<BlockState> INPUT_STRING = new BlockStateComponent(ComponentRole.INPUT, false);
+	public static final RecipeComponent<BlockState> OUTPUT_STRING = new BlockStateComponent(ComponentRole.OUTPUT, false);
+	public static final RecipeComponent<BlockState> BLOCK_STRING = new BlockStateComponent(ComponentRole.OTHER, false);
+
 
 	@Override
 	public ComponentRole role() {
@@ -35,8 +45,13 @@ public record BlockStateComponent(ComponentRole crole) implements RecipeComponen
 	}
 
 	@Override
-	public JsonPrimitive write(RecipeJS recipe, BlockState value) {
-		return new JsonPrimitive(BlockStateParser.serialize(value));
+	public JsonElement write(RecipeJS recipe, BlockState value) {
+		if (preferObjectForm) {
+			return BlockState.CODEC.encode(value, JsonOps.INSTANCE, new JsonObject()).getOrThrow(true, message -> {throw new RecipeExceptionJS("Failed to write blockstate to object form: " + message);});
+		} else {
+			return new JsonPrimitive(BlockStateParser.serialize(value));
+		}
+
 	}
 
 	@Override
@@ -47,10 +62,14 @@ public record BlockStateComponent(ComponentRole crole) implements RecipeComponen
 			return b.defaultBlockState();
 		} else if (from instanceof JsonPrimitive json) {
 			return UtilsJS.parseBlockState(json.getAsString());
-		} else if (from instanceof JsonObject json) {
-			return BlockState.CODEC.parse(JsonOps.INSTANCE, json).getOrThrow(true, message -> {throw new RecipeExceptionJS("Failed to parse blockstate: " + message);});
 		} else {
-			return UtilsJS.parseBlockState(String.valueOf(from));
+			Map<?,?> map = MapJS.of(from);
+			if (map == null)
+				return UtilsJS.parseBlockState(String.valueOf(from));
+			else
+				// this is formatted like so:
+				// { Name: "blockid", Properties: {Property: "value"}}
+				return BlockState.CODEC.parse(JsonOps.INSTANCE, GSON.toJsonTree(from)).getOrThrow(true, message -> {throw new RecipeExceptionJS("Failed to parse blockstate: " + message);});
 		}
 	}
 

--- a/common/src/main/java/dev/latvian/mods/kubejs/recipe/component/BlockStateComponent.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/recipe/component/BlockStateComponent.java
@@ -1,7 +1,10 @@
 package dev.latvian.mods.kubejs.recipe.component;
 
+import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
+import com.mojang.serialization.JsonOps;
 import dev.latvian.mods.kubejs.block.state.BlockStatePredicate;
+import dev.latvian.mods.kubejs.recipe.RecipeExceptionJS;
 import dev.latvian.mods.kubejs.recipe.RecipeJS;
 import dev.latvian.mods.kubejs.recipe.RecipeKey;
 import dev.latvian.mods.kubejs.recipe.ReplacementMatch;
@@ -12,7 +15,7 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 
 public record BlockStateComponent(ComponentRole crole) implements RecipeComponent<BlockState> {
-	public static final RecipeComponent<BlockState> INPUT = new BlockStateComponent(ComponentRole.INPUT);
+	public static final RecipeComponent<BlockState> 	INPUT = new BlockStateComponent(ComponentRole.INPUT);
 	public static final RecipeComponent<BlockState> OUTPUT = new BlockStateComponent(ComponentRole.OUTPUT);
 	public static final RecipeComponent<BlockState> BLOCK = new BlockStateComponent(ComponentRole.OTHER);
 
@@ -44,6 +47,8 @@ public record BlockStateComponent(ComponentRole crole) implements RecipeComponen
 			return b.defaultBlockState();
 		} else if (from instanceof JsonPrimitive json) {
 			return UtilsJS.parseBlockState(json.getAsString());
+		} else if (from instanceof JsonObject json) {
+			return BlockState.CODEC.parse(JsonOps.INSTANCE, json).getOrThrow(true, message -> {throw new RecipeExceptionJS("Failed to parse blockstate: " + message);});
 		} else {
 			return UtilsJS.parseBlockState(String.valueOf(from));
 		}

--- a/common/src/main/java/dev/latvian/mods/kubejs/recipe/component/EnumComponent.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/recipe/component/EnumComponent.java
@@ -3,12 +3,28 @@ package dev.latvian.mods.kubejs.recipe.component;
 import com.google.gson.JsonPrimitive;
 import dev.latvian.mods.kubejs.recipe.RecipeExceptionJS;
 import dev.latvian.mods.kubejs.recipe.RecipeJS;
+import dev.latvian.mods.kubejs.recipe.schema.DynamicRecipeComponent;
+import dev.latvian.mods.kubejs.typings.desc.TypeDescJS;
 import dev.latvian.mods.kubejs.util.UtilsJS;
+import dev.latvian.mods.rhino.NativeJavaClass;
 
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
 public record EnumComponent<T extends Enum<T>>(Class<T> enumType, Function<T, String> toStringFunc, BiFunction<Class<T>, String, T> toEnumFunc) implements RecipeComponent<T> {
+	@SuppressWarnings({"unchecked", "rawtypes"})
+	public static final DynamicRecipeComponent DYNAMIC = new DynamicRecipeComponent(TypeDescJS.object(), (ctx, scope, args) -> {
+		Object o = args.get("enum");
+		Class clazz;
+		if (o instanceof NativeJavaClass njc) clazz = njc.getClassObject();
+		if (o instanceof Class c) clazz = c;
+		else try {
+			return new EnumComponent<>((Class) Class.forName(String.valueOf(o)));
+		} catch (ClassNotFoundException e) {
+			throw new RecipeExceptionJS("Error loading class for EnumComponent", e);
+		}
+		if (!clazz.isEnum()) throw new RecipeExceptionJS("Class " + clazz.getTypeName() + " is not an enum!");
+	});
 	private static final Function<Enum<?>, String> DEFAULT_TO_STRING = e -> e.name().toLowerCase();
 	private static final BiFunction<Class<? extends Enum<?>>, String, Enum<?>> DEFAULT_TO_ENUM = (c, s) -> {
 		for (var e : c.getEnumConstants()) {

--- a/common/src/main/java/dev/latvian/mods/kubejs/recipe/component/MappingRecipeComponent.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/recipe/component/MappingRecipeComponent.java
@@ -18,6 +18,10 @@ public class MappingRecipeComponent<T> implements RecipeComponentWithParent<T> {
 		this.mappingFrom = mappingFrom;
 	}
 
+	@Override
+	public String componentType() {
+		return "mapping";
+	}
 
 	@Override
 	public T read(RecipeJS recipe, Object from) {

--- a/common/src/main/java/dev/latvian/mods/kubejs/recipe/component/MappingRecipeComponent.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/recipe/component/MappingRecipeComponent.java
@@ -1,0 +1,36 @@
+package dev.latvian.mods.kubejs.recipe.component;
+
+import com.google.gson.JsonElement;
+import dev.latvian.mods.kubejs.recipe.RecipeJS;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.function.UnaryOperator;
+
+public class MappingRecipeComponent<T> implements RecipeComponentWithParent<T> {
+
+	private final RecipeComponent<T> parent;
+	private final UnaryOperator<Object> mappingTo;
+	private final UnaryOperator<JsonElement> mappingFrom;
+
+	public MappingRecipeComponent(RecipeComponent<T> parent, UnaryOperator<Object> mappingTo, UnaryOperator<JsonElement> mappingFrom) {
+		this.parent = parent;
+		this.mappingTo = mappingTo;
+		this.mappingFrom = mappingFrom;
+	}
+
+
+	@Override
+	public T read(RecipeJS recipe, Object from) {
+		return RecipeComponentWithParent.super.read(recipe, mappingTo.apply(from));
+	}
+
+	@Override
+	public @Nullable JsonElement write(RecipeJS recipe, T value) {
+		return mappingFrom.apply(RecipeComponentWithParent.super.write(recipe, value));
+	}
+
+	@Override
+	public RecipeComponent<T> parentComponent() {
+		return parent;
+	}
+}

--- a/common/src/main/java/dev/latvian/mods/kubejs/recipe/component/RecipeComponent.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/recipe/component/RecipeComponent.java
@@ -15,6 +15,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.Array;
 import java.util.Map;
+import java.util.function.UnaryOperator;
 
 /**
  * A <b>recipe component</b> is a reusable definition of a recipe element (such as an in/output item, a fluid, or even just a number value)
@@ -296,5 +297,21 @@ public interface RecipeComponent<T> {
 
 	default <O> AndRecipeComponent<T, O> and(RecipeComponent<O> other) {
 		return new AndRecipeComponent<>(this, other);
+	}
+
+	default MappingRecipeComponent<T> mapIn(UnaryOperator<Object> mappingTo) {
+		return map(mappingTo, UnaryOperator.identity());
+	}
+
+	default MappingRecipeComponent<T> mapTo(UnaryOperator<JsonElement> mappingFrom) {
+		return map(UnaryOperator.identity(), mappingFrom);
+	}
+
+	default MappingRecipeComponent<T> map(UnaryOperator<Object> mappingTo, UnaryOperator<JsonElement> mappingFrom) {
+		return new MappingRecipeComponent<>(this, mappingTo, mappingFrom);
+	}
+
+	default SimpleMappingRecipeComponent<T> simpleMap(Object mappings) {
+		return new SimpleMappingRecipeComponent<>(this, mappings);
 	}
 }

--- a/common/src/main/java/dev/latvian/mods/kubejs/recipe/component/RecipeComponent.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/recipe/component/RecipeComponent.java
@@ -8,6 +8,7 @@ import dev.latvian.mods.kubejs.recipe.RecipeJS;
 import dev.latvian.mods.kubejs.recipe.RecipeKey;
 import dev.latvian.mods.kubejs.recipe.ReplacementMatch;
 import dev.latvian.mods.kubejs.recipe.schema.RecipeSchema;
+import dev.latvian.mods.kubejs.typings.Info;
 import dev.latvian.mods.kubejs.typings.desc.DescriptionContext;
 import dev.latvian.mods.kubejs.typings.desc.TypeDescJS;
 import dev.latvian.mods.kubejs.util.TinyMap;
@@ -299,18 +300,28 @@ public interface RecipeComponent<T> {
 		return new AndRecipeComponent<>(this, other);
 	}
 
+	// The below helpers are mainly intended for scripters, if you are an addon developer just make your own component instead of reusing the existing ones.
+	@Info("Returns a new RecipeComponent that applies the mappingTo function to the input before it is passed to this component to be read")
 	default MappingRecipeComponent<T> mapIn(UnaryOperator<Object> mappingTo) {
 		return map(mappingTo, UnaryOperator.identity());
 	}
 
-	default MappingRecipeComponent<T> mapTo(UnaryOperator<JsonElement> mappingFrom) {
+	@Info("Returns a new RecipeComponent that applies the mappingFrom function after the component writes to json, before that json is saved")
+	default MappingRecipeComponent<T> mapOut(UnaryOperator<JsonElement> mappingFrom) {
 		return map(UnaryOperator.identity(), mappingFrom);
 	}
 
+	@Info("Returns a new RecipeComponent that applies the mappingTo function to the input before it is passed to this component to be read, and the mappingFrom function after the component writes to json, before that json is saved")
 	default MappingRecipeComponent<T> map(UnaryOperator<Object> mappingTo, UnaryOperator<JsonElement> mappingFrom) {
 		return new MappingRecipeComponent<>(this, mappingTo, mappingFrom);
 	}
 
+	@Info("""
+            Returns a new RecipeComponent that maps the keys in a JsonObject according to the provided map, both before the json gets passed to the component and after the component returns a written json object.
+            The mappings should be provided in the format `{recipe: "component"}` where recipe is the key as in the recipe, and component is the key as how the RecipeComponent expects it.
+            Any keys not included in the provided map will be ignored, and any keys in the provided map that are not in either the input object or output object will be ignored.
+            Note that if the input or output is not a JsonObject (ie its an ItemStack, or it is a JsonPrimitive) then that will pass through this without being modified.
+            If you wish to handle those situations use the actual map function""")
 	default SimpleMappingRecipeComponent<T> simpleMap(Object mappings) {
 		return new SimpleMappingRecipeComponent<>(this, mappings);
 	}

--- a/common/src/main/java/dev/latvian/mods/kubejs/recipe/component/RegistryComponent.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/recipe/component/RegistryComponent.java
@@ -4,14 +4,28 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
 import dev.latvian.mods.kubejs.fluid.FluidStackJS;
 import dev.latvian.mods.kubejs.recipe.RecipeJS;
+import dev.latvian.mods.kubejs.recipe.schema.DynamicRecipeComponent;
 import dev.latvian.mods.kubejs.registry.RegistryInfo;
 import dev.latvian.mods.kubejs.typings.desc.DescriptionContext;
 import dev.latvian.mods.kubejs.typings.desc.TypeDescJS;
 import dev.latvian.mods.kubejs.util.UtilsJS;
+import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 
 public record RegistryComponent<T>(RegistryInfo<T> registry) implements RecipeComponent<T> {
+	@SuppressWarnings("unchecked")
+	public static final DynamicRecipeComponent DYNAMIC = new DynamicRecipeComponent(TypeDescJS.object(1).add("registry", TypeDescJS.STRING.or(DescriptionContext.DEFAULT.javaType(RegistryInfo.class))), (ctx, scope, args) -> {
+		Object registry = args.get("registry");
+		RegistryInfo<?> regInfo;
+		if (registry instanceof RegistryInfo<?> registryInfo) regInfo = registryInfo;
+		else if (registry instanceof ResourceKey<?> resourceKey) regInfo = RegistryInfo.of((ResourceKey<? extends Registry<?>>) resourceKey);
+		else regInfo = RegistryInfo.of(ResourceKey.createRegistryKey(new ResourceLocation(String.valueOf(registry))));
+
+		return new RegistryComponent<>(regInfo);
+	});
+
 	@Override
 	public String componentType() {
 		return "registry_element";

--- a/common/src/main/java/dev/latvian/mods/kubejs/recipe/component/SimpleMappingRecipeComponent.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/recipe/component/SimpleMappingRecipeComponent.java
@@ -1,0 +1,53 @@
+package dev.latvian.mods.kubejs.recipe.component;
+
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import dev.latvian.mods.kubejs.util.MapJS;
+
+import java.util.Map;
+import java.util.Objects;
+
+public class SimpleMappingRecipeComponent<T> extends MappingRecipeComponent<T> {
+
+	@SuppressWarnings("unchecked")
+	public SimpleMappingRecipeComponent(RecipeComponent<T> parent, Object mappings) {
+		this(HashBiMap.create((Map<String, String>) Objects.requireNonNull(MapJS.of(mappings), "mappings null or invalid map. try using {left: 'right', more: 'mappings'} format")), parent);
+	}
+
+	private SimpleMappingRecipeComponent(BiMap<String, String> mappings, RecipeComponent<T> parent) {
+		super(parent, o -> to(o, mappings), j -> from(j, mappings.inverse()));
+	}
+
+	@SuppressWarnings("unchecked")
+	public static Object to(Object o, Map<String, String> mappings) {
+		Map<String, Object> m = (Map<String, Object>) MapJS.of(o); // If Object instanceof Map then if the caller has a reference to it then they will see the mutated map, which may cause issues but hopefully won't
+		if (m == null) return o; // we cant deal with it if it's not a map
+        mappings.forEach((from, to) -> {
+			if (m.containsKey(from)) {
+				var value = m.get(from);
+				// Doing it in this order means we prevent the map growing
+				m.remove(from);
+				m.put(to, value);
+			}
+		});
+		return m;
+	}
+
+	public static JsonElement from(JsonElement parentOutput, Map<String, String> mappings) {
+		if (parentOutput instanceof JsonObject json) {
+			// this is the map that backs the json object, so modifying it modifies the json
+			Map<String, JsonElement> map = json.asMap();
+			mappings.forEach((from, to) -> {
+				if (map.containsKey(from)) {
+					var value = map.get(from);
+					// Doing it in this order means we prevent the map growing
+					map.remove(from);
+					map.put(to, value);
+				}
+			});
+		}
+		return parentOutput;
+	}
+}

--- a/common/src/main/java/dev/latvian/mods/kubejs/recipe/component/SimpleMappingRecipeComponent.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/recipe/component/SimpleMappingRecipeComponent.java
@@ -20,6 +20,11 @@ public class SimpleMappingRecipeComponent<T> extends MappingRecipeComponent<T> {
 		super(parent, o -> to(o, mappings), j -> from(j, mappings.inverse()));
 	}
 
+	@Override
+	public String componentType() {
+		return "simple_mapping";
+	}
+
 	@SuppressWarnings("unchecked")
 	public static Object to(Object o, Map<String, String> mappings) {
 		Map<String, Object> m = (Map<String, Object>) MapJS.of(o); // If Object instanceof Map then if the caller has a reference to it then they will see the mutated map, which may cause issues but hopefully won't

--- a/common/src/main/java/dev/latvian/mods/kubejs/recipe/component/TagKeyComponent.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/recipe/component/TagKeyComponent.java
@@ -16,12 +16,14 @@ import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.material.Fluid;
 
 public record TagKeyComponent<T>(ResourceKey<? extends Registry<T>> registry, Class<?> registryType) implements RecipeComponent<TagKey<T>> {
 	public static final RecipeComponent<TagKey<Block>> BLOCK = new TagKeyComponent<>(Registries.BLOCK, Block.class);
 	public static final RecipeComponent<TagKey<Item>> ITEM = new TagKeyComponent<>(Registries.ITEM, Item.class);
 	public static final RecipeComponent<TagKey<EntityType<?>>> ENTITY_TYPE = new TagKeyComponent<>(Registries.ENTITY_TYPE, EntityType.class);
 	public static final RecipeComponent<TagKey<Biome>> BIOME = new TagKeyComponent<>(Registries.BIOME, Biome.class);
+	public static final RecipeComponent<TagKey<Fluid>> FLUID = new TagKeyComponent<>(Registries.FLUID, Fluid.class);
 
 	public static final DynamicRecipeComponent DYNAMIC = new DynamicRecipeComponent(TypeDescJS.object()
 		.add("registry", TypeDescJS.STRING)

--- a/common/src/main/java/dev/latvian/mods/kubejs/recipe/schema/RecipeSchema.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/recipe/schema/RecipeSchema.java
@@ -9,6 +9,7 @@ import dev.latvian.mods.kubejs.recipe.RecipeJS;
 import dev.latvian.mods.kubejs.recipe.RecipeKey;
 import dev.latvian.mods.kubejs.recipe.RecipeTypeFunction;
 import dev.latvian.mods.kubejs.util.JsonIO;
+import dev.latvian.mods.rhino.util.RemapForJS;
 import it.unimi.dsi.fastutil.ints.Int2ObjectArrayMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import net.minecraft.resources.ResourceLocation;
@@ -120,6 +121,7 @@ public class RecipeSchema {
 	 * @return This schema.
 	 * @implNote If a constructor is manually defined using this method, constructors will not be automatically generated.
 	 */
+	@RemapForJS("addConstructor") // constructor is a reserved word in TypeScript, so remap this for scripters who use .d.ts files for typing hints
 	public RecipeSchema constructor(RecipeConstructor.Factory factory, RecipeKey<?>... keys) {
 		var c = new RecipeConstructor(this, keys, factory);
 
@@ -134,6 +136,7 @@ public class RecipeSchema {
 		return this;
 	}
 
+	@RemapForJS("addConstructor") // constructor is a reserved word in TypeScript, so remap this for scripters who use .d.ts files for typing hints
 	public RecipeSchema constructor(RecipeKey<?>... keys) {
 		return constructor(RecipeConstructor.Factory.DEFAULT, keys);
 	}


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->
### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->
This PR includes many things related to RecipeComponents:
- Adds a MappingRecipeComponent, which applies the given functions to the input before another recipe component gets it, and after the other recipe output returns a serialized output.
- Adds a SimpleMappingRecipeComponent, which uses the MappingRecipeComponent to change the keys in a json/map before it is passed to the inner component and after the inner component serializes something. This is useful for scripters when a mod uses the same format, just with different key names (like all mods and vanilla with block state inputs. see example)  
- Adds methods to RecipeComponent for the two above components. As these are mainly intended for use by scripters they are documented with @Info annotations with some documentation.
- Registers the enum component in the recipe component registry, for use by scripters. This is a dynamic component that takes one argument, `class` for the enum class.
- Adds fluidTag recipe component to the recipe component registry
- Migrates the blockstate components to default to the object form that vanilla uses, and moves the old string format to its own registry entry. Note that either will work as input in scripts, the only difference between the two is what it serializes to. It is intended that scripters use simpleMap with this component to map it to a mods needs, due to mods using different names for the block id and properties.
- Register the RegistryComponent to the recipe component register as a dynamic component that takes one component, that of the registries resource location (or a RegistryInfo from `Utils.registries`)
- Add a RemapForJS annotation to RecipeSchema#constructor as constructor is a reserved keyword in typescript, causing typing hints tools to not show these methods. For scripters it is now called addConstructor


#### Example Script <!-- Please provide an example script showing that the bug is fixed, or how the feature is used, if applicable -->
This doesn't cover everything, but it covers most things. I do have a full set of AE2 recipes that use almost all of this stuff, but they are too long for what is meant to be a more minimal example.
```js
//requires: ae2
const $EntropyMode = Java.loadClass('appeng.recipes.entropy.EntropyMode')
const $RecipeComponentBuilder = Java.loadClass('dev.latvian.mods.kubejs.recipe.component.RecipeComponentBuilder')
const $RecipeSchema = Java.loadClass('dev.latvian.mods.kubejs.recipe.schema.RecipeSchema')

StartupEvents.recipeSchemaRegistry(event => {
    let fluidStateComponent = new $RecipeComponentBuilder(
      event.components.get('registryObject')({registry: 'fluid'}).key('id'), 
      new $MapRecipeComponent(
        event.components.get('nonBlankString')(), 
        event.components.get('nonBlankString')(), 
      false).key('properties').defaultOptional()
    )
    event.register('ae2:entropy', new $RecipeSchema(   
        new $RecipeComponentBuilder(
            event.components.get('outputBlockState')().simpleMap({ id: 'Name', properties: 'Properties' }).key('block').defaultOptional(),
            fluidStateComponent.key('fluid').defaultOptional(),
            event.components.get('outputItemArray')().key('drops').optional([])
        ).outputRole().key('output'),
        new $RecipeComponentBuilder(
            event.components.get('inputBlockState')().simpleMap({ id: 'Name', properties: 'Properties' }).key('block').defaultOptional(),
            fluidStateComponent.key('fluid').defaultOptional()
        ).inputRole().key('input'),
        event.components.get('enum')({ class: $EntropyMode }).key('mode')
    ))
})
```

#### Other details <!-- Any other important information, like if this is likely to break addons -->
There are only two breaking changes here for scripters, and one of those is also for addons.
For scripters it is the constructor method name change, and the one that affects them both is the changing of the default block state component serialization state, although I doubt anyone was using that.