### PR TITLE
Fixed Shapeless Recipes ignoring output recipe NBT

### DIFF
--- a/fabric/src/main/java/dev/latvian/mods/kubejs/core/mixin/fabric/ShapedRecipeMixin.java
+++ b/fabric/src/main/java/dev/latvian/mods/kubejs/core/mixin/fabric/ShapedRecipeMixin.java
@@ -1,0 +1,54 @@
+package dev.latvian.mods.kubejs.core.mixin.fabric;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSyntaxException;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import dev.latvian.mods.rhino.mod.util.NBTUtils;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.TagParser;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(net.minecraft.world.item.crafting.ShapedRecipe.class)
+public class ShapedRecipeMixin {
+	@Inject(
+		method = "itemStackFromJson",
+		at = @At(
+			value = "RETURN",
+			remap = false
+		),
+		cancellable = false
+	)
+	private static void itemStackFromJson(JsonObject jsonObject, CallbackInfoReturnable<ItemStack> cir) {
+		if(cir.getReturnValue() == null || cir.getReturnValue() == ItemStack.EMPTY) {
+			return;
+		}
+
+		if(jsonObject.has("nbt")) {
+			var json = jsonObject.get("nbt");
+			// Process null
+			if (json == null || json.isJsonNull()) {
+				return;
+			}
+
+			try {
+				CompoundTag tag = null;
+				if (json.isJsonObject()) {
+					// We use a normal .toString() to convert the json to string, and read it as SNBT.
+					// Using DynamicOps would mess with the type of integers and cause things like damage comparisons to fail...
+					tag = TagParser.parseTag(json.toString());
+				} else {
+					// Assume it's a string representation of the NBT
+					tag = TagParser.parseTag(GsonHelper.convertToString(json, "nbt"));
+				}
+				cir.getReturnValue().getOrCreateTag().merge(tag);
+			} catch (CommandSyntaxException commandSyntaxException) {
+				throw new JsonSyntaxException("Invalid nbt tag: " + commandSyntaxException.getMessage());
+			}
+		}
+	}
+}

--- a/fabric/src/main/resources/kubejs-fabric.mixins.json
+++ b/fabric/src/main/resources/kubejs-fabric.mixins.json
@@ -8,6 +8,7 @@
 		"DifferenceIngredientMixin",
 		"IngredientMatchingMixin",
 		"NbtIngredientMixin",
+		"ShapedRecipeMixin",
 		"tools.shears.BlockInteractShearsMixin",
 		"tools.shears.EntityInteractShearsMixin",
 		"tools.shears.MatchToolMixin",


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->
### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->
Fix Issue #711
The issue was that shapeless recipes only parsed item ID and count from output, as opposed to ID, count, and NBT.
The way I fixed it was to copy NBTIngredient's logic for parsing NBT Tags, and apply that logic at a mixin to the return of the ShapelessRecipe's itemStackFromJson method.

#### Example Script <!-- Please provide an example script showing that the bug is fixed, or how the feature is used, if applicable -->
```js
ServerEvents.recipes(event => {
        // Strong NBT
	event.shapeless(
			Item.of('minecraft:wooden_sword', '{Damage:20}').strongNBT(),
			[Item.of('minecraft:stick')]
	)
        // Weak NBT
	event.shapeless(
			Item.of('minecraft:wooden_sword', '{Damage:20}').weakNBT(),
			[Item.of('minecraft:dirt')]
	)
        // Normal NBT
	event.shapeless(
			Item.of('minecraft:wooden_sword', '{Damage:20}'),
			[Item.of('minecraft:cobblestone')]
	)
})
```

#### Other details <!-- Any other important information, like if this is likely to break addons -->
![image](https://github.com/KubeJS-Mods/KubeJS/assets/73712365/4c7c38fb-6c4c-46df-9152-843ca7d648a0)
![image](https://github.com/KubeJS-Mods/KubeJS/assets/73712365/d5408160-48a0-4b1f-b311-a6f8d7bfbd09)
![image](https://github.com/KubeJS-Mods/KubeJS/assets/73712365/d0a542f3-bcf4-441d-80a4-555dbb8bf1d0)
