### PR TITLE
Implement reloadable native events

### DIFF
--- a/src/main/java/dev/latvian/mods/kubejs/neoforge/NativeEventHandler.java
+++ b/src/main/java/dev/latvian/mods/kubejs/neoforge/NativeEventHandler.java
@@ -43,29 +43,17 @@ public class NativeEventHandler extends BaseFunction {
 				throw new IllegalStateException("Expected argument to be a function. Event syntax: " + getExampleSyntax());
 			}
 
+			var priority = (EventPriority) Context.jsToJava(cx, unknownPriority, EventPriority.class);
 			var consumer = (NativeEventConsumer) Context.jsToJava(cx, unknownFunction, NativeEventConsumer.class);
 			var securedConsumer = secure(consumer);
 			//noinspection unchecked
-			NeoForge.EVENT_BUS.addListener(getPriority(unknownPriority), false, (Class<Event>) eventClass, securedConsumer);
+			NeoForge.EVENT_BUS.addListener(priority, false, (Class<Event>) eventClass, securedConsumer);
 			consumers.add(securedConsumer);
 		} catch (Exception ex) {
 			ScriptType.STARTUP.console.error(ex.getLocalizedMessage());
 		}
 
 		return null;
-	}
-
-	private EventPriority getPriority(Object unknownPriority) {
-		if (unknownPriority instanceof EventPriority ep) {
-			return ep;
-		}
-
-		try {
-			return EventPriority.valueOf(unknownPriority.toString().toUpperCase());
-		} catch (Exception ex) {
-			ScriptType.STARTUP.console.error("Invalid priority: " + unknownPriority);
-			return EventPriority.NORMAL;
-		}
 	}
 
 	private String getExampleSyntax() {

--- a/src/main/java/dev/latvian/mods/kubejs/neoforge/NativeEventHandler.java
+++ b/src/main/java/dev/latvian/mods/kubejs/neoforge/NativeEventHandler.java
@@ -79,7 +79,7 @@ public class NativeEventHandler extends BaseFunction {
 			try {
 				consumer.accept(event);
 			} catch (Exception ex) {
-				ScriptType.STARTUP.console.error(ex.getLocalizedMessage());
+				NativeEvents.throwException("Error in native event '" + NativeEvents.NAME + "." + name + "'", ex);
 			}
 		};
 	}

--- a/src/main/java/dev/latvian/mods/kubejs/neoforge/NativeEventHandler.java
+++ b/src/main/java/dev/latvian/mods/kubejs/neoforge/NativeEventHandler.java
@@ -1,0 +1,86 @@
+package dev.latvian.mods.kubejs.neoforge;
+
+import dev.latvian.mods.kubejs.script.ScriptType;
+import dev.latvian.mods.rhino.BaseFunction;
+import dev.latvian.mods.rhino.Context;
+import dev.latvian.mods.rhino.Function;
+import dev.latvian.mods.rhino.Scriptable;
+import dev.latvian.mods.rhino.util.HideFromJS;
+import net.neoforged.bus.api.Event;
+import net.neoforged.bus.api.EventPriority;
+import net.neoforged.neoforge.common.NeoForge;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class NativeEventHandler extends BaseFunction {
+	private final List<NativeEventConsumer> consumers = new ArrayList<>();
+	private final String name;
+	private final Class<? extends Event> eventClass;
+
+	public NativeEventHandler(String name, Class<? extends Event> eventClass) {
+		this.name = name;
+		this.eventClass = eventClass;
+	}
+
+	@HideFromJS
+	public void unregister() {
+		for (NativeEventConsumer consumer : consumers) {
+			NeoForge.EVENT_BUS.unregister(consumer);
+		}
+	}
+
+	@Override
+	public Object call(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+		try {
+			if (args.length < 1 || args.length > 2) {
+				throw new IllegalStateException("Expected 1 or 2 arguments for native events. Event syntax: " + getExampleSyntax());
+			}
+
+			Object unknownPriority = args.length == 2 ? args[0] : EventPriority.NORMAL;
+			Object unknownFunction = args.length == 2 ? args[1] : args[0];
+			if (!(unknownFunction instanceof Function)) {
+				throw new IllegalStateException("Expected argument to be a function. Event syntax: " + getExampleSyntax());
+			}
+
+			var consumer = (NativeEventConsumer) Context.jsToJava(cx, unknownFunction, NativeEventConsumer.class);
+			var securedConsumer = secure(consumer);
+			//noinspection unchecked
+			NeoForge.EVENT_BUS.addListener(getPriority(unknownPriority), false, (Class<Event>) eventClass, securedConsumer);
+			consumers.add(securedConsumer);
+		} catch (Exception ex) {
+			ScriptType.STARTUP.console.error(ex.getLocalizedMessage());
+		}
+
+		return null;
+	}
+
+	private EventPriority getPriority(Object unknownPriority) {
+		if (unknownPriority instanceof EventPriority ep) {
+			return ep;
+		}
+
+		try {
+			return EventPriority.valueOf(unknownPriority.toString().toUpperCase());
+		} catch (Exception ex) {
+			ScriptType.STARTUP.console.error("Invalid priority: " + unknownPriority);
+			return EventPriority.NORMAL;
+		}
+	}
+
+	private String getExampleSyntax() {
+		String def = NativeEvents.NAME + "." + name + "(event => { ... })";
+		String priority = NativeEvents.NAME + "." + name + "(priority, event => { ... })";
+		return def + " or " + priority;
+	}
+
+	private NativeEventConsumer secure(NativeEventConsumer consumer) {
+		return event -> {
+			try {
+				consumer.accept(event);
+			} catch (Exception ex) {
+				ScriptType.STARTUP.console.error(ex.getLocalizedMessage());
+			}
+		};
+	}
+}

