### PR TITLE
fix tags export from kubejs export command

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/core/TagLoaderKJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/core/TagLoaderKJS.java
@@ -64,29 +64,29 @@ public interface TagLoaderKJS<T> {
 				map.put(entry.getKey(), entry.getValue().entries);
 			}
 
-			if (DataExport.export != null) {
-				var loc = "tags/" + regInfo + "/";
-
-				for (var entry : map.entrySet()) {
-					var list = new ArrayList<String>();
-
-					for (var e : entry.getValue()) {
-						list.add(e.entry().toString());
-					}
-
-					list.sort(String.CASE_INSENSITIVE_ORDER);
-					var arr = new JsonArray();
-
-					for (var e : list) {
-						arr.add(e);
-					}
-
-					DataExport.export.addJson(loc + entry.getKey() + ".json", arr);
-				}
-			}
-
 			if (event.totalAdded > 0 || event.totalRemoved > 0 || ConsoleJS.SERVER.shouldPrintDebug()) {
 				ConsoleJS.SERVER.info("[%s] Found %d tags, added %d objects, removed %d objects".formatted(regInfo, event.tags.size(), event.totalAdded, event.totalRemoved));
+			}
+		}
+
+		if (DataExport.export != null) {
+			var loc = "tags/" + regInfo + "/";
+
+			for (var entry : map.entrySet()) {
+				var list = new ArrayList<String>();
+
+				for (var e : entry.getValue()) {
+					list.add(e.entry().toString());
+				}
+
+				list.sort(String.CASE_INSENSITIVE_ORDER);
+				var arr = new JsonArray();
+
+				for (var e : list) {
+					arr.add(e);
+				}
+
+				DataExport.export.addJson(loc + entry.getKey() + ".json", arr);
 			}
 		}
 	}


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->
### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->

Fixes exporting tags, now exports all tags, not only listened to tag events

#### Example Script <!-- Please provide an example script showing that the bug is fixed, or how the feature is used, if applicable -->
```js
/kubejs export
```

Edit: Diff is so ugly, all I did was removing this piece of code inside the first `if`

![image](https://github.com/KubeJS-Mods/KubeJS/assets/97140255/37e271c6-9c1d-4fe8-b0ff-3e684ac59301)



#### Other details <!-- Any other important information, like if this is likely to break addons -->