### PR TITLE
fix: prevent tier from changing instance of same class

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/item/custom/HandheldItemBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/item/custom/HandheldItemBuilder.java
@@ -24,7 +24,7 @@ public abstract class HandheldItemBuilder extends ItemBuilder {
 	}
 
 	public HandheldItemBuilder tier(Tier t) {
-		toolTier = new MutableToolTier(t);
+		toolTier = t instanceof MutableToolTier mtt ? mtt : new MutableToolTier(t);
 		return this;
 	}
 


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->
### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->
When you register a tier with `ItemEvents.toolTierRegistry` it already creates a MutableToolTier, if we don't preserve the instance we start to have problems with [TierSortingRegistry](https://lexxie.site/forge/1.19.2/net/minecraftforge/common/TierSortingRegistry.html#registerTier(net.minecraft.world.item.Tier,net.minecraft.resources.ResourceLocation,java.util.List,java.util.List)) because of mismatching instances.
This problem only occurs to blocks without any of the 3 "needs_(stone|iron|diamond)_tool" and the `forge:needs_netherite_tool` is not included on the deprecated method (`DiggerItem#isCorrectToolForDrops(BlockState)`) that is being called.


#### Example Script <!-- Please provide an example script showing that the bug is fixed, or how the feature is used, if applicable -->
```js
const $TierSortingRegistry = Java.loadClass("net.minecraftforge.common.TierSortingRegistry")
const $Tiers = Java.loadClass("net.minecraft.world.item.Tiers")

ItemEvents.toolTierRegistry(event => {
  event.add("copper", tier => {
    tier.uses = 215
    tier.speed = 5
    tier.attackDamageBonus = 1
    tier.level = 1
    tier.enchantmentValue = 7
    tier.repairIngredient = "#forge:ingots/copper"
  })
  
  $TierSortingRegistry.registerTier(
    "copper", //typewraped to ItemBuilder::toToolTier(Object), will get MutableToolTier from ItemBuilder.TOOL_TIERS because we registered above
    "copper",
    [$Tiers.STONE], [$Tiers.IRON]
  )
})

StartupEvents.registry("item", event => {
  event.create("kubejs:copper_pickaxe", "pickaxe")
  .glow(true)
  .tag("forge:tools/pickaxes")
  .tier("copper") // This bad boy is reinstantiating the MutableToolTier, making it not to be the same obj registered at TierSortingRegistry
  .texture("minecraft:item/golden_pickaxe")
})

StartupEvents.registry("block", event => {
  event.create("aluminum_ore")
    .material("stone")
    .model("minecraft:block/diamond_ore")
    .tagBlock("minecraft:mineable/pickaxe")
    .tagBlock("forge:ores/aluminum")
    .tagBlock("forge:needs_netherite_tool")
    .requiresTool()
})
```
![image](https://github.com/KubeJS-Mods/KubeJS/assets/97140255/859ddbfc-8451-464c-ad5f-3e67c55f310d)

#### Other details <!-- Any other important information, like if this is likely to break addons -->