--- a/src/main/java/dev/latvian/mods/kubejs/neoforge/NativeEvents.java
+++ b/src/main/java/dev/latvian/mods/kubejs/neoforge/NativeEvents.java
@@ -1,0 +1,138 @@
+package dev.latvian.mods.kubejs.neoforge;
+
+import dev.latvian.mods.kubejs.KubeJS;
+import dev.latvian.mods.kubejs.script.ScriptType;
+import dev.latvian.mods.rhino.BaseFunction;
+import dev.latvian.mods.rhino.Context;
+import dev.latvian.mods.rhino.NativeJavaObject;
+import dev.latvian.mods.rhino.Scriptable;
+import dev.latvian.mods.rhino.util.CustomJavaToJsWrapper;
+import net.neoforged.bus.api.Event;
+import net.neoforged.bus.api.EventPriority;
+import net.neoforged.neoforge.common.NeoForge;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class NativeEvents implements CustomJavaToJsWrapper {
+
+	public static final String NAME = "NativeEvents";
+	@Nullable
+	private static NativeEvents lastKnownBus;
+	private final Map<String, NativeEventHandler> handlers = new HashMap<>();
+	private final List<NativeEventConsumer> directConsumers = new ArrayList<>();
+
+	public static NativeEvents create() {
+		if (lastKnownBus != null) {
+			lastKnownBus.clear();
+		}
+
+		NativeEvents bus = new NativeEvents();
+		lastKnownBus = bus;
+		return bus;
+	}
+
+	private void clear() {
+		ScriptType.STARTUP.console.info("Clearing native events");
+		for (var handler : handlers.values()) {
+			handler.unregister();
+		}
+		handlers.clear();
+
+		for (var consumer : directConsumers) {
+			NeoForge.EVENT_BUS.unregister(consumer);
+		}
+		directConsumers.clear();
+	}
+
+	private NativeEvents() {
+	}
+
+	@Override
+	public Scriptable convertJavaToJs(Context context, Scriptable scriptable, Class<?> aClass) {
+		return new Wrapper(scriptable, this, aClass, context);
+	}
+
+	@Nullable
+	public NativeEventHandler getHandler(String name) {
+		var handler = handlers.get(name);
+		if (handler != null) {
+			return handler;
+		}
+
+		var eventClass = NeoForgeEventsLookup.INSTANCE.get(name);
+		if (eventClass == null) {
+			return null;
+		}
+
+		handler = new NativeEventHandler(name, eventClass);
+		handlers.put(name, handler);
+		return handler;
+	}
+
+	public Object onEvent(Object eventClass, NativeEventConsumer consumer) {
+		return onEvent(EventPriority.NORMAL, eventClass, consumer);
+	}
+
+	public Object onEvent(EventPriority priority, Object eventClass, NativeEventConsumer consumer) {
+		if (!(eventClass instanceof CharSequence || eventClass instanceof Class)) {
+			throw new RuntimeException("Invalid syntax! " + NAME + ".onEvent(eventType, function) requires event class and handler");
+		}
+
+		try {
+			var type = eventClass instanceof Class<?> c ? c : Class.forName(eventClass.toString());
+			var secured = secure(consumer);
+			//noinspection unchecked
+			NeoForge.EVENT_BUS.addListener(priority, false, (Class<Event>) type, secured);
+			directConsumers.add(secured);
+		} catch (Exception ex) {
+			throw new RuntimeException(ex);
+		}
+
+		return null;
+	}
+
+	private NativeEventConsumer secure(NativeEventConsumer consumer) {
+		return event -> {
+			try {
+				consumer.accept(event);
+			} catch (Exception ex) {
+				ScriptType.STARTUP.console.error(ex.getLocalizedMessage(), ex);
+				KubeJS.LOGGER.error(ex.getLocalizedMessage(), ex);
+			}
+		};
+	}
+
+	public static class Wrapper extends NativeJavaObject {
+		private final NativeEvents nativeEvents;
+		private final BaseFunction empty = new BaseFunction() {
+			@Override
+			public Object call(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+				return null;
+			}
+		};
+
+		public Wrapper(Scriptable scope, NativeEvents nativeEvents, Class<?> staticType, Context cx) {
+			super(scope, nativeEvents, staticType, cx);
+			this.nativeEvents = nativeEvents;
+		}
+
+		@Override
+		public Object get(Context cx, String name, Scriptable start) {
+			NativeEventHandler handler = nativeEvents.getHandler(name);
+			if (handler != null) {
+				return handler;
+			}
+
+			Object result = super.get(cx, name, start);
+			if (result == null || result == Scriptable.NOT_FOUND) {
+				return empty;
+			}
+
+			return result;
+		}
+	}
+}

