### PR TITLE
DRAFT: Use Locale.ROOT for converting script file names to lower case

### DIFF
--- a/src/main/java/dev/latvian/mods/kubejs/script/ScriptFileInfo.java
+++ b/src/main/java/dev/latvian/mods/kubejs/script/ScriptFileInfo.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -32,7 +33,7 @@ public class ScriptFileInfo {
 	public ScriptFileInfo(ScriptPackInfo p, String f) {
 		pack = p;
 		file = f;
-		id = ResourceLocation.fromNamespaceAndPath(pack.namespace, FILE_FIXER.matcher(pack.pathStart + file).replaceAll("_").toLowerCase());
+		id = ResourceLocation.fromNamespaceAndPath(pack.namespace, FILE_FIXER.matcher(pack.pathStart + file).replaceAll("_").toLowerCase(Locale.ROOT));
 		location = ID.string(pack.namespace + ":" + pack.pathStart + file);
 		properties = new HashMap<>();
 		priority = 0;


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->
### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->
This prevents an issue faced by players with the Turkish language, as an uppercase I is changed to a lowercase dotless ı in that locale, which is not a valid character for resource names.



#### Example Script <!-- Please provide an example script showing that the bug is fixed, or how the feature is used, if applicable -->
Any script with a capital I in the file name should trigger the bug before this pr, when using the turkish locale via `-Duser.language=tr` to force the turkish language for minecraft. Note that MultiMC automatically add `-Duser.language=en` after the java arguments from the user, masking this bug even when trying to trigger it.

#### Other details <!-- Any other important information, like if this is likely to break addons -->
This is currently a draft since i want to discuss what other instances of toLowerCase/toUpperCase should be changed to include the root locale.

Edit: as a workaround players can add `-Duser.language=en` to their Java arguments.

Here is an example crash from a player that had this issue:
[crash-2024-06-01_03.45.49-fml.txt](https://github.com/user-attachments/files/15938019/crash-2024-06-01_03.45.49-fml.txt)
