### PR TITLE
fix: `kubejs export events` markdown url

### DIFF
--- a/src/main/java/dev/latvian/mods/kubejs/command/DumpCommands.java
+++ b/src/main/java/dev/latvian/mods/kubejs/command/DumpCommands.java
@@ -24,6 +24,7 @@ import java.nio.file.Files;
 public class DumpCommands {
 	private static final char UNICODE_TICK = '✔';
 	private static final char UNICODE_CROSS = '✘';
+	private static final char BRANCH_NAME = "main";
 
 	public static int events(CommandSourceStack source) {
 		var groups = EventGroups.ALL.get().map();
@@ -78,7 +79,8 @@ public class DumpCommands {
 
 				if (eventType.getPackageName().startsWith("dev.latvian.mods.kubejs")) {
 					builder.append('[').append(UtilsJS.toMappedTypeString(eventType)).append(']')
-						.append('(').append("https://github.com/KubeJS-Mods/KubeJS/tree/main/src/main/java/")
+						.append('(').append("https://github.com/KubeJS-Mods/KubeJS/tree/main/src/")
+						.append(BRANCH_NAME).append("/java/")
 						.append(eventType.getPackageName().replace('.', '/'))
 						.append('/').append(eventType.getSimpleName()).append(".java")
 						.append(')');

--- a/src/main/java/dev/latvian/mods/kubejs/command/DumpCommands.java
+++ b/src/main/java/dev/latvian/mods/kubejs/command/DumpCommands.java
@@ -79,9 +79,7 @@ public class DumpCommands {
 
 				if (eventType.getPackageName().startsWith("dev.latvian.mods.kubejs")) {
 					builder.append('[').append(UtilsJS.toMappedTypeString(eventType)).append(']')
-						.append('(').append("https://github.com/KubeJS-Mods/KubeJS/tree/")
-						.append(KubeJS.MC_VERSION_NUMBER)
-						.append("/common/src/main/java/")
+						.append('(').append("https://github.com/KubeJS-Mods/KubeJS/tree/main/src/main/java/")
 						.append(eventType.getPackageName().replace('.', '/'))
 						.append('/').append(eventType.getSimpleName()).append(".java")
 						.append(')');

--- a/src/main/java/dev/latvian/mods/kubejs/command/DumpCommands.java
+++ b/src/main/java/dev/latvian/mods/kubejs/command/DumpCommands.java
@@ -24,7 +24,6 @@ import java.nio.file.Files;
 public class DumpCommands {
 	private static final char UNICODE_TICK = '✔';
 	private static final char UNICODE_CROSS = '✘';
-	private static final char BRANCH_NAME = "main";
 
 	public static int events(CommandSourceStack source) {
 		var groups = EventGroups.ALL.get().map();
@@ -79,8 +78,7 @@ public class DumpCommands {
 
 				if (eventType.getPackageName().startsWith("dev.latvian.mods.kubejs")) {
 					builder.append('[').append(UtilsJS.toMappedTypeString(eventType)).append(']')
-						.append('(').append("https://github.com/KubeJS-Mods/KubeJS/tree/main/src/")
-						.append(BRANCH_NAME).append("/java/")
+						.append('(').append("https://github.com/KubeJS-Mods/KubeJS/tree/main/src/main/java/")
 						.append(eventType.getPackageName().replace('.', '/'))
 						.append('/').append(eventType.getSimpleName()).append(".java")
 						.append(')');

--- a/src/main/java/dev/latvian/mods/kubejs/command/DumpCommands.java
+++ b/src/main/java/dev/latvian/mods/kubejs/command/DumpCommands.java
@@ -2,7 +2,6 @@ package dev.latvian.mods.kubejs.command;
 
 import com.google.common.base.Strings;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
-import dev.latvian.mods.kubejs.KubeJS;
 import dev.latvian.mods.kubejs.KubeJSPaths;
 import dev.latvian.mods.kubejs.event.EventGroups;
 import dev.latvian.mods.kubejs.script.ConsoleJS;


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->

### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->

The branch in 1.21 should be main and the path should be the path before the project structure was refactored.

https://discord.com/channels/303440391124942858/1288956688732393585