### PR TITLE
Add some utils to `RegistryWrapper`

### DIFF
--- a/src/main/java/dev/latvian/mods/kubejs/bindings/HolderSetWrapper.java
+++ b/src/main/java/dev/latvian/mods/kubejs/bindings/HolderSetWrapper.java
@@ -1,0 +1,67 @@
+package dev.latvian.mods.kubejs.bindings;
+
+import com.google.common.collect.Iterators;
+import dev.latvian.mods.kubejs.util.UtilsJS;
+import net.minecraft.core.Holder;
+import net.minecraft.core.HolderSet;
+import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.RandomSource;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public record HolderSetWrapper<T>(Registry<T> registry, HolderSet<T> holders) implements Iterable<T> {
+
+	public int size() {
+		return holders.size();
+	}
+
+	public boolean isEmpty() {
+		return holders.size() == 0;
+	}
+
+	public boolean contains(ResourceLocation id) {
+		return registry.getHolder(id).filter(holders::contains).isPresent();
+	}
+
+	public boolean containsValue(T value) {
+		return holders.contains(registry.wrapAsHolder(value));
+	}
+
+	public List<T> getValues() {
+		return holders.stream().map(Holder::value).toList();
+	}
+
+	public Set<ResourceLocation> getKeys() {
+		return holders.stream().map(holder -> {
+			var key = holder.getKey();
+			if (key == null) {
+				return null;
+			}
+
+			return key.location();
+		}).filter(Objects::nonNull).collect(Collectors.toSet());
+	}
+
+	@Nullable
+	public T getRandom() {
+		return getRandom(UtilsJS.RANDOM);
+	}
+
+	@Nullable
+	public T getRandom(RandomSource random) {
+		return holders.getRandomElement(random).map(Holder::value).orElse(null);
+	}
+
+	@NotNull
+	@Override
+	public Iterator<T> iterator() {
+		return Iterators.transform(holders.iterator(), Holder::value);
+	}
+}

--- a/src/main/java/dev/latvian/mods/kubejs/bindings/RegistryWrapper.java
+++ b/src/main/java/dev/latvian/mods/kubejs/bindings/RegistryWrapper.java
@@ -1,16 +1,22 @@
 package dev.latvian.mods.kubejs.bindings;
 
+import dev.latvian.mods.kubejs.holder.HolderWrapper;
 import dev.latvian.mods.kubejs.util.RegistryAccessContainer;
+import dev.latvian.mods.kubejs.util.UtilsJS;
 import dev.latvian.mods.rhino.Context;
+import net.minecraft.core.Holder;
+import net.minecraft.core.HolderSet;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.RandomSource;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -27,6 +33,10 @@ public record RegistryWrapper<T>(Registry<T> registry, ResourceKey<T> unknownKey
 		return registry.containsKey(id);
 	}
 
+	public boolean containsValue(T value) {
+		return registry.containsValue(value);
+	}
+
 	public Set<Map.Entry<ResourceLocation, T>> getEntrySet() {
 		return registry.entrySet().stream().map(e -> Map.entry(e.getKey().location(), e.getValue())).collect(Collectors.toSet());
 	}
@@ -35,12 +45,27 @@ public record RegistryWrapper<T>(Registry<T> registry, ResourceKey<T> unknownKey
 		return registry.entrySet().stream().collect(Collectors.toMap(e -> e.getKey().location(), Map.Entry::getValue));
 	}
 
+	public HolderSetWrapper<T> getValues(Object filter) {
+		var holderSet = HolderWrapper.wrapSimpleSet(registry, filter);
+		return new HolderSetWrapper<>(registry, Objects.requireNonNullElseGet(holderSet, HolderSet::empty));
+	}
+
 	public List<T> getValues() {
 		return registry.stream().collect(Collectors.toList());
 	}
 
 	public Set<ResourceLocation> getKeys() {
 		return registry.keySet();
+	}
+
+	@Nullable
+	public T getRandom() {
+		return getRandom(UtilsJS.RANDOM);
+	}
+
+	@Nullable
+	public T getRandom(RandomSource random) {
+		return registry.getRandom(random).map(Holder::value).orElse(null);
 	}
 
 	@Nullable

--- a/src/main/java/dev/latvian/mods/kubejs/bindings/UtilsWrapper.java
+++ b/src/main/java/dev/latvian/mods/kubejs/bindings/UtilsWrapper.java
@@ -12,6 +12,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.stats.Stat;
 import net.minecraft.stats.Stats;
+import net.minecraft.util.RandomSource;
 import net.minecraft.world.item.CreativeModeTab;
 import org.jetbrains.annotations.Nullable;
 
@@ -28,13 +29,13 @@ import java.util.regex.Pattern;
 @Info("A collection of utilities")
 public interface UtilsWrapper {
 	@Info("Get a Random, for generating random numbers. Note this will always return the same Random instance")
-	static Random getRandom() {
+	static RandomSource getRandom() {
 		return UtilsJS.RANDOM;
 	}
 
 	@Info("Get a new random with the specified seed")
-	static Random newRandom(long seed) {
-		return new Random(seed);
+	static RandomSource newRandom(long seed) {
+		return RandomSource.create(seed);
 	}
 
 	@Info("Get an immutable empty list")

--- a/src/main/java/dev/latvian/mods/kubejs/util/UtilsJS.java
+++ b/src/main/java/dev/latvian/mods/kubejs/util/UtilsJS.java
@@ -24,6 +24,7 @@ import net.minecraft.nbt.NumericTag;
 import net.minecraft.nbt.StringTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.RandomSource;
 import net.minecraft.world.item.CreativeModeTab;
 import org.jetbrains.annotations.Nullable;
 
@@ -48,7 +49,7 @@ import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 public class UtilsJS {
-	public static final Random RANDOM = new Random();
+	public static final RandomSource RANDOM = RandomSource.create();
 	public static final ResourceLocation AIR_LOCATION = ResourceLocation.parse("minecraft:air");
 	public static final Pattern SNAKE_CASE_SPLIT = Pattern.compile("[:_/]");
 	public static final Set<String> ALWAYS_LOWER_CASE = new HashSet<>(Arrays.asList("a", "an", "the", "of", "on", "in", "and", "or", "but", "for"));


### PR DESCRIPTION
Adds some utils to the RegistryWrapper and also creates a HolderSetWrapper. 
Also changed Utils.RANDOM to use `RandomSource` which is the default random generator minecraft uses.

Example uses biomes, so it's for server events where tags already are bound.
```js
const tag = "#minecraft:is_savanna";
const registry = Registry.of("worldgen/biome");
const holders = registry.getValues(tag);
const biome = registry.getRandom();
const biomeId = registry.getId(biome);
const biome2 = holders.getRandom();
const biome2Id = registry.getId(biome2);

console.log(`All savanna biomes: ${holders.keys}`)
console.log(`Biome: ${biomeId} contains in ${tag}: ${holders.containsValue(biome)} / ${holders.contains(biomeId)}`);
console.log(`Biome 2: ${biome2Id} contains in ${tag}: ${holders.containsValue(biome2)} / ${holders.contains(biome2Id)}`);
console.log(`Biomes do exist: ${registry.containsValue(biome)} / ${registry.containsValue(biome2)}`);
console.log(registry.getValues(tag).size());
```