### PR TITLE
[1.21] SoundEvent and ParticleType Utilities

### DIFF
--- a/src/main/java/dev/latvian/mods/kubejs/bindings/event/ClientEvents.java
+++ b/src/main/java/dev/latvian/mods/kubejs/bindings/event/ClientEvents.java
@@ -7,6 +7,7 @@ import dev.latvian.mods.kubejs.client.DebugInfoKubeEvent;
 import dev.latvian.mods.kubejs.client.EntityRendererRegistryKubeEvent;
 import dev.latvian.mods.kubejs.client.LangKubeEvent;
 import dev.latvian.mods.kubejs.client.MenuScreenRegistryKubeEvent;
+import dev.latvian.mods.kubejs.client.ParticleProviderRegistryKubeEvent;
 import dev.latvian.mods.kubejs.event.EventGroup;
 import dev.latvian.mods.kubejs.event.EventHandler;
 import dev.latvian.mods.kubejs.event.EventTargetType;
@@ -29,4 +30,5 @@ public interface ClientEvents {
 	EventHandler DEBUG_RIGHT = GROUP.client("rightDebugInfo", () -> DebugInfoKubeEvent.class);
 	TargetedEventHandler<ResourceLocation> ATLAS_SPRITE_REGISTRY = GROUP.client("atlasSpriteRegistry", () -> AtlasSpriteRegistryKubeEvent.class).requiredTarget(EventTargetType.ID);
 	TargetedEventHandler<String> LANG = GROUP.client("lang", () -> LangKubeEvent.class).requiredTarget(EventTargetType.STRING);
+	EventHandler PARTICLE_PROVIDER_REGISTRY = GROUP.client("particleProviderRegistry", () -> ParticleProviderRegistryKubeEvent.class);
 }

