### PR TITLE
restrict scanning fields to static only

### DIFF
--- a/src/main/java/dev/latvian/mods/kubejs/registry/RegistryType.java
+++ b/src/main/java/dev/latvian/mods/kubejs/registry/RegistryType.java
@@ -131,7 +131,7 @@ public record RegistryType<T>(ResourceKey<Registry<T>> key, Class<?> baseClass, 
 				.flatMap(Stream::of)
 				.forEach(field -> {
 					try {
-						if (!VALID_TYPES.get().contains(field.getType())) {
+						if (!VALID_TYPES.get().contains(field.getType()) || !Modifier.isStatic(field.getModifiers())) {
 							return;
 						}
 


### PR DESCRIPTION
There was a case where someone used a registry as a field in their Record and the scanner got it, no need to get non-static fields.