### PR TITLE
Added `setRandomTickCallback` for block modification

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/core/BlockKJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/core/BlockKJS.java
@@ -1,6 +1,7 @@
 package dev.latvian.mods.kubejs.core;
 
 import dev.latvian.mods.kubejs.block.BlockBuilder;
+import dev.latvian.mods.kubejs.block.RandomTickCallbackJS;
 import dev.latvian.mods.kubejs.util.UtilsJS;
 import dev.latvian.mods.rhino.util.RemapPrefixForJS;
 import net.minecraft.nbt.CompoundTag;
@@ -10,6 +11,7 @@ import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.state.BlockState;
 
 import java.util.List;
+import java.util.function.Consumer;
 
 @RemapPrefixForJS("kjs$")
 public interface BlockKJS extends BlockBuilderProvider {
@@ -42,6 +44,10 @@ public interface BlockKJS extends BlockBuilderProvider {
 	}
 
 	default void kjs$setIsRandomlyTicking(boolean v) {
+		throw new NoMixinException();
+	}
+
+	default void kjs$setRandomTickCallback(Consumer<RandomTickCallbackJS> callback) {
 		throw new NoMixinException();
 	}
 

--- a/common/src/main/java/dev/latvian/mods/kubejs/core/mixin/common/BlockBehaviourMixin.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/core/mixin/common/BlockBehaviourMixin.java
@@ -80,6 +80,7 @@ public abstract class BlockBehaviourMixin implements BlockKJS {
 
 	@Override
 	public void kjs$setRandomTickCallback(Consumer<RandomTickCallbackJS> callback) {
+		kjs$setIsRandomlyTicking(true);
 		this.kjs$randomTickCallback = callback;
 	}
 


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->
### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->

Currently, the block modification event has a method `.setIsRandomlyTicking`, which, when set to `false`, disables the random tick of a block. However, setting this to `true` does nothing, as an originally not-ticking block will not have any logic about ticking.

This PR implements `setRandomTickCallback` for `BlockKJS` and `BlockBehaviourMixin`, making it possible for user to set custom ticking behavior for blocks that are not originally tickable.

#### Example Script <!-- Please provide an example script showing that the bug is fixed, or how the feature is used, if applicable -->

This code snippet:

```js
// startup script
BlockEvents.modification(event => {
    event.modify('iron_block', block => {
        block.setIsRandomlyTicking(true)
        block.setRandomTickCallback(callback => {
            let { block } = callback
            block.set("copper_block")
        })
    })
})
```

Will allow the iron block to be converted to copper block when being ticked.

https://github.com/KubeJS-Mods/KubeJS/assets/24620047/d3a5f957-f2ee-4994-ba4d-26af70756c1e

#### Other details <!-- Any other important information, like if this is likely to break addons -->