### PR TITLE
 Implement Localization Support for CreativeTabs Titles

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/item/creativetab/KubeJSCreativeTabs.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/item/creativetab/KubeJSCreativeTabs.java
@@ -9,16 +9,15 @@ import dev.latvian.mods.kubejs.registry.RegistryInfo;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.CreativeModeTab;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Items;
 
 public class KubeJSCreativeTabs {
 	public static final DeferredRegister<CreativeModeTab> REGISTER = DeferredRegister.create(KubeJS.MOD_ID, Registries.CREATIVE_MODE_TAB);
 
-	public static void init() {
+	public static void init() {	
 		if (!CommonProperties.get().serverOnly) {
 			REGISTER.register("tab", () -> MiscPlatformHelper.get().creativeModeTab(
-				Component.literal("KubeJS"),
+				Component.translatable("itemGroup.kubejs.tab"),
 				() -> {
 					var is = ItemStackJS.of(CommonProperties.get().creativeModeTabIcon);
 					return is.isEmpty() ? Items.PURPLE_DYE.getDefaultInstance() : is;
@@ -29,7 +28,6 @@ public class KubeJSCreativeTabs {
 					}
 				}
 			));
-
 			REGISTER.register();
 		}
 	}

--- a/common/src/main/resources/assets/kubejs/lang/en_us.json
+++ b/common/src/main/resources/assets/kubejs/lang/en_us.json
@@ -1,3 +1,3 @@
 {
-	"itemGroup.kubejs.tab": "test"
+	"itemGroup.kubejs.tab": "KubeJS"
 }

--- a/common/src/main/resources/assets/kubejs/lang/en_us.json
+++ b/common/src/main/resources/assets/kubejs/lang/en_us.json
@@ -1,0 +1,3 @@
+{
+	"itemGroup.kubejs.tab": "test"
+}


### PR DESCRIPTION
While working on KubeJS, I encountered an issue where I couldn't modify the titles of CreativeTabs due to their titles being hard-coded. After reviewing the code, I decided to fork the repository and implement a solution that replaces the hard-coded titles with localizable key names. This modification allows the titles of CreativeTabs to be defined in localization files, enhancing flexibility and supporting multiple languages. Additionally, I have included an en_us language file to demonstrate the localization support.

Please review this change for potential inclusion in the main branch. This update should make CreativeTabs more versatile and accessible for modders looking to support multiple languages in their Minecraft mods.

Thank you for considering this pull request.