### PR TITLE
FEATURE: Added a CarpetBlockBuilder

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/BuiltinKubeJSPlugin.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/BuiltinKubeJSPlugin.java
@@ -34,6 +34,7 @@ import dev.latvian.mods.kubejs.block.MaterialJS;
 import dev.latvian.mods.kubejs.block.MaterialListJS;
 import dev.latvian.mods.kubejs.block.SoundTypeWrapper;
 import dev.latvian.mods.kubejs.block.custom.BasicBlockJS;
+import dev.latvian.mods.kubejs.block.custom.CarpetBlockBuilder;
 import dev.latvian.mods.kubejs.block.custom.CropBlockBuilder;
 import dev.latvian.mods.kubejs.block.custom.FallingBlockBuilder;
 import dev.latvian.mods.kubejs.block.custom.FenceBlockBuilder;
@@ -194,6 +195,7 @@ public class BuiltinKubeJSPlugin extends KubeJSPlugin {
 		RegistryInfo.BLOCK.addType("falling", FallingBlockBuilder.class, FallingBlockBuilder::new);
 		RegistryInfo.BLOCK.addType("crop", CropBlockBuilder.class, CropBlockBuilder::new);
 		RegistryInfo.BLOCK.addType("cardinal", HorizontalDirectionalBlockBuilder.class, HorizontalDirectionalBlockBuilder::new);
+		RegistryInfo.BLOCK.addType("carpet", CarpetBlockBuilder.class, CarpetBlockBuilder::new);
 
 		RegistryInfo.ITEM.addType("basic", BasicItemJS.Builder.class, BasicItemJS.Builder::new);
 		RegistryInfo.ITEM.addType("sword", SwordItemBuilder.class, SwordItemBuilder::new);

--- a/common/src/main/java/dev/latvian/mods/kubejs/block/custom/CarpetBlockBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/custom/CarpetBlockBuilder.java
@@ -1,0 +1,40 @@
+package dev.latvian.mods.kubejs.block.custom;
+
+import dev.latvian.mods.kubejs.client.VariantBlockStateGenerator;
+import dev.latvian.mods.kubejs.generator.AssetJsonGenerator;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.CarpetBlock;
+
+public class CarpetBlockBuilder extends ShapedBlockBuilder {
+	public CarpetBlockBuilder(ResourceLocation i) {
+		super(i, "_carpet");
+		tagBoth(BlockTags.WOOL_CARPETS.location());
+	}
+
+	@Override
+	public Block createObject() {
+		return new CarpetBlock(createProperties());
+	}
+
+	@Override
+	protected void generateBlockStateJson(VariantBlockStateGenerator bs) {
+		var mod = newID("block/", "").toString();
+		bs.variant("", (v) -> v.model(mod));
+	}
+
+	@Override
+	protected void generateBlockModelJsons(AssetJsonGenerator generator) {
+		var texture = textures.get("texture").getAsString();
+
+		generator.blockModel(id, m -> {
+			m.parent("minecraft:block/carpet");
+			m.texture("wool", texture);
+		});
+	}
+
+	public CarpetBlockBuilder texture(String texture) {
+		return (CarpetBlockBuilder) textureAll(texture);
+	}
+}


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->
### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->
Added a new Carpet block builder that mimics vanilla carpets.

![image](https://github.com/KubeJS-Mods/KubeJS/assets/73712365/c6dfe304-deaf-495b-b8cc-625fd0cb2edf)


#### Example Script <!-- Please provide an example script showing that the bug is fixed, or how the feature is used, if applicable -->
```js
StartupEvents.registry('block', (event) => {
	event.create('tnt_carpet', 'carpet')
			.material('minecraft:wool')
			.displayName('TNT Carpet')
			.texture('minecraft:block/tnt_side')
})
```

#### Other details <!-- Any other important information, like if this is likely to break addons -->