### PR TITLE
Added type descriptors for `extras` in events

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/bindings/event/BlockEvents.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/bindings/event/BlockEvents.java
@@ -20,7 +20,7 @@ import net.minecraft.world.level.block.state.BlockState;
 public interface BlockEvents {
 	EventGroup GROUP = EventGroup.of("BlockEvents");
 
-	Extra SUPPORTS_BLOCK = new Extra().transformer(BlockEvents::transformBlock).toString(o -> ((Block) o).kjs$getId()).identity();
+	Extra SUPPORTS_BLOCK = new Extra().transformer(BlockEvents::transformBlock).toString(o -> ((Block) o).kjs$getId()).identity().describeType(context -> context.javaType(Block.class));
 
 	private static Block transformBlock(Object o) {
 		if (o == null) {

--- a/common/src/main/java/dev/latvian/mods/kubejs/bindings/event/EntityEvents.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/bindings/event/EntityEvents.java
@@ -14,7 +14,7 @@ import net.minecraft.world.entity.EntityType;
 public interface EntityEvents {
 	EventGroup GROUP = EventGroup.of("EntityEvents");
 
-	Extra SUPPORTS_ENTITY_TYPE = new Extra().transformer(EntityEvents::transformEntityType).identity();
+	Extra SUPPORTS_ENTITY_TYPE = new Extra().transformer(EntityEvents::transformEntityType).identity().describeType(context -> context.javaType(EntityType.class));
 
 	private static Object transformEntityType(Object o) {
 		if (o == null || o instanceof EntityType) {

--- a/common/src/main/java/dev/latvian/mods/kubejs/bindings/event/ItemEvents.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/bindings/event/ItemEvents.java
@@ -24,7 +24,7 @@ import net.minecraft.world.level.ItemLike;
 public interface ItemEvents {
 	EventGroup GROUP = EventGroup.of("ItemEvents");
 
-	Extra SUPPORTS_ITEM = new Extra().transformer(ItemEvents::transformItem).toString(o -> ((Item) o).kjs$getId()).identity();
+	Extra SUPPORTS_ITEM = new Extra().transformer(ItemEvents::transformItem).toString(o -> ((Item) o).kjs$getId()).identity().describeType(context -> context.javaType(Item.class));
 
 	private static Object transformItem(Object o) {
 		if (o == null) {

--- a/common/src/main/java/dev/latvian/mods/kubejs/bindings/event/PlayerEvents.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/bindings/event/PlayerEvents.java
@@ -16,7 +16,7 @@ import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.MenuType;
 
 public interface PlayerEvents {
-	Extra SUPPORTS_MENU_TYPE = new Extra().transformer(PlayerEvents::transformMenuType).identity();
+	Extra SUPPORTS_MENU_TYPE = new Extra().transformer(PlayerEvents::transformMenuType).identity().describeType(context -> context.javaType(MenuType.class));
 
 	static Object transformMenuType(Object o) {
 		if (o == null) {

--- a/common/src/main/java/dev/latvian/mods/kubejs/event/Extra.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/event/Extra.java
@@ -1,11 +1,14 @@
 package dev.latvian.mods.kubejs.event;
 
+import dev.latvian.mods.kubejs.typings.desc.DescriptionContext;
+import dev.latvian.mods.kubejs.typings.desc.TypeDescJS;
 import dev.latvian.mods.kubejs.util.UtilsJS;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 public class Extra {
@@ -62,6 +65,7 @@ public class Extra {
 	public boolean required;
 	public Predicate<Object> validator;
 	public Transformer toString;
+	public Function<DescriptionContext, TypeDescJS> describeType;
 
 	public Extra() {
 		this.transformer = Transformer.IDENTITY;
@@ -69,6 +73,7 @@ public class Extra {
 		this.required = false;
 		this.validator = UtilsJS.ALWAYS_TRUE;
 		this.toString = Transformer.IDENTITY;
+		this.describeType = context -> TypeDescJS.STRING;
 	}
 
 	public Extra copy() {
@@ -98,6 +103,11 @@ public class Extra {
 
 	public Extra validator(Predicate<Object> validator) {
 		this.validator = validator;
+		return this;
+	}
+
+	public Extra describeType(Function<DescriptionContext, TypeDescJS> describeType) {
+		this.describeType = describeType;
 		return this;
 	}
 


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->
### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->

Added `TypeDescJS` for `Extra`s in events to make extras can be typed and dumped by typing mods.

`Extra` now holds a `describeType` field which is a `Function<DescriptionContext, TypeDescJS>`. Mods can call the `describeType` field with a context to get the type description of the extra.

The `Extra` is typed to accept a `string` by default.