### PR TITLE
use `this.x = x` instead of `x = _x`

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/client/VariantBlockStateGenerator.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/client/VariantBlockStateGenerator.java
@@ -47,13 +47,13 @@ public class VariantBlockStateGenerator {
 			return this;
 		}
 
-		public Model x(int _x) {
-			x = _x;
+		public Model x(int x) {
+			this.x = x;
 			return this;
 		}
 
-		public Model y(int _y) {
-			y = _y;
+		public Model y(int y) {
+			this.y = y;
 			return this;
 		}
 

--- a/common/src/main/java/dev/latvian/mods/kubejs/level/ExplosionJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/level/ExplosionJS.java
@@ -12,11 +12,11 @@ public class ExplosionJS {
 	public boolean causesFire;
 	public Level.ExplosionInteraction explosionMode;
 
-	public ExplosionJS(LevelAccessor l, double _x, double _y, double _z) {
+	public ExplosionJS(LevelAccessor l, double x, double y, double z) {
 		level = l;
-		x = _x;
-		y = _y;
-		z = _z;
+		this.x = x;
+		this.y = y;
+		this.z = z;
 		exploder = null;
 		strength = 3F;
 		causesFire = false;

--- a/common/src/main/java/dev/latvian/mods/kubejs/recipe/RecipeJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/recipe/RecipeJS.java
@@ -204,8 +204,8 @@ public class RecipeJS implements RecipeKJS, CustomJavaToJsWrapper {
 		changed = true;
 	}
 
-	public RecipeJS id(ResourceLocation _id) {
-		id = _id;
+	public RecipeJS id(ResourceLocation id) {
+		this.id = id;
 		save();
 		return this;
 	}


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->
### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->

Use `this.x = x` instead of `x = _x` to make the parameter name more intuitive