### PR TITLE
Fixed crops in 1.21

### DIFF
--- a/src/main/java/dev/latvian/mods/kubejs/block/SeedItemBuilder.java
+++ b/src/main/java/dev/latvian/mods/kubejs/block/SeedItemBuilder.java
@@ -1,35 +1,41 @@
 package dev.latvian.mods.kubejs.block;
 
+import dev.latvian.mods.kubejs.KubeJS;
+import dev.latvian.mods.kubejs.block.custom.BasicCropBlockJS;
 import dev.latvian.mods.kubejs.generator.KubeAssetGenerator;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.npc.Villager;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemNameBlockItem;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.LevelReader;
 import net.neoforged.neoforge.common.SpecialPlantable;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class SeedItemBuilder extends BlockItemBuilder {
-	public static class SeedItemJS extends Item implements SpecialPlantable {
+	public static class SeedItemJS extends ItemNameBlockItem implements SpecialPlantable {
 		public SeedItemJS(SeedItemBuilder b) {
-			super(b.createItemProperties());
+			super(b.blockBuilder.get(), b.createItemProperties());
 		}
 
 		@Override
-		public boolean canPlacePlantAtPosition(ItemStack stack, LevelReader level, BlockPos pos, @Nullable Direction direction) {
-			return false;
+		public boolean canPlacePlantAtPosition(@NotNull ItemStack stack, @NotNull LevelReader level, @NotNull BlockPos pos, @Nullable Direction direction) {
+			BasicCropBlockJS cropBlock = (BasicCropBlockJS) getBlock();
+			return cropBlock.canSurvive(cropBlock.defaultBlockState(), level, pos);
 		}
 
 		@Override
-		public void spawnPlantAtPosition(ItemStack stack, LevelAccessor level, BlockPos pos, @Nullable Direction direction) {
+		public void spawnPlantAtPosition(@NotNull ItemStack stack, LevelAccessor level, @NotNull BlockPos pos, @Nullable Direction direction) {
+			level.setBlock(pos, getBlock().defaultBlockState(), 2);
 		}
 
 		@Override
-		public boolean villagerCanPlantItem(Villager villager) {
-			return false;
+		public boolean villagerCanPlantItem(@NotNull Villager villager) {
+			return true;
 		}
 	}
 


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->

### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->

Fixed the seed item and crop block drops in 1.21+. Also added code so farmers can plant/replant the crop, as well as a few utility functions in shape building.

- Crops are now added as `item: Item, count: NumberProvider`, instead of `item: ItemStack, chance: double` due to vanilla code change
- Added `carrot`, `potato`, `wheat`, and `beetroot` for shape builders to build shapes that are similar to the corresponding crop at a given age

#### Example Script <!-- Please provide an example script showing that the bug is fixed, or how the feature is used, if applicable -->

```js
StartupEvents.registry('block', event => {
    event.create('canopy', 'crop')
        // So the crop will have a hitbox similar to wheat
        .age(7, builder => builder.wheat()) 
        // Marks the seed to be plantable, however, the farmer will 
        // always harvest the crop due to the vanilla code
        .farmersCanPlant() 
        // Drop 0-4 iron swords at a time
        .crop('iron_sword', { min: 0, max: 4 })
})
```

#### Other details <!-- Any other important information, like if this is likely to break addons -->

- Fortune enchantment does not boost seed production because I don't know how to get a registry lookup there yet.