### PR TITLE
Add support for showing the fluid tags associated with the fluid cont…

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/command/KubeJSCommands.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/command/KubeJSCommands.java
@@ -30,6 +30,7 @@ import dev.latvian.mods.kubejs.server.DataExport;
 import dev.latvian.mods.kubejs.server.ServerScriptManager;
 import dev.latvian.mods.kubejs.typings.Info;
 import dev.latvian.mods.kubejs.util.ConsoleJS;
+import dev.latvian.mods.kubejs.util.Tags;
 import dev.latvian.mods.kubejs.util.UtilsJS;
 import dev.latvian.mods.rhino.JavaMembers;
 import net.minecraft.ChatFormatting;
@@ -57,7 +58,9 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.InteractionHand;
+import net.minecraft.world.item.BucketItem;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.material.Fluids;
 import org.apache.commons.io.FileUtils;
 
 import java.io.File;
@@ -529,6 +532,17 @@ public class KubeJSCommands {
 
 		for (var id : tags) {
 			player.sendSystemMessage(copy("'#" + id + "'", ChatFormatting.YELLOW, "Item Tag [" + IngredientPlatformHelper.get().tag(id.toString()).kjs$getStacks().size() + " items]"));
+		}
+
+		var item = stack.getItem();
+		if (item instanceof BucketItem) {
+			var fluid = ((BucketItem)item).arch$getFluid();
+			if (fluid != Fluids.EMPTY) {
+				List<ResourceLocation> fluidTags = Tags.byFluid(fluid).map(TagKey::location).toList();
+				for (var id : fluidTags) {
+					player.sendSystemMessage(copy("'#" + id + "'", ChatFormatting.LIGHT_PURPLE, "Fluid Tag [" + IngredientPlatformHelper.get().tag(id.toString()).kjs$getStacks().size() + "]"));
+				}
+			}
 		}
 
 		player.sendSystemMessage(copy("'@" + stack.kjs$getMod() + "'", ChatFormatting.AQUA, "Mod [" + IngredientPlatformHelper.get().mod(stack.kjs$getMod()).kjs$getStacks().size() + " items]"));


### PR DESCRIPTION
Add support for showing the fluid tags associated with the fluid contained by a BucketItem to the hand command.

<!-- These comments won't appear in the final PR, so you can just leave them here -->
### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->

Adds support for showing the fluid tags associated with the fluid contained by a BucketItem to the KubeJS hand command output.

This could be expanded to do the same for any fluid container, but I couldn't find a way of doing this with Architectury cross-platform API. If there is a way to do this and I've missed it, feel free to let me know and I'll open a future PR to add that functionality too.

#### Example Script <!-- Please provide an example script showing that the bug is fixed, or how the feature is used, if applicable -->
Expand the functionality of the hand command.

#### Other details <!-- Any other important information, like if this is likely to break addons -->
Not applicable.

#### Example Command Output

![output screenshot](https://github.com/KubeJS-Mods/KubeJS/assets/2759895/998dfb69-d7d8-4e70-9c57-fdc4c2fe00ad)