### PR TITLE
Implement texture handling for BlockItemBuilder texture overrides

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/block/BlockBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/block/BlockBuilder.java
@@ -218,11 +218,17 @@ public abstract class BlockBuilder extends BuilderBase<Block> {
 	}
 
 	protected void generateItemModelJson(ModelGenerator m) {
-		if (!model.isEmpty()) {
-			m.parent(model);
+		if (itemBuilder.textureJson.size() != 0) {
+			m.parent("minecraft:item/generated");
 		} else {
-			m.parent(newID("block/", "").toString());
+			if (!model.isEmpty()) {
+				m.parent(model);
+			} else {
+				m.parent(newID("block/", "").toString());
+			}
+			itemBuilder.texture(newID("item/", "").toString());
 		}
+		m.textures(itemBuilder.textureJson);
 	}
 
 	protected void generateBlockModelJsons(AssetJsonGenerator generator) {


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->

### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->

`BlockItemBuilder`s ignore texture overrides provided via the `.texture` method, preventing scripters from changing a block item's texture without a workaround. See https://discord.com/channels/303440391124942858/1098748984572518440 . This fix attempts to mimic the behavior of `ItemBuilder` which handles this data correctly, but its `generateAssetJsons` method is overridden by `BlockItemBuilder`.

#### Example Script <!-- Please provide an example script showing that the bug is fixed, or how the feature is used, if applicable -->

```js
// kubejs/startup/example.js
StartupEvents.registry('block', event => {
    event.create('dirt_pile')
        .model("kubejs:block/dirt_pile")
        .item(builder => {
            builder
                .displayName("Pile o' Dirt")
                // This workaround works because the modelJson attribute is processed in `generateItemModelJson`
                // .modelJson({
                //     parent: 'minecraft:item/generated',
                //     textures: {
                //       layer0: 'kubejs:item/dirt_pile',
                //     },
                // })
                // ...but this doesn't, because the textureJson attribute is not, and this item will have the parent model texture
                .texture("kubejs:item/dirt_pile")
        })
})
```

#### Other details <!-- Any other important information, like if this is likely to break addons -->

I'm very new to this codebase and MC modding in general so there is probably something I've overlooked :)