### PR TITLE
Fix `block` of `BlockEntityJS` always having a `null` level

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/block/entity/BlockEntityJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/entity/BlockEntityJS.java
@@ -18,7 +18,7 @@ import java.util.UUID;
 
 public class BlockEntityJS extends BlockEntity {
 	public final BlockEntityInfo info;
-	public final BlockContainerJS block;
+	protected BlockContainerJS block;
 	public final int x, y, z;
 	public int tick, cycle;
 	public CompoundTag data;
@@ -29,9 +29,6 @@ public class BlockEntityJS extends BlockEntity {
 	public BlockEntityJS(BlockPos blockPos, BlockState blockState, BlockEntityInfo entityInfo) {
 		super(entityInfo.entityType, blockPos, blockState);
 		this.info = entityInfo;
-		this.block = new BlockContainerJS(level, blockPos);
-		this.block.cachedState = blockState;
-		this.block.cachedEntity = this;
 		this.x = blockPos.getX();
 		this.y = blockPos.getY();
 		this.z = blockPos.getZ();
@@ -168,5 +165,13 @@ public class BlockEntityJS extends BlockEntity {
 		if (c) {
 			cycle++;
 		}
+	}
+
+	public BlockContainerJS getBlock() {
+		if (block == null) {
+			this.block = new BlockContainerJS(level, worldPosition);
+			this.block.cachedEntity = this;
+		}
+		return block;
 	}
 }


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->
### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->

Current `block` of `BlockEntityJS` is created in the constructor of `BlockEntityJS`:

https://github.com/KubeJS-Mods/KubeJS/blob/d7da1123de18078283b485f46834dbb7037ae09c/common/src/main/java/dev/latvian/mods/kubejs/block/entity/BlockEntityJS.java#L32-L34

However, this created a problem as the `level` of the `BlockEntity` is always null in the constructor:

```java
public abstract class BlockEntity {
	protected Level level;
	protected final BlockPos worldPosition;
	protected boolean remove;
	private BlockState blockState;

	public BlockEntity(BlockEntityType<?> blockEntityType, BlockPos blockPos, BlockState blockState) {
		this.type = blockEntityType;
		this.worldPosition = blockPos.immutable();
		this.blockState = blockState;
	}

```

So any method call related to `level` will cause a `NullPointerException`. The `level` of `BlockEntity` is set via `setLevel` after instantiation.

The PR fixed such a problem by delaying the creation of `BlockContainerJS` till the first call.