--- a/src/main/java/dev/latvian/mods/kubejs/neoforge/NativeEvents.java
+++ b/src/main/java/dev/latvian/mods/kubejs/neoforge/NativeEvents.java
@@ -13,6 +13,7 @@ import net.neoforged.neoforge.common.NeoForge;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -71,6 +72,14 @@ public class NativeEvents implements CustomJavaToJsWrapper {
 		handler = new NativeEventHandler(name, eventClass);
 		handlers.put(name, handler);
 		return handler;
+	}
+
+	public void printAllEvents() {
+		NeoForgeEventsLookup.INSTANCE.getEvents()
+			.entrySet()
+			.stream()
+			.sorted(Comparator.comparing(Map.Entry::getKey))
+			.forEach(entry -> KubeJS.LOGGER.info(entry.getKey() + " - ['" + entry.getValue().getName() + "']"));
 	}
 
 	public Object onEvent(Object eventClass, NativeEventConsumer consumer) {

--- a/src/main/java/dev/latvian/mods/kubejs/neoforge/NativeModEventsWrapper.java
+++ b/src/main/java/dev/latvian/mods/kubejs/neoforge/NativeModEventsWrapper.java
@@ -5,13 +5,17 @@ import dev.latvian.mods.kubejs.util.ConsoleJS;
 import net.neoforged.bus.api.EventPriority;
 import net.neoforged.bus.api.IEventBus;
 
-public record NativeModEventsWrapper(String name, IEventBus eventBus) {
+public record NativeModEventsWrapper(String name, IEventBus eventBus, boolean deprecated) {
 	public Object onEvent(Object eventClass, NativeEventConsumer consumer) {
 		if (!(eventClass instanceof CharSequence || eventClass instanceof Class)) {
 			throw new RuntimeException("Invalid syntax! " + name + ".onEvent(eventType, function) requires event class and handler");
 		} else if (!KubeJS.getStartupScriptManager().firstLoad) {
 			ConsoleJS.STARTUP.warn(name + ".onEvent() can't be reloaded! You will have to restart the game for changes to take effect.");
 			return null;
+		}
+
+		if (deprecated) {
+			ConsoleJS.STARTUP.warn("The event " + name + " is deprecated. Use " + NativeEvents.NAME + ".onEvent() instead.");
 		}
 
 		try {

--- a/src/main/java/dev/latvian/mods/kubejs/neoforge/NativeModEventsWrapper.java
+++ b/src/main/java/dev/latvian/mods/kubejs/neoforge/NativeModEventsWrapper.java
@@ -5,7 +5,7 @@ import dev.latvian.mods.kubejs.util.ConsoleJS;
 import net.neoforged.bus.api.EventPriority;
 import net.neoforged.bus.api.IEventBus;
 
-public record NativeEventWrapper(String name, IEventBus eventBus) {
+public record NativeModEventsWrapper(String name, IEventBus eventBus) {
 	public Object onEvent(Object eventClass, NativeEventConsumer consumer) {
 		if (!(eventClass instanceof CharSequence || eventClass instanceof Class)) {
 			throw new RuntimeException("Invalid syntax! " + name + ".onEvent(eventType, function) requires event class and handler");

--- a/src/main/java/dev/latvian/mods/kubejs/neoforge/NeoForgeEventsLookup.java
+++ b/src/main/java/dev/latvian/mods/kubejs/neoforge/NeoForgeEventsLookup.java
@@ -1,0 +1,206 @@
+package dev.latvian.mods.kubejs.neoforge;
+
+import com.google.common.base.CaseFormat;
+import dev.latvian.mods.kubejs.KubeJS;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
+import net.neoforged.bus.api.Event;
+import net.neoforged.fml.ModList;
+import net.neoforged.fml.loading.FMLEnvironment;
+import net.neoforged.fml.loading.moddiscovery.ModAnnotation;
+import net.neoforged.neoforgespi.language.ModFileScanData;
+import org.apache.commons.lang3.StringUtils;
+import org.objectweb.asm.Type;
+import org.spongepowered.asm.mixin.Mixin;
+
+import javax.annotation.Nullable;
+import java.lang.annotation.ElementType;
+import java.lang.reflect.Modifier;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class NeoForgeEventsLookup {
+
+	public static final NeoForgeEventsLookup INSTANCE = new NeoForgeEventsLookup();
+	@Nullable
+	private Map<String, Class<? extends Event>> eventMap;
+
+	@Nullable
+	public Class<? extends Event> get(String name) {
+		if (eventMap != null) {
+			return eventMap.get(name);
+		}
+
+		reloadEventMap();
+		return eventMap.get(name);
+	}
+
+	public void reloadEventMap() {
+		eventMap = new HashMap<>();
+		for (var data : ModList.get().getAllScanData()) {
+			if (!data.getTargets().containsKey("neoforge")) {
+				continue;
+			}
+
+			var invalidEventClasses = getInvalidClasses(data.getAnnotations());
+			for (var cd : data.getClasses()) {
+				String className = cd.clazz().getClassName();
+
+				if (isInvalidClassName(className) || isInvalidClass(invalidEventClasses, className)) {
+					continue;
+				}
+
+				var eventClass = getClass(className);
+				if (eventClass == null) {
+					continue;
+				}
+
+				var formattedName = formatEventName(className.substring(className.lastIndexOf('.') + 1));
+				if (eventMap.containsKey(formattedName)) {
+					KubeJS.LOGGER.warn("[NativeEvents] Event class " + className + " for name '" + formattedName + "' is already registered as: " + eventMap.get(formattedName));
+					continue;
+				}
+
+				eventMap.put(formattedName, eventClass);
+			}
+		}
+
+		KubeJS.LOGGER.info("[NativeEvents] Loaded " + eventMap.size() + " events");
+	}
+
+	/**
+	 * Get all invalid classes which should not be loaded.
+	 * This includes all classes which are annotated with {@link Mixin} or with {@link OnlyIn}, when they current dist does not match.
+	 *
+	 * @param annotations all annotations
+	 * @return set of invalid classes
+	 */
+	private Set<String> getInvalidClasses(Set<ModFileScanData.AnnotationData> annotations) {
+		Type onlyIn = Type.getType(OnlyIn.class);
+		Type mixin = Type.getType(Mixin.class);
+
+		Set<String> invalid = new HashSet<>();
+		for (ModFileScanData.AnnotationData annotation : annotations) {
+			if (!annotation.targetType().equals(ElementType.TYPE)) {
+				continue;
+			}
+
+			if (isInvalidDist(annotation, onlyIn) || isMixin(annotation, mixin)) {
+				invalid.add(annotation.clazz().getClassName());
+			}
+		}
+
+		return invalid;
+	}
+
+	/**
+	 * Checks if given className is part of invalid classes. It also checks if the super class is part of invalid classes.
+	 *
+	 * @param invalidClasses set of invalid classes
+	 * @param className      class name
+	 * @return true if invalid
+	 */
+	private boolean isInvalidClass(Set<String> invalidClasses, String className) {
+		if (invalidClasses.contains(className)) {
+			return true;
+		}
+
+		String[] parts = className.split("\\$", 2);
+		return invalidClasses.contains(parts[0]);
+	}
+
+	private boolean isMixin(ModFileScanData.AnnotationData annotation, Type mixinType) {
+		return annotation.annotationType().equals(mixinType);
+	}
+
+	private boolean isInvalidDist(ModFileScanData.AnnotationData annotation, Type distType) {
+		Type type = annotation.annotationType();
+		if (!type.equals(distType)) {
+			return false;
+		}
+
+		Object unknownValue = annotation.annotationData().get("value");
+		if (unknownValue instanceof ModAnnotation.EnumHolder enumHolder) {
+			String invalidValue = FMLEnvironment.dist == Dist.CLIENT ? Dist.DEDICATED_SERVER.name() : Dist.CLIENT.name();
+			return enumHolder.getValue().equals(invalidValue);
+		}
+
+		return false;
+	}
+
+	/**
+	 * Checks if given class name is invalid. Only classes which end with "Event" are valid, but also subtypes of it.
+	 *
+	 * @param fullClassName class name
+	 * @return true if class name is invalid
+	 */
+	private boolean isInvalidClassName(String fullClassName) {
+		String[] parts = fullClassName.split("\\$");
+		for (String part : parts) {
+			if (part.endsWith("Event")) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	public String formatEventName(String className) {
+		var mainParts = className.split("\\$");
+		int index = 0;
+		for (int i = mainParts.length - 1; i >= 0; i--) {
+			if (mainParts[i].endsWith("Event")) {
+				index = i;
+				break;
+			}
+		}
+
+		mainParts[index] = mainParts[index].replace("Event", "");
+
+		StringBuilder name = new StringBuilder();
+		String lastPart = "$";
+		for (int i = index; i < mainParts.length; i++) {
+			String[] parts = StringUtils.splitByCharacterTypeCamelCase(mainParts[i]);
+			for (String part : parts) {
+				if (part.equals(lastPart)) {
+					continue;
+				}
+
+				name.append(part);
+				lastPart = part;
+			}
+		}
+
+		return CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL, name.toString());
+	}
+
+	public Map<String, Class<? extends Event>> getEvents() {
+		if (eventMap == null) {
+			reloadEventMap();
+		}
+
+		return Collections.unmodifiableMap(eventMap);
+	}
+
+	@Nullable
+	private Class<? extends Event> getClass(String className) {
+		try {
+			Class<?> aClass = Class.forName(className, false, this.getClass().getClassLoader());
+			if (aClass.isInterface() || Modifier.isAbstract(aClass.getModifiers())) {
+				return null;
+			}
+
+			if (Event.class.isAssignableFrom(aClass)) {
+				//noinspection unchecked
+				return (Class<? extends Event>) aClass;
+			}
+		} catch (Throwable ignored) {
+			String s = "";
+		}
+
+		return null;
+	}
+}

--- a/src/main/java/dev/latvian/mods/kubejs/neoforge/NeoForgeKubeJSPlugin.java
+++ b/src/main/java/dev/latvian/mods/kubejs/neoforge/NeoForgeKubeJSPlugin.java
@@ -8,6 +8,7 @@ import dev.latvian.mods.kubejs.script.ScriptType;
 import dev.latvian.mods.kubejs.util.ClassFilter;
 import dev.latvian.mods.rhino.util.wrap.TypeWrappers;
 import net.neoforged.fml.ModList;
+import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.fluids.FluidStack;
 
 public class NeoForgeKubeJSPlugin extends BuiltinKubeJSPlugin {
@@ -39,8 +40,10 @@ public class NeoForgeKubeJSPlugin extends BuiltinKubeJSPlugin {
 
 		if (event.getType().isStartup()) {
 			event.add(NativeEvents.NAME, NativeEvents.create());
+			event.add("ForgeEvents", new NativeModEventsWrapper("ForgeEvents", NeoForge.EVENT_BUS, true));
+			event.add("NeoForgeEvents", new NativeModEventsWrapper("NeoForgeEvents", NeoForge.EVENT_BUS, true));
 			KubeJSEntryPoint.eventBus().ifPresent(bus -> event.add("NativeModEvents",
-				new NativeModEventsWrapper("NativeModEvents", bus)));
+				new NativeModEventsWrapper("NativeModEvents", bus, false)));
 		}
 	}
 

--- a/src/main/java/dev/latvian/mods/kubejs/neoforge/NeoForgeKubeJSPlugin.java
+++ b/src/main/java/dev/latvian/mods/kubejs/neoforge/NeoForgeKubeJSPlugin.java
@@ -8,7 +8,6 @@ import dev.latvian.mods.kubejs.script.ScriptType;
 import dev.latvian.mods.kubejs.util.ClassFilter;
 import dev.latvian.mods.rhino.util.wrap.TypeWrappers;
 import net.neoforged.fml.ModList;
-import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.fluids.FluidStack;
 
 public class NeoForgeKubeJSPlugin extends BuiltinKubeJSPlugin {
@@ -39,9 +38,9 @@ public class NeoForgeKubeJSPlugin extends BuiltinKubeJSPlugin {
 		super.registerBindings(event);
 
 		if (event.getType().isStartup()) {
-			event.add("NativeEvents", new NativeEventWrapper("NativeEvents", NeoForge.EVENT_BUS));
+			event.add(NativeEvents.NAME, NativeEvents.create());
 			KubeJSEntryPoint.eventBus().ifPresent(bus -> event.add("NativeModEvents",
-				new NativeEventWrapper("NativeModEvents", bus)));
+				new NativeModEventsWrapper("NativeModEvents", bus)));
 		}
 	}
 


### PR DESCRIPTION
Implement reloadable native events also added the ability to use priorities. 

Besides `NativeEvents.onEvent()` it's also possible to directly call events like `NativeEvents.clientChat()`.
If an event is client-side only, like `ScreenEvent`, we will return a dummy function to not crash

Reloading startup scripts via `/kubejs reload startup_scripts` will unregister the events on the NeoForge EventBus and will register the new listeners. Say bye to using `global` to bypass native event reloading.

Startup Scripts:
```js
NativeEvents.clientChat("low", (event) => {
	console.info("LOW PRIO: " + event.message);
});

NativeEvents.clientChat((event) => {
	console.info("NORMAL PRIO: " + event.message);
});

NativeEvents.onEvent("net.neoforged.neoforge.client.event.ClientChatEvent", event => {
	console.info("onEvent: " + event.message);
})

NativeEvents.onEvent("low", "net.neoforged.neoforge.client.event.ClientChatEvent", event => {
	console.info("onEvent low prio: " + event.message);
})

NativeEvents.mobSpawnPositionCheck((event) => {
	console.log(event.entity);
})

NativeEvents.screenInitPost((event) => {
	console.info("screenInitPost: " + event.screen);
})
```

`printAllEvents` can be used to print all possible events + their class
```js
NativeEvents.printAllEvents()
```