### PR TITLE
Support negative priority

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/script/ScriptFileInfo.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/script/ScriptFileInfo.java
@@ -16,7 +16,7 @@ import java.util.regex.Pattern;
 
 public class ScriptFileInfo {
 	private static final Pattern FILE_FIXER = Pattern.compile("[^\\w./]");
-	private static final Pattern PROPERTY_PATTERN = Pattern.compile("^(\\w+)\\s*[:=]?\\s*(\\w+)$");
+	private static final Pattern PROPERTY_PATTERN = Pattern.compile("^(\\w+)\\s*[:=]?\\s*(-?\\w+)$");
 
 	public final ScriptPackInfo pack;
 	public final String file;


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->
### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->

Adding features described in #782. Negative priorities allow a script to be executed after other scripts.

#### Example Script <!-- Please provide an example script showing that the bug is fixed, or how the feature is used, if applicable -->
```js
// priority: -1
```

#### Other details <!-- Any other important information, like if this is likely to break addons -->

This regex also allows heading `-` as it's implemented via `-?`, but I think it's fine as other properties are still strings yet.