### PR TITLE
Fixed MobEffectBuilder and BasicMobEffect in 1.20.4

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/misc/MobEffectBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/misc/MobEffectBuilder.java
@@ -4,15 +4,20 @@ import dev.latvian.mods.kubejs.registry.BuilderBase;
 import dev.latvian.mods.kubejs.registry.RegistryInfo;
 import dev.latvian.mods.rhino.mod.util.color.Color;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.effect.AttributeModifierTemplate;
 import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.effect.MobEffectCategory;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
+/**
+ * @author Prunoideae
+ */
 public abstract class MobEffectBuilder extends BuilderBase<MobEffect> {
 
 	@FunctionalInterface
@@ -22,8 +27,9 @@ public abstract class MobEffectBuilder extends BuilderBase<MobEffect> {
 
 	public transient MobEffectCategory category;
 	public transient EffectTickCallback effectTick;
-	public transient Map<ResourceLocation, AttributeModifier> attributeModifiers;
+	public transient Map<ResourceLocation, AttributeModifierTemplate> attributeModifiers;
 	public transient int color;
+	public transient boolean instant;
 
 	public MobEffectBuilder(ResourceLocation i) {
 		super(i);
@@ -39,8 +45,7 @@ public abstract class MobEffectBuilder extends BuilderBase<MobEffect> {
 	}
 
 	public MobEffectBuilder modifyAttribute(ResourceLocation attribute, String identifier, double d, AttributeModifier.Operation operation) {
-		AttributeModifier attributeModifier = new AttributeModifier(new UUID(identifier.hashCode(), identifier.hashCode()), identifier, d, operation);
-		attributeModifiers.put(attribute, attributeModifier);
+		attributeModifiers.put(attribute, new MobEffectJSAttributeModifierTemplate(identifier, d, operation));
 		return this;
 	}
 
@@ -65,5 +70,40 @@ public abstract class MobEffectBuilder extends BuilderBase<MobEffect> {
 	public MobEffectBuilder color(Color col) {
 		color = col.getRgbJS();
 		return this;
+	}
+
+	public MobEffectBuilder instant() {
+		return instant(true);
+	}
+
+	public MobEffectBuilder instant(boolean instant) {
+		this.instant = instant;
+		return this;
+	}
+
+	static class MobEffectJSAttributeModifierTemplate implements AttributeModifierTemplate {
+
+		private final UUID uuid;
+		private final String id;
+		private final double amount;
+		private final AttributeModifier.Operation operation;
+
+		public MobEffectJSAttributeModifierTemplate(String id, double amount, AttributeModifier.Operation operation) {
+			this.id = id;
+			this.amount = amount;
+			this.operation = operation;
+
+			this.uuid = new UUID(id.hashCode(), id.hashCode());
+		}
+
+		@Override
+		public @NotNull UUID getAttributeModifierId() {
+			return uuid;
+		}
+
+		@Override
+		public @NotNull AttributeModifier create(int i) {
+			return new AttributeModifier(uuid, this.id, this.amount, this.operation);
+		}
 	}
 }


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->
### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->

Also added method `instant` so user can make "instant" mob effect properly now (like healing or damaging potion).
