### PR TITLE
Reset RegexIDFilter interner after recipes are loaded

### DIFF
--- a/src/main/java/dev/latvian/mods/kubejs/recipe/RecipesKubeEvent.java
+++ b/src/main/java/dev/latvian/mods/kubejs/recipe/RecipesKubeEvent.java
@@ -19,6 +19,7 @@ import dev.latvian.mods.kubejs.recipe.filter.ConstantFilter;
 import dev.latvian.mods.kubejs.recipe.filter.IDFilter;
 import dev.latvian.mods.kubejs.recipe.filter.OrFilter;
 import dev.latvian.mods.kubejs.recipe.filter.RecipeFilter;
+import dev.latvian.mods.kubejs.recipe.filter.RegexIDFilter;
 import dev.latvian.mods.kubejs.recipe.match.ReplacementMatchInfo;
 import dev.latvian.mods.kubejs.recipe.schema.RecipeSchema;
 import dev.latvian.mods.kubejs.recipe.schema.RecipeSchemaStorage;
@@ -428,6 +429,8 @@ public class RecipesKubeEvent implements KubeEvent {
 				ConsoleJS.SERVER.info(r.getOrCreateId() + ": " + r.json);
 			}
 		}
+
+		RegexIDFilter.clearInternCache();
 	}
 
 	@Nullable

--- a/src/main/java/dev/latvian/mods/kubejs/recipe/filter/RegexIDFilter.java
+++ b/src/main/java/dev/latvian/mods/kubejs/recipe/filter/RegexIDFilter.java
@@ -14,7 +14,11 @@ public class RegexIDFilter implements RecipeFilter {
 	private final Pattern pattern;
 	private final ConcurrentHashMap<ResourceLocation, Boolean> matchCache = new ConcurrentHashMap<>();
 
-	private static final Interner<RegexIDFilter> INTERNER = Interners.newStrongInterner();
+	private static Interner<RegexIDFilter> INTERNER;
+
+	static {
+		clearInternCache();
+	}
 
 	private RegexIDFilter(Pattern i) {
 		pattern = i;
@@ -22,6 +26,10 @@ public class RegexIDFilter implements RecipeFilter {
 
 	public static RegexIDFilter of(Pattern i) {
 		return INTERNER.intern(new RegexIDFilter(i));
+	}
+
+	public static void clearInternCache() {
+		INTERNER = Interners.newStrongInterner();
 	}
 
 	@Override


### PR DESCRIPTION
This avoids many RegexIDFilter instances remaining in memory and holding on to match caches.

In Monifactory, this saves roughly 60MB of memory.