### PR TITLE
Enable BlockStatePredicate list sizes of 1

### DIFF
--- a/src/main/java/dev/latvian/mods/kubejs/block/state/BlockStatePredicate.java
+++ b/src/main/java/dev/latvian/mods/kubejs/block/state/BlockStatePredicate.java
@@ -87,7 +87,7 @@ public sealed interface BlockStatePredicate extends Predicate<BlockState>, Repla
 
 		if (list.isEmpty()) {
 			return Simple.NONE;
-		} else if (list.size() > 1) {
+		} else {
 			var predicates = new ArrayList<BlockStatePredicate>();
 
 			for (var o1 : list) {


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->

### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->

This fixes an issue with calling `BlockStatePredicate.wrap` with a list of size 1.

#### Example Script <!-- Please provide an example script showing that the bug is fixed, or how the feature is used, if applicable -->

With existing implementation, `b1` is an empty list, while `b2` is not

```js
const b1 = BlockStatePredicate.wrap(['minecraft:oak_log']).getBlockIds();
const b2 = BlockStatePredicate.wrap(['minecraft:oak_log', 'minecraft:birch_log']).getBlockIds();

console.log(b1);
console.log(b2);
```

I removed the check for list size > 1 completely, rather than change it to list size > 0, as there should never be a case where list size is < 0, and the empty case is handled in the other branch.

Let me know if you would prefer there to be an explicit check for size > 0 and I can update the PR

#### Other details <!-- Any other important information, like if this is likely to break addons -->