### PR TITLE
Use `Holder<Item>` for crops to allow items as crops

### DIFF
--- a/src/main/java/dev/latvian/mods/kubejs/block/custom/CropBlockBuilder.java
+++ b/src/main/java/dev/latvian/mods/kubejs/block/custom/CropBlockBuilder.java
@@ -68,7 +68,7 @@ public class CropBlockBuilder extends BlockBuilder {
 
 		@Info("""
 			Describe the shape of the crop at a specific age.
-			
+						
 			min/max coordinates are double values between 0 and 16.
 			""")
 		public ShapeBuilder shape(int age, double minX, double minY, double minZ, double maxX, double maxY, double maxZ) {
@@ -126,6 +126,7 @@ public class CropBlockBuilder extends BlockBuilder {
 	public transient SurviveCallback surviveCallback;
 
 	public transient List<Pair<Holder<Item>, NumberProvider>> outputs;
+	public transient boolean noSeeds;
 
 	public CropBlockBuilder(ResourceLocation id) {
 		super(id);
@@ -141,6 +142,7 @@ public class CropBlockBuilder extends BlockBuilder {
 		hardness = 0.0f;
 		resistance = 0.0f;
 		outputs = new ArrayList<>();
+		noSeeds = false;
 		notSolid = true;
 
 		soundType(SoundType.CROP);
@@ -157,6 +159,12 @@ public class CropBlockBuilder extends BlockBuilder {
 	@Override
 	public BlockBuilder noItem() {
 		itemBuilder = null;
+		return this;
+	}
+
+	@Info("Remove seed drops from the loot table, does not prevent seed item from creating.")
+	public CropBlockBuilder noSeeds() {
+		this.noSeeds = true;
 		return this;
 	}
 
@@ -239,7 +247,7 @@ public class CropBlockBuilder extends BlockBuilder {
 			builder.withPool(LootPool.lootPool().add(cropItem));
 		}
 
-		if (itemBuilder != null) {
+		if (itemBuilder != null && !noSeeds) {
 			var pool = LootPool.lootPool().add(LootItem.lootTableItem(itemBuilder.get())
 				.when(mature)
 				.otherwise(LootItem.lootTableItem(itemBuilder.get()))

--- a/src/main/java/dev/latvian/mods/kubejs/block/custom/CropBlockBuilder.java
+++ b/src/main/java/dev/latvian/mods/kubejs/block/custom/CropBlockBuilder.java
@@ -13,6 +13,7 @@ import dev.latvian.mods.kubejs.typings.Info;
 import dev.latvian.mods.rhino.util.ReturnsSelf;
 import net.minecraft.advancements.critereon.StatePropertiesPredicate;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Holder;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.world.item.Item;
@@ -124,7 +125,7 @@ public class CropBlockBuilder extends BlockBuilder {
 	public transient ToIntFunction<RandomTickCallbackJS> fertilizerCallback;
 	public transient SurviveCallback surviveCallback;
 
-	public transient List<Pair<Item, NumberProvider>> outputs;
+	public transient List<Pair<Holder<Item>, NumberProvider>> outputs;
 
 	public CropBlockBuilder(ResourceLocation id) {
 		super(id);
@@ -160,13 +161,13 @@ public class CropBlockBuilder extends BlockBuilder {
 	}
 
 	@Info("Add a crop output with exactly one output.")
-	public CropBlockBuilder crop(Item output) {
+	public CropBlockBuilder crop(Holder<Item> output) {
 		crop(output, ConstantValue.exactly(1.0f));
 		return this;
 	}
 
 	@Info("Add a crop output with a specific amount.")
-	public CropBlockBuilder crop(Item output, NumberProvider chance) {
+	public CropBlockBuilder crop(Holder<Item> output, NumberProvider chance) {
 		outputs.add(new Pair<>(output, chance));
 		return this;
 	}
@@ -229,7 +230,10 @@ public class CropBlockBuilder extends BlockBuilder {
 
 		var builder = LootTable.lootTable();
 		for (var output : outputs) {
-			var cropItem = LootItem.lootTableItem(output.getFirst())
+			if (!output.getFirst().isBound()) {
+				continue;
+			}
+			var cropItem = LootItem.lootTableItem(output.getFirst().value())
 				.apply(SetItemCountFunction.setCount(output.getSecond()))
 				.when(mature);
 			builder.withPool(LootPool.lootPool().add(cropItem));


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->

### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->

Made the `Item` in `crop(Item crop, NumberProvider chance)` to use `Holder<Item>` instead so non-vanilla items can be used as crop output.

Also added a `noSeeds` method to prevent seeds from dropping in the loot table, while seed item is still created.