### PR TITLE
Fixed NPE due to `spawnerEither` is `null` and chest GUI deleting items picked up

### DIFF
--- a/src/main/java/dev/latvian/mods/kubejs/entity/CheckLivingEntitySpawnKubeEvent.java
+++ b/src/main/java/dev/latvian/mods/kubejs/entity/CheckLivingEntitySpawnKubeEvent.java
@@ -10,6 +10,7 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.MobSpawnType;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 @Info("""
@@ -60,8 +61,8 @@ public class CheckLivingEntitySpawnKubeEvent implements KubeLivingEntityEvent {
 		return type;
 	}
 
-	@Info("The spawner that spawned the entity. Can be null if the entity was spawned by worldgen.")
-	@Nullable
+	@Info("The spawner that spawned the entity.")
+	@NotNull
 	public SpawnerJS getSpawner() {
 		if (spawner == null) {
 			spawner = SpawnerJS.of(spawnerEither);

--- a/src/main/java/dev/latvian/mods/kubejs/level/SpawnerJS.java
+++ b/src/main/java/dev/latvian/mods/kubejs/level/SpawnerJS.java
@@ -7,6 +7,10 @@ import org.jetbrains.annotations.Nullable;
 
 public record SpawnerJS(@Nullable Entity entity, @Nullable BlockContainerJS block) {
 	public static SpawnerJS of(Either<BlockEntity, Entity> spawner) {
+		if (spawner == null) {
+			return new SpawnerJS(null, null);
+		}
+
 		var e = spawner.right().orElse(null);
 
 		if (e != null) {
@@ -20,5 +24,9 @@ public record SpawnerJS(@Nullable Entity entity, @Nullable BlockContainerJS bloc
 		}
 
 		return new SpawnerJS(null, null);
+	}
+
+	public boolean isWorldgen() {
+		return entity == null && block == null;
 	}
 }

--- a/src/main/java/dev/latvian/mods/kubejs/server/KubeJSServerEventHandler.java
+++ b/src/main/java/dev/latvian/mods/kubejs/server/KubeJSServerEventHandler.java
@@ -5,6 +5,7 @@ import dev.latvian.mods.kubejs.bindings.event.LevelEvents;
 import dev.latvian.mods.kubejs.bindings.event.ServerEvents;
 import dev.latvian.mods.kubejs.command.CommandRegistryKubeEvent;
 import dev.latvian.mods.kubejs.command.KubeJSCommands;
+import dev.latvian.mods.kubejs.gui.chest.CustomChestMenu;
 import dev.latvian.mods.kubejs.level.SimpleLevelKubeEvent;
 import dev.latvian.mods.kubejs.script.PlatformWrapper;
 import dev.latvian.mods.kubejs.script.ScriptType;
@@ -17,6 +18,7 @@ import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.NbtAccounter;
 import net.minecraft.nbt.NbtIo;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.storage.LevelResource;
@@ -24,9 +26,11 @@ import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.fml.loading.FMLEnvironment;
+import net.neoforged.neoforge.common.util.TriState;
 import net.neoforged.neoforge.event.AddReloadListenerEvent;
 import net.neoforged.neoforge.event.CommandEvent;
 import net.neoforged.neoforge.event.RegisterCommandsEvent;
+import net.neoforged.neoforge.event.entity.player.ItemEntityPickupEvent;
 import net.neoforged.neoforge.event.level.LevelEvent;
 import net.neoforged.neoforge.event.server.ServerAboutToStartEvent;
 import net.neoforged.neoforge.event.server.ServerStartingEvent;
@@ -172,5 +176,14 @@ public class KubeJSServerEventHandler {
 	@SubscribeEvent
 	public static void addReloadListeners(AddReloadListenerEvent event) {
 		event.addListener(new KubeJSReloadListener(event.getServerResources()));
+	}
+
+	@SubscribeEvent
+	public static void preventPickupDuringChestGUI(ItemEntityPickupEvent.Pre event) {
+		var e = event.getPlayer();
+
+		if (e instanceof ServerPlayer player && player.isAlive() && !player.hasDisconnected() && player.containerMenu instanceof CustomChestMenu) {
+			event.setCanPickup(TriState.FALSE);
+		}
 	}
 }


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->

### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->

Current `FinalizeSpawn` event has a nullable spawner, so 

https://github.com/KubeJS-Mods/KubeJS/blob/eb9b153259f6219adc70f4e8482cd653a9fbd460/src/main/java/dev/latvian/mods/kubejs/level/SpawnerJS.java#L10

will throw NPE since spawner is null.

```java
    @Nullable
    public Either<BlockEntity, Entity> getSpawner() {
        return this.spawner;
    }
```

Also fixed #911 by preventing player from picking up items if a chest GUI is opened.