--- a/src/main/java/dev/latvian/mods/kubejs/client/ClientAssetPacks.java
+++ b/src/main/java/dev/latvian/mods/kubejs/client/ClientAssetPacks.java
@@ -61,6 +61,8 @@ public class ClientAssetPacks {
 
 		KubeJSPlugins.forEachPlugin(internalAssetPack, KubeJSPlugin::generateAssets);
 
+		internalAssetPack.buildSounds();
+
 		var langMap = new HashMap<LangKubeEvent.Key, String>();
 		var langEvents = new HashMap<String, LangKubeEvent>();
 		var enUsLangEvent = langEvents.computeIfAbsent("en_us", s -> new LangKubeEvent(s, langMap));

--- a/src/main/java/dev/latvian/mods/kubejs/client/KubeAnimatedParticle.java
+++ b/src/main/java/dev/latvian/mods/kubejs/client/KubeAnimatedParticle.java
@@ -7,12 +7,18 @@ import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.particle.SimpleAnimatedParticle;
 import net.minecraft.client.particle.SpriteSet;
 import net.minecraft.util.RandomSource;
+import net.minecraft.world.phys.Vec3;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.function.Consumer;
 
 public class KubeAnimatedParticle extends SimpleAnimatedParticle {
 
 	private Float2IntFunction lightColorFunction;
+	@Nullable
+	private Consumer<KubeAnimatedParticle> onTick;
 
-	protected KubeAnimatedParticle(ClientLevel level, double x, double y, double z, SpriteSet sprites) {
+	public KubeAnimatedParticle(ClientLevel level, double x, double y, double z, SpriteSet sprites) {
 		super(level, x, y, z, sprites, 0.0125F);
 		setLifetime(20);
 		setSpriteFromAge(sprites);
@@ -51,6 +57,14 @@ public class KubeAnimatedParticle extends SimpleAnimatedParticle {
 		lightColorFunction = function;
 	}
 
+	public void onTick(@Nullable Consumer<KubeAnimatedParticle> tick) {
+		onTick = tick;
+	}
+
+	public void setSpeed(Vec3 speed) {
+		setParticleSpeed(speed.x(), speed.y(), speed.z());
+	}
+
 	// Getters for protected values
 
 	public ClientLevel getLevel() {	return level; }
@@ -66,5 +80,13 @@ public class KubeAnimatedParticle extends SimpleAnimatedParticle {
 	@Override
 	public int getLightColor(float partialTick) {
 		return lightColorFunction.get(partialTick);
+	}
+
+	@Override
+	public void tick() {
+		super.tick();
+		if (onTick != null) {
+			onTick.accept(this);
+		}
 	}
 }

--- a/src/main/java/dev/latvian/mods/kubejs/client/KubeAnimatedParticle.java
+++ b/src/main/java/dev/latvian/mods/kubejs/client/KubeAnimatedParticle.java
@@ -8,11 +8,11 @@ import net.minecraft.client.particle.SimpleAnimatedParticle;
 import net.minecraft.client.particle.SpriteSet;
 import net.minecraft.util.RandomSource;
 
-public class kubeAnimatedParticle extends SimpleAnimatedParticle {
+public class KubeAnimatedParticle extends SimpleAnimatedParticle {
 
 	private Float2IntFunction lightColorFunction;
 
-	protected kubeAnimatedParticle(ClientLevel level, double x, double y, double z, SpriteSet sprites) {
+	protected KubeAnimatedParticle(ClientLevel level, double x, double y, double z, SpriteSet sprites) {
 		super(level, x, y, z, sprites, 0.0125F);
 		setLifetime(20);
 		setSpriteFromAge(sprites);

--- a/src/main/java/dev/latvian/mods/kubejs/client/KubeJSModClientEventHandler.java
+++ b/src/main/java/dev/latvian/mods/kubejs/client/KubeJSModClientEventHandler.java
@@ -37,6 +37,7 @@ import net.neoforged.neoforge.client.event.EntityRenderersEvent;
 import net.neoforged.neoforge.client.event.RegisterColorHandlersEvent;
 import net.neoforged.neoforge.client.event.RegisterKeyMappingsEvent;
 import net.neoforged.neoforge.client.event.RegisterMenuScreensEvent;
+import net.neoforged.neoforge.client.event.RegisterParticleProvidersEvent;
 import net.neoforged.neoforge.client.event.RegisterShadersEvent;
 import net.neoforged.neoforge.client.extensions.common.IClientFluidTypeExtensions;
 import net.neoforged.neoforge.client.extensions.common.RegisterClientExtensionsEvent;
@@ -174,6 +175,13 @@ public class KubeJSModClientEventHandler {
 					}
 				}, b.get());
 			}
+		}
+	}
+
+	@SubscribeEvent
+	public static void registerParticleProviders(RegisterParticleProvidersEvent event) {
+		if (ClientEvents.PARTICLE_PROVIDER_REGISTRY.hasListeners()) {
+			ClientEvents.PARTICLE_PROVIDER_REGISTRY.post(new ParticleProviderRegistryKubeEvent(event));
 		}
 	}
 }

--- a/src/main/java/dev/latvian/mods/kubejs/client/ParticleGenerator.java
+++ b/src/main/java/dev/latvian/mods/kubejs/client/ParticleGenerator.java
@@ -1,0 +1,30 @@
+package dev.latvian.mods.kubejs.client;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ParticleGenerator {
+
+	public transient List<String> textures = new ArrayList<>();
+
+	public ParticleGenerator texture(String texture) {
+		textures.add(texture);
+		return this;
+	}
+
+	public ParticleGenerator textures(List<String> textures) {
+		this.textures = textures;
+		return this;
+	}
+
+	public JsonObject toJson() {
+		var array = new JsonArray(textures.size());
+		textures.forEach(array::add);
+		var json = new JsonObject();
+		json.add("textures", array);
+		return json;
+	}
+}

--- a/src/main/java/dev/latvian/mods/kubejs/client/ParticleProviderRegistryKubeEvent.java
+++ b/src/main/java/dev/latvian/mods/kubejs/client/ParticleProviderRegistryKubeEvent.java
@@ -1,0 +1,15 @@
+package dev.latvian.mods.kubejs.client;
+
+import dev.latvian.mods.kubejs.event.KubeEvent;
+import net.neoforged.neoforge.client.event.RegisterParticleProvidersEvent;
+
+public class ParticleProviderRegistryKubeEvent implements KubeEvent {
+
+	private final RegisterParticleProvidersEvent parent;
+
+	public ParticleProviderRegistryKubeEvent(RegisterParticleProvidersEvent event) {
+		parent = event;
+	}
+
+	// TODO: Oh dear
+}

--- a/src/main/java/dev/latvian/mods/kubejs/client/ParticleProviderRegistryKubeEvent.java
+++ b/src/main/java/dev/latvian/mods/kubejs/client/ParticleProviderRegistryKubeEvent.java
@@ -1,6 +1,5 @@
 package dev.latvian.mods.kubejs.client;
 
-import dev.latvian.mods.kubejs.event.KubeEvent;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.particle.Particle;
 import net.minecraft.client.particle.ParticleEngine;
@@ -12,7 +11,7 @@ import net.neoforged.neoforge.client.event.RegisterParticleProvidersEvent;
 
 import java.util.function.Consumer;
 
-public class ParticleProviderRegistryKubeEvent implements KubeEvent {
+public class ParticleProviderRegistryKubeEvent implements ClientKubeEvent {
 
 	private final RegisterParticleProvidersEvent parent;
 

--- a/src/main/java/dev/latvian/mods/kubejs/client/ParticleProviderRegistryKubeEvent.java
+++ b/src/main/java/dev/latvian/mods/kubejs/client/ParticleProviderRegistryKubeEvent.java
@@ -1,7 +1,16 @@
 package dev.latvian.mods.kubejs.client;
 
 import dev.latvian.mods.kubejs.event.KubeEvent;
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.client.particle.Particle;
+import net.minecraft.client.particle.ParticleEngine;
+import net.minecraft.client.particle.ParticleProvider;
+import net.minecraft.client.particle.SpriteSet;
+import net.minecraft.core.particles.ParticleOptions;
+import net.minecraft.core.particles.ParticleType;
 import net.neoforged.neoforge.client.event.RegisterParticleProvidersEvent;
+
+import java.util.function.Consumer;
 
 public class ParticleProviderRegistryKubeEvent implements KubeEvent {
 
@@ -11,5 +20,33 @@ public class ParticleProviderRegistryKubeEvent implements KubeEvent {
 		parent = event;
 	}
 
-	// TODO: Oh dear
+	public <T extends ParticleOptions> void register(ParticleType<T> type, SpriteSetParticleProvider<T> spriteProvider) {
+		parent.registerSpriteSet(type, spriteProvider);
+	}
+
+	public <T extends ParticleOptions> void register(ParticleType<T> type, Consumer<KubeAnimatedParticle> particle) {
+		parent.registerSpriteSet(type, set -> (type1, level, x, y, z, xSpeed, ySpeed, zSpeed) -> {
+				var kube = new KubeAnimatedParticle(level, x, y, z, set);
+				kube.setParticleSpeed(xSpeed, ySpeed, zSpeed);
+				particle.accept(kube);
+				return kube;
+		});
+	}
+
+	public <T extends ParticleOptions> void register(ParticleType<T> type) {
+		register(type, p -> {});
+	}
+
+	public <T extends ParticleOptions> void registerSpecial(ParticleType<T> type, ParticleProvider<T> provider) {
+		parent.registerSpecial(type, provider);
+	}
+
+	@FunctionalInterface
+	public interface SpriteSetParticleProvider<T extends ParticleOptions> extends ParticleEngine.SpriteParticleRegistration<T> {
+		Particle create(T type, ClientLevel clientLevel, double x, double y, double z, SpriteSet sprites, double xSpeed, double ySpeed, double zSpeed);
+
+		default ParticleProvider<T> create(SpriteSet sprites) {
+			return (type, level, x, y, z, xSpeed, ySpeed, zSpeed) -> create(type, level, x, y, z, sprites, xSpeed, ySpeed, zSpeed);
+		}
+	}
 }

--- a/src/main/java/dev/latvian/mods/kubejs/client/SoundsGenerator.java
+++ b/src/main/java/dev/latvian/mods/kubejs/client/SoundsGenerator.java
@@ -1,0 +1,171 @@
+package dev.latvian.mods.kubejs.client;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import net.minecraft.Util;
+import net.minecraft.util.Mth;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+public class SoundsGenerator {
+
+	private final Map<String, SoundGen> sounds = new HashMap<>();
+
+	public void addSound(String path, Consumer<SoundGen> consumer, boolean overlayExisting) {
+		if (overlayExisting && sounds.containsKey(path)) {
+			consumer.accept(sounds.get(path));
+		} else {
+			sounds.put(path, Util.make(new SoundGen(), consumer));
+		}
+	}
+
+	public void addSound(String path, Consumer<SoundGen> consumer) {
+		addSound(path, consumer, false);
+	}
+
+	public JsonObject toJson() {
+		var json = new JsonObject();
+		sounds.forEach((path, gen) -> json.add(path, gen.toJson()));
+		return json;
+	}
+
+	public static class SoundGen {
+
+		private boolean replace = false;
+		@Nullable
+		private String subtitle;
+		private final List<SoundInstance> instances = new ArrayList<>();
+
+		public SoundGen replace(boolean b) {
+			replace = b;
+			return this;
+		}
+
+		public SoundGen replace() { return replace(true); }
+
+		public SoundGen subtitle(@Nullable String subtitle) {
+			this.subtitle = subtitle;
+			return this;
+		}
+
+		public SoundGen sound(String file) {
+			instances.add(new SoundInstance(file));
+			return this;
+		}
+
+		public SoundGen sounds(String... sounds) {
+			instances.addAll(Stream.of(sounds).map(SoundInstance::new).toList());
+			return this;
+		}
+
+		public SoundGen sound(String file, Consumer<SoundInstance> consumer) {
+			instances.add(Util.make(new SoundInstance(file), consumer));
+			return this;
+		}
+
+		public JsonObject toJson() {
+			var json = new JsonObject();
+			if (replace) {
+				json.addProperty("replace", true);
+			}
+			if (subtitle != null) {
+				json.addProperty("subtitle", subtitle);
+			}
+			if (!instances.isEmpty()) {
+				var array = new JsonArray(instances.size());
+				instances.forEach(inst -> array.add(inst.toJson()));
+				json.add("sounds", array);
+			}
+			return json;
+		}
+
+	}
+
+	public static class SoundInstance {
+
+		private final String fileLocation;
+		private boolean complex = false;
+		private float volume = 1.0F;
+		private float pitch = 1.0F;
+		private int weight = 1;
+		private boolean stream = false;
+		private int attenuationDistance = 16;
+		private boolean preload = false;
+		private boolean isEventReference = false;
+
+		public SoundInstance(String fileLocation) {
+			this.fileLocation = fileLocation;
+		}
+
+		private SoundInstance complex() {
+			complex = true;
+			return this;
+		}
+
+		public SoundInstance volume(float f) {
+			volume = Mth.clamp(f, 0.0F, 1.0F);
+			return complex();
+		}
+
+		public SoundInstance pitch(float f) {
+			pitch = Mth.clamp(f, 0.0F, 1.0F);
+			return complex();
+		}
+
+		public SoundInstance weight(int i) {
+			weight = i;
+			return complex();
+		}
+
+		public SoundInstance stream(boolean b) {
+			stream = b;
+			return complex();
+		}
+
+		public SoundInstance stream() { return stream(true); }
+
+		public SoundInstance attenuationDistance(int i) {
+			attenuationDistance = i;
+			return complex();
+		}
+
+		public SoundInstance preload(boolean b) {
+			preload = b;
+			return complex();
+		}
+
+		public SoundInstance preload() { return preload(true); }
+
+		public SoundInstance asReferenceToEvent() {
+			isEventReference = true;
+			return complex();
+		}
+
+		public JsonElement toJson() {
+			if (!complex) {
+				return new JsonPrimitive(fileLocation.toString());
+			}
+
+			final JsonObject json = new JsonObject();
+			json.addProperty("name", fileLocation.toString());
+			json.addProperty("volume", volume);
+			json.addProperty("pitch", pitch);
+			json.addProperty("weight", weight);
+			json.addProperty("stream", stream);
+			json.addProperty("attenuation_distance", attenuationDistance);
+			json.addProperty("preload", preload);
+			if (isEventReference) {
+				json.addProperty("type", "event");
+			}
+			return json;
+		}
+	}
+}

--- a/src/main/java/dev/latvian/mods/kubejs/client/kubeAnimatedParticle.java
+++ b/src/main/java/dev/latvian/mods/kubejs/client/kubeAnimatedParticle.java
@@ -1,0 +1,70 @@
+package dev.latvian.mods.kubejs.client;
+
+import dev.latvian.mods.kubejs.color.Color;
+import dev.latvian.mods.kubejs.typings.Info;
+import it.unimi.dsi.fastutil.floats.Float2IntFunction;
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.client.particle.SimpleAnimatedParticle;
+import net.minecraft.client.particle.SpriteSet;
+import net.minecraft.util.RandomSource;
+
+public class kubeAnimatedParticle extends SimpleAnimatedParticle {
+
+	private Float2IntFunction lightColorFunction;
+
+	protected kubeAnimatedParticle(ClientLevel level, double x, double y, double z, SpriteSet sprites) {
+		super(level, x, y, z, sprites, 0.0125F);
+		setLifetime(20);
+		setSpriteFromAge(sprites);
+		lightColorFunction = super::getLightColor;
+	}
+
+	public void setGravity(float g) {
+		gravity = g;
+	}
+
+	@Info(value = "Sets teh friction of the particle, the particle's motion is multiplied by this value every tick")
+	public void setFriction(float f) {
+		friction = f;
+	}
+
+	public void setColor(Color color, boolean alpha) {
+		setColor(color.getRgbJS());
+		if (alpha) {
+			setAlpha((color.getArgbJS() >>> 24) / 255F);
+		}
+	}
+
+	public void setColor(Color color) {
+		setColor(color, false);
+	}
+
+	public void setPhysicality(boolean hasPhysics) {
+		this.hasPhysics = hasPhysics;
+	}
+
+	public void setFasterWhenYMotionBlocked(boolean b) {
+		speedUpWhenYMotionIsBlocked = b;
+	}
+
+	public void setLightColor(Float2IntFunction function) {
+		lightColorFunction = function;
+	}
+
+	// Getters for protected values
+
+	public ClientLevel getLevel() {	return level; }
+	public double getX() { return x; }
+	public double getY() { return y; }
+	public double getZ() { return z; }
+	public double getXSpeed() { return xd; }
+	public double getYSpeed() { return yd; }
+	public double getZSpeed() { return zd; }
+	public SpriteSet getSpriteSet() { return sprites; }
+	public RandomSource getRandom() { return random; }
+
+	@Override
+	public int getLightColor(float partialTick) {
+		return lightColorFunction.get(partialTick);
+	}
+}

--- a/src/main/java/dev/latvian/mods/kubejs/core/ClientLevelKJS.java
+++ b/src/main/java/dev/latvian/mods/kubejs/core/ClientLevelKJS.java
@@ -1,9 +1,11 @@
 package dev.latvian.mods.kubejs.core;
 
+import dev.latvian.mods.kubejs.client.KubeAnimatedParticle;
 import dev.latvian.mods.kubejs.player.EntityArrayList;
 import dev.latvian.mods.kubejs.script.ScriptType;
 import dev.latvian.mods.rhino.util.RemapPrefixForJS;
 import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.client.particle.SpriteSet;
 import net.minecraft.core.particles.ParticleOptions;
 
 @RemapPrefixForJS("kjs$")
@@ -52,5 +54,9 @@ public interface ClientLevelKJS extends LevelKJS {
 				}
 			}
 		}
+	}
+
+	default KubeAnimatedParticle kubeParticle(double x, double y, double z, SpriteSet spriteSet) {
+		return new KubeAnimatedParticle(kjs$self(), x, y, z, spriteSet);
 	}
 }

