### PR TITLE
fix Data Export

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/server/DataExport.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/server/DataExport.java
@@ -117,8 +117,10 @@ public class DataExport {
 			appendLine(logStringBuilder, calendar, line);
 		}
 
-		logStringBuilder.setLength(logStringBuilder.length() - 1);
-		addString("errors.log", logStringBuilder.toString());
+		if (logStringBuilder.length() > 0) {
+			logStringBuilder.setLength(logStringBuilder.length() - 1);
+			addString("errors.log", logStringBuilder.toString());
+		}
 
 		logStringBuilder.setLength(0);
 
@@ -126,8 +128,10 @@ public class DataExport {
 			appendLine(logStringBuilder, calendar, line);
 		}
 
-		logStringBuilder.setLength(logStringBuilder.length() - 1);
-		addString("warnings.log", logStringBuilder.toString());
+		if (logStringBuilder.length() > 0) {
+			logStringBuilder.setLength(logStringBuilder.length() - 1);
+			addString("warnings.log", logStringBuilder.toString());
+		}
 
 		var modArr = new JsonArray();
 


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->
### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->
Fixed data export

The command `/kubejs export` does not work when there is no errors or warnings. (Out of Bound error)