### PR TITLE
enables customizable bucket models to fluid builder

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/fluid/FluidBucketItemBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/fluid/FluidBucketItemBuilder.java
@@ -21,6 +21,21 @@ public class FluidBucketItemBuilder extends ItemBuilder {
 
 	@Override
 	public void generateAssetJsons(AssetJsonGenerator generator) {
-		generator.itemModel(id, m -> m.parent("kubejs:item/generated_bucket"));
+		if (modelJson != null) {
+			generator.json(AssetJsonGenerator.asItemModelLocation(id), modelJson);
+			return;
+		}
+
+		generator.itemModel(id, m -> {
+			if (!parentModel.isEmpty()) {
+				m.parent(parentModel);
+			} else {
+				m.parent("kubejs:item/generated_bucket");
+			}
+
+			if (textureJson.size() > 0) {
+				m.textures(textureJson);
+			}
+		});
 	}
 }


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->
### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->
Current implementation is overriding any kind of model customization on the FluidBucketItemBuilder.
This PR adds some checks and use those if defined.


#### Example Script <!-- Please provide an example script showing that the bug is fixed, or how the feature is used, if applicable -->
at client_scripts
```js
ClientEvents.highPriorityAssets(event => {
  event.addModel("item", "kubejs:milk_bucket", generator => {
    generator.parent("item/generated")
    generator.textures({
      layer0: "kubejs:item/special_bucket",
      layer1: "kubejs:item/milk_topping"
    })
  })
  event.addModel("item", "kubejs:milkshake_bucket", generator => {
    generator.parent("item/generated")
    generator.textures({
      layer0: "kubejs:item/special_bucket",
      layer1: "kubejs:item/milkshake_topping"
    })
  })
})
```
at startup_scripts
```js
StartupEvents.registry("fluid", (event) => {
  let milkBucketsList = [
    ["azalea_flowers", "COMMON", 0xa13f9e],
    ["banana", "COMMON", 0xfbfabd],
    ["coco", "COMMON", 0x744e33],
    ["coconut", "COMMON", 0xf3f3e3],
    ["coffee", "COMMON", 0x87500d],
    ["maple_syrup", "COMMON", 0xc45116],
    ["matcha", "COMMON", 0xc8cf5c],
    ["mint", "COMMON", 0x6cd189],
    ["honey", "COMMON", 0xfcec8c],
    ["lush_fruit", "COMMON", 0xd0488d],
    ["sweet_berries", "COMMON", 0x891d1d],
    ["glittering_dust", "COMMON", 0x56dca3]
  ]

  let milkBuckets = (name, rarity, color) => {
    event
      .create(name + "_milk")
      .thickTexture(color)
      .color(color)
      .bucketItem
      .parentModel("kubejs:item/milk_bucket")
      .rarity(rarity)

    event
      .create(name + "_milkshake")
      .thickTexture(color)
      .color(color)
      .bucketItem
      .parentModel("kubejs:item/milkshake_bucket")
      .rarity(rarity)
  }

  milkBucketsList.forEach((bucket) => {
    milkBuckets(bucket[0], bucket[1], bucket[2])
  })

  event
    .create("regular_fluid")
    .thickTexture(0xfcec8c)
    .color(0xfcec8c)
})
```

Required files at `kubejs/assets/kubejs/textures/item/`
[textures.zip](https://github.com/KubeJS-Mods/KubeJS/files/15234103/textures.zip)

## Before the PR
![fluid_builder_not_working](https://github.com/KubeJS-Mods/KubeJS/assets/97140255/9b897f24-7c11-4e1f-9360-df1edd1a9611)

## After the PR (added regular_fluid to show default working as intended)
![fluid_builder_working](https://github.com/KubeJS-Mods/KubeJS/assets/97140255/fc33e0af-d881-4aea-9871-9ced55eea451)



#### Other details <!-- Any other important information, like if this is likely to break addons -->
Tested on Fabric and Forge.