### PR TITLE
fix event handler to persist script registry order (1.20.1) 

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/event/EventHandler.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/event/EventHandler.java
@@ -14,8 +14,8 @@ import dev.latvian.mods.rhino.util.HideFromJS;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
-import java.util.HashSet;
-import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -142,7 +142,7 @@ public final class EventHandler extends BaseFunction {
 			map = eventContainers;
 		} else {
 			if (extraEventContainers == null) {
-				extraEventContainers = extra.identity ? new IdentityHashMap<>() : new HashMap<>();
+				extraEventContainers = extra.identity ? new LinkedHashMap<>() : new HashMap<>();
 			}
 
 			map = extraEventContainers.get(extraId);
@@ -362,7 +362,7 @@ public final class EventHandler extends BaseFunction {
 			return Set.of();
 		}
 
-		var set = new HashSet<>();
+		var set = new LinkedHashSet<>();
 
 		forEachListener(type, c -> {
 			if (c.extraId != null) {


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->
### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->
This change now persists register order as in JavaScript side.