--- a/src/main/java/dev/latvian/mods/kubejs/generator/KubeAssetGenerator.java
+++ b/src/main/java/dev/latvian/mods/kubejs/generator/KubeAssetGenerator.java
@@ -3,8 +3,11 @@ package dev.latvian.mods.kubejs.generator;
 import dev.latvian.mods.kubejs.client.LoadedTexture;
 import dev.latvian.mods.kubejs.client.ModelGenerator;
 import dev.latvian.mods.kubejs.client.MultipartBlockStateGenerator;
+import dev.latvian.mods.kubejs.client.ParticleGenerator;
+import dev.latvian.mods.kubejs.client.SoundsGenerator;
 import dev.latvian.mods.kubejs.client.VariantBlockStateGenerator;
 import dev.latvian.mods.kubejs.color.Color;
+import dev.latvian.mods.kubejs.event.EventResult;
 import dev.latvian.mods.kubejs.script.ConsoleJS;
 import dev.latvian.mods.kubejs.script.data.GeneratedData;
 import net.minecraft.Util;
@@ -129,5 +132,19 @@ public interface KubeAssetGenerator extends KubeResourceGenerator {
 
 		texture(target, in);
 		return true;
+	}
+
+	default void particle(ResourceLocation id, Consumer<ParticleGenerator> consumer) {
+		json(ResourceLocation.fromNamespaceAndPath(id.getNamespace(), "particle/" + id.getPath()), Util.make(new ParticleGenerator(), consumer).toJson());
+	}
+
+	default void sounds(String namespace, Consumer<SoundsGenerator> consumer) {}
+
+	default void buildSounds() {}
+
+	@Override
+	default void afterPosted(EventResult result) {
+		KubeResourceGenerator.super.afterPosted(result);
+		buildSounds();
 	}
 }

