### PR TITLE
fix some ATs

### DIFF
--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -37,6 +37,7 @@ public net.minecraft.world.level.block.state.BlockBehaviour$Properties <init>()V
 
 public net.minecraft.server.packs.resources.MultiPackResourceManager namespacedManagers # Ljava.util.Map;
 public net.minecraft.server.packs.resources.MultiPackResourceManager packs # Ljava.util.List;
+public net.minecraft.resources.RegistryDataLoader$Loader <init>(Lnet/minecraft/resources/RegistryDataLoader$RegistryData;Lnet/minecraft/core/WritableRegistry;Ljava/util/Map;)V
 public net.minecraft.resources.RegistryDataLoader$Loader
 public net.minecraft.resources.RegistryDataLoader$LoadingFunction
 
@@ -74,7 +75,7 @@ public net.minecraft.server.level.ServerPlayerGameMode isDestroyingBlock # Z
 public net.minecraft.server.commands.TeleportCommand performTeleport(Lnet.minecraft.commands.CommandSourceStack;Lnet.minecraft.world.entity.Entity;Lnet.minecraft.server.level.ServerLevel;DDDLjava.util.Set;FFLnet.minecraft.server.commands.TeleportCommand$LookAt;)V
 public net.minecraft.commands.arguments.selector.EntitySelector contextFreePredicates # Ljava.util.List;
 public net.minecraft.world.level.storage.loot.LootContext$EntityTarget name # Ljava.lang.String;
-public net.minecraft.world.level.storage.loot.LootDataType codec # Lcom.mojang.serialization.Codec;
+# public net.minecraft.world.level.storage.loot.LootDataType codec # Lcom.mojang.serialization.Codec;
 public net.minecraft.world.level.storage.loot.functions.SetComponentsFunction <init>(Ljava.util.List;Lnet.minecraft.core.component.DataComponentPatch;)V
 public net.minecraft.world.level.storage.loot.functions.LootItemConditionalFunction simpleBuilder(Ljava.util.function.Function;)Lnet.minecraft.world.level.storage.loot.functions.LootItemConditionalFunction$Builder;
 
@@ -87,6 +88,7 @@ public-f net.minecraft.world.level.Explosion radius # F
 # client stuff
 public net.minecraft.client.gui.components.AbstractSelectionList$Entry
 public net.minecraft.client.gui.components.ImageButton sprites # Lnet.minecraft.client.gui.components.WidgetSprites;
+public net.minecraft.client.Minecraft$GameLoadCookie <init>(Lcom/mojang/realmsclient/client/RealmsClient;Lnet/minecraft/client/main/GameConfig$QuickPlayData;)V
 public net.minecraft.client.Minecraft$GameLoadCookie
 public net.minecraft.client.gui.screens.Screen narratables # Ljava.util.List;
 public net.minecraft.client.renderer.RenderType$OutlineProperty

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -20,6 +20,7 @@ public net.minecraft.world.item.crafting.ShapelessRecipe$Serializer CODEC # Lcom
 public-f net.minecraft.world.item.crafting.ShapedRecipePattern symmetrical # Z
 
 # attributes
+public net.minecraft.world.effect.MobEffect$AttributeTemplate <init>(Lnet/minecraft/resources/ResourceLocation;DLnet/minecraft/world/entity/ai/attributes/AttributeModifier$Operation;Lit/unimi/dsi/fastutil/ints/Int2DoubleFunction;)V
 public net.minecraft.world.effect.MobEffect$AttributeTemplate
 public net.minecraft.world.effect.MobEffect attributeModifiers # Ljava.util.Map;
 public net.minecraft.world.effect.MobEffect$AttributeTemplate <init>(Lnet.minecraft.resources.ResourceLocation;DLnet.minecraft.world.entity.ai.attributes.AttributeModifier$Operation;)V


### PR DESCRIPTION
Looks like when AT'ing to records we should also AT their constructor

```md
Access transformer PUBLIC LEAVE /home/pietrolopes/.gradle/caches/modules-2/files-2.1/dev.latvian.mods/kubejs-neoforge/2100.7.0-build.123/5db7e10e32c6a10e5bba09a32b79e6cc7ae98b2c/kubejs-neoforge-2100.7.0-build.123-accesstransformer.cfg:90 targeting record class net.minecraft.client.Minecraft$GameLoadCookie attempts to widen its access without widening the constructor's access. You must AT the constructor too: "public net.minecraft.client.Minecraft$GameLoadCookie <init>(Lcom/mojang/realmsclient/client/RealmsClient;Lnet/minecraft/client/main/GameConfig$QuickPlayData;)V"

Access transformer PUBLIC LEAVE /home/pietrolopes/.gradle/caches/modules-2/files-2.1/dev.latvian.mods/kubejs-neoforge/2100.7.0-build.123/5db7e10e32c6a10e5bba09a32b79e6cc7ae98b2c/kubejs-neoforge-2100.7.0-build.123-accesstransformer.cfg:40 targeting record class net.minecraft.resources.RegistryDataLoader$Loader attempts to widen its access without widening the constructor's access. You must AT the constructor too: "public net.minecraft.resources.RegistryDataLoader$Loader <init>(Lnet/minecraft/resources/RegistryDataLoader$RegistryData;Lnet/minecraft/core/WritableRegistry;Ljava/util/Map;)V"

Access transformer PUBLIC LEAVE /home/pietrolopes/.gradle/caches/modules-2/files-2.1/dev.latvian.mods/kubejs-neoforge/2100.7.0-build.123/5db7e10e32c6a10e5bba09a32b79e6cc7ae98b2c/kubejs-neoforge-2100.7.0-build.123-accesstransformer.cfg:77, targeting net.minecraft.world.level.storage.loot.LootDataType FIELD codec did not apply as its target doesn't exist

Transformation failed
```

Weird that it failed when implementing/importing but on KubeJS itself it runs fine (same errors/warnings but won't prevent from building) :thinking: 