### PR TITLE
Add hurtEnemy callback to ItemBuilder (1.20.4)

### DIFF
--- a/src/main/java/dev/latvian/mods/kubejs/core/mixin/common/ItemMixin.java
+++ b/src/main/java/dev/latvian/mods/kubejs/core/mixin/common/ItemMixin.java
@@ -209,6 +209,13 @@ public abstract class ItemMixin implements ItemKJS {
 		}
 	}
 
+	@Inject(method = "hurtEnemy", at = @At("HEAD"), cancellable = true)
+	private void hurtEnemy(ItemStack itemStack, LivingEntity livingEntity, LivingEntity livingEntity2, CallbackInfoReturnable<Boolean> cir) {
+		if (kjs$itemBuilder != null && kjs$itemBuilder.hurtEnemy != null) {
+			cir.setReturnValue(kjs$itemBuilder.hurtEnemy.test(new ItemBuilder.HurtEnemyContext(itemStack, livingEntity, livingEntity2)));
+		}
+	}
+
 	@Override
 	public Ingredient kjs$asIngredient() {
 		if (kjs$asIngredient == null) {

--- a/src/main/java/dev/latvian/mods/kubejs/item/ItemBuilder.java
+++ b/src/main/java/dev/latvian/mods/kubejs/item/ItemBuilder.java
@@ -39,6 +39,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.ToIntFunction;
 
 @SuppressWarnings({"unused", "UnusedReturnValue"})
@@ -110,6 +111,7 @@ public abstract class ItemBuilder extends BuilderBase<Item> {
 	public transient UseCallback use;
 	public transient FinishUsingCallback finishUsing;
 	public transient ReleaseUsingCallback releaseUsing;
+	public transient Predicate<HurtEnemyContext> hurtEnemy;
 
 	public String texture;
 	public String parentModel;
@@ -137,6 +139,7 @@ public abstract class ItemBuilder extends BuilderBase<Item> {
 		finishUsing = null;
 		releaseUsing = null;
 		fireResistant = false;
+		hurtEnemy = null;
 	}
 
 	@Override
@@ -427,6 +430,16 @@ public abstract class ItemBuilder extends BuilderBase<Item> {
 		return this;
 	}
 
+	@Info("""
+		Gets called when the item is used to hurt an entity.
+		
+		For example, when using a sword to hit a mob, this is called.
+		""")
+	public ItemBuilder hurtEnemy(Predicate<HurtEnemyContext> context) {
+		this.hurtEnemy = context;
+		return this;
+	}
+
 	@FunctionalInterface
 	public interface UseCallback {
 		boolean use(Level level, Player player, InteractionHand interactionHand);
@@ -446,4 +459,6 @@ public abstract class ItemBuilder extends BuilderBase<Item> {
 	public interface NameCallback {
 		Component apply(ItemStack itemStack);
 	}
+
+	public record HurtEnemyContext(ItemStack getItem, LivingEntity getTarget, LivingEntity getAttacker) {}
 }


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->
### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->
Port of my other PR for the `hurtEnemy` callback to 1.20.4.


#### Example Script <!-- Please provide an example script showing that the bug is fixed, or how the feature is used, if applicable -->
```js
StartupEvents.registry('item', event => {
	event.create('test')
		.hurtEnemy(ctx => {
		console.log([ctx.item, ctx.target, ctx.attacker])
		global.attackTest(ctx)
		return true
	})
})

global.attackTest = function(ctx) {
	let exp = ctx.target.level.createExplosion(ctx.target.x, ctx.target.y + 1, ctx.target.z)
	exp.strength(1.25)
	exp.explode()
}
```

#### Other details <!-- Any other important information, like if this is likely to break addons -->