--- a/src/main/java/dev/latvian/mods/kubejs/generator/KubeAssetGenerator.java
+++ b/src/main/java/dev/latvian/mods/kubejs/generator/KubeAssetGenerator.java
@@ -135,7 +135,7 @@ public interface KubeAssetGenerator extends KubeResourceGenerator {
 	}
 
 	default void particle(ResourceLocation id, Consumer<ParticleGenerator> consumer) {
-		json(ResourceLocation.fromNamespaceAndPath(id.getNamespace(), "particle/" + id.getPath()), Util.make(new ParticleGenerator(), consumer).toJson());
+		json(ResourceLocation.fromNamespaceAndPath(id.getNamespace(), "particles/" + id.getPath()), Util.make(new ParticleGenerator(), consumer).toJson());
 	}
 
 	default void sounds(String namespace, Consumer<SoundsGenerator> consumer) {}

--- a/src/main/java/dev/latvian/mods/kubejs/misc/ParticleTypeBuilder.java
+++ b/src/main/java/dev/latvian/mods/kubejs/misc/ParticleTypeBuilder.java
@@ -56,6 +56,11 @@ public class ParticleTypeBuilder extends BuilderBase<ParticleType<?>> {
 		return this;
 	}
 
+	public ParticleTypeBuilder texture(String texture) {
+		assetGen = g -> g.texture(texture);
+		return this;
+	}
+
 	@Override
 	public void generateAssets(KubeAssetGenerator generator) {
 		generator.particle(id, assetGen);

--- a/src/main/java/dev/latvian/mods/kubejs/misc/ParticleTypeBuilder.java
+++ b/src/main/java/dev/latvian/mods/kubejs/misc/ParticleTypeBuilder.java
@@ -1,6 +1,8 @@
 package dev.latvian.mods.kubejs.misc;
 
 import com.mojang.serialization.MapCodec;
+import dev.latvian.mods.kubejs.client.ParticleGenerator;
+import dev.latvian.mods.kubejs.generator.KubeAssetGenerator;
 import dev.latvian.mods.kubejs.registry.BuilderBase;
 import dev.latvian.mods.rhino.util.ReturnsSelf;
 import net.minecraft.core.particles.ParticleOptions;
@@ -9,15 +11,20 @@ import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.resources.ResourceLocation;
 
+import java.util.List;
+import java.util.function.Consumer;
+
 @ReturnsSelf
 public class ParticleTypeBuilder extends BuilderBase<ParticleType<?>> {
 	public transient boolean overrideLimiter;
 	public transient MapCodec<ParticleOptions> codec;
 	public transient StreamCodec<? super RegistryFriendlyByteBuf, ParticleOptions> streamCodec;
+	public transient Consumer<ParticleGenerator> assetGen;
 
 	public ParticleTypeBuilder(ResourceLocation i) {
 		super(i);
 		overrideLimiter = false;
+		assetGen = gen -> gen.texture(id.toString());
 	}
 
 	@Override
@@ -42,5 +49,15 @@ public class ParticleTypeBuilder extends BuilderBase<ParticleType<?>> {
 	public ParticleTypeBuilder streamCodec(StreamCodec<? super RegistryFriendlyByteBuf, ParticleOptions> s) {
 		streamCodec = s;
 		return this;
+	}
+
+	public ParticleTypeBuilder textures(List<String> textures) {
+		assetGen = g -> g.textures(textures);
+		return this;
+	}
+
+	@Override
+	public void generateAssets(KubeAssetGenerator generator) {
+		generator.particle(id, assetGen);
 	}
 }

--- a/src/main/java/dev/latvian/mods/kubejs/misc/SoundEventBuilder.java
+++ b/src/main/java/dev/latvian/mods/kubejs/misc/SoundEventBuilder.java
@@ -1,16 +1,36 @@
 package dev.latvian.mods.kubejs.misc;
 
+import dev.latvian.mods.kubejs.client.SoundsGenerator;
+import dev.latvian.mods.kubejs.generator.KubeAssetGenerator;
 import dev.latvian.mods.kubejs.registry.BuilderBase;
+import dev.latvian.mods.rhino.util.ReturnsSelf;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvent;
 
+import java.util.function.Consumer;
+
+@ReturnsSelf
 public class SoundEventBuilder extends BuilderBase<SoundEvent> {
+
+	public transient Consumer<SoundsGenerator.SoundGen> assetGen;
+
 	public SoundEventBuilder(ResourceLocation i) {
 		super(i);
+		assetGen = gen -> gen.sound(id.toString()).subtitle(id.toLanguageKey("sound"));
+	}
+
+	public SoundEventBuilder sounds(Consumer<SoundsGenerator.SoundGen> gen) {
+		assetGen = gen;
+		return this;
 	}
 
 	@Override
 	public SoundEvent createObject() {
 		return SoundEvent.createVariableRangeEvent(id);
+	}
+
+	@Override
+	public void generateAssets(KubeAssetGenerator generator) {
+		generator.sounds(id.getNamespace(), g -> g.addSound(id.getPath(), assetGen));
 	}
 }

--- a/src/main/java/dev/latvian/mods/kubejs/script/data/VirtualAssetPack.java
+++ b/src/main/java/dev/latvian/mods/kubejs/script/data/VirtualAssetPack.java
@@ -1,20 +1,26 @@
 package dev.latvian.mods.kubejs.script.data;
 
 import dev.latvian.mods.kubejs.client.LoadedTexture;
+import dev.latvian.mods.kubejs.client.SoundsGenerator;
+import dev.latvian.mods.kubejs.event.EventResult;
 import dev.latvian.mods.kubejs.generator.KubeAssetGenerator;
 import dev.latvian.mods.kubejs.script.ScriptType;
+import net.minecraft.Util;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.PackType;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Consumer;
 
 public class VirtualAssetPack extends VirtualResourcePack implements KubeAssetGenerator {
 	private final Map<ResourceLocation, LoadedTexture> loadedTextures;
+	private final Map<String, SoundsGenerator> sounds;
 
 	public VirtualAssetPack(GeneratedDataStage stage) {
 		super(ScriptType.CLIENT, PackType.CLIENT_RESOURCES, stage);
 		loadedTextures = new HashMap<>();
+		sounds = new HashMap<>();
 	}
 
 	@Override
@@ -35,5 +41,16 @@ public class VirtualAssetPack extends VirtualResourcePack implements KubeAssetGe
 	public void close() {
 		super.close();
 		loadedTextures.clear();
+	}
+
+	@Override
+	public void sounds(String namespace, Consumer<SoundsGenerator> consumer) {
+		sounds.put(namespace, Util.make(new SoundsGenerator(), consumer));
+	}
+
+	@Override
+	public void buildSounds() {
+		sounds.forEach((mod, gen) -> json(ResourceLocation.fromNamespaceAndPath(mod, "sounds"), gen.toJson()));
+		sounds.clear();
 	}
 }


### PR DESCRIPTION
### Description

Adds asset generation capabilities for `SoundEvent`s and `ParticleType`s and adds an event for registering particle providers

A port of #836 for 1.21

#### Example Script

Startup:
```js
StartupEvents.registry('sound_event', e => {
  e.create('test')
    .sounds(g => {
      g.subtitle('kubejs.sound.test')
      g.sounds('minecraft:item/bucket/empty1', 'minecraft:item/bucket/empty2', 'minecraft:item/bucket/empty3')
  })
})

StartupEvents.registry('particle_type', e => {
  e.create('test')
    .textures([
      'minecraft:big_smoke_0',
      'minecraft:big_smoke_1',
      'minecraft:big_smoke_2',
      'minecraft:big_smoke_3'
    ])
  e.create('kubejs:mod')
    .texture('minecraft:big_smoke_11')
  e.create('kubejs:custom')
  e.create('special')
})
```

Client:
```js
const HugeExplosionSeedParticle$Provider = Java.loadClass('net.minecraft.client.particle.HugeExplosionSeedParticle$Provider')

ClientEvents.particleProviderRegistry(event => {
  // Registers a default, simple provider for kubejs:test
  event.register('kubejs:test')
  // Registers a default, simple provider for kubejs:mod and allows users to edit the particle
  event.register('kubejs:mod', particle => {
    // Modify particle's options
    particle.friction = 1
    particle.gravity = 0.5
    particle.color = 0xFF4545
    particle.fasterWhenYMotionBlocked = true
  })
  // Registers a custom provider
  event.register('kubejs:custom', (type, clientlevel, x, y, z, spriteSet, xSpeed, ySpeed, zSpeed) => {
    var kube = clientLevel.kubeParticle(x, y, z, spriteSet);
    kube.color = 0xDD232D
    kube.onTick(particle => {
      particle.speed = [0, particle.ySpeed * 1.1, 0]
    })
    return kube
  })

  // Register a 'special' provider (does not have a SpriteSet provided)
  event.registerSpecial('kubejs:special', new HugeExplosionSeedParticle$Provider())
})

ClientEvents.lang('en_us', event => {
  event.add('kubejs.sound.test', 'Test Sound')
})
```

#### Other details

There is a new method in `ClientLevelKJS` which enables the create of new `KubeAnimatedParticle`s, it may be better to put it (and other particle classes?) into a generic `Particle` wrapper