### PR TITLE
Keybind registry and keypress events

### DIFF
--- a/src/main/java/dev/latvian/mods/kubejs/bindings/event/ClientEvents.java
+++ b/src/main/java/dev/latvian/mods/kubejs/bindings/event/ClientEvents.java
@@ -34,5 +34,6 @@ public interface ClientEvents {
 	EventHandler PARTICLE_PROVIDER_REGISTRY = GROUP.client("particleProviderRegistry", () -> ParticleProviderRegistryKubeEvent.class);
 	EventHandler KEYBIND_REGISTRY = GROUP.startup("keybindRegistry", () -> KeybindRegistryKubeEvent.class);
 	TargetedEventHandler<String> KEY_DOWN = GROUP.client("keyDown", () -> ClientPlayerKubeEvent.class).requiredTarget(EventTargetType.STRING);
+	TargetedEventHandler<String> KEY_UP = GROUP.client("keyUp", () -> ClientPlayerKubeEvent.class).requiredTarget(EventTargetType.STRING);
 	TargetedEventHandler<String> KEY_PRESSED = GROUP.client("keyPressed", () -> ClientPlayerKubeEvent.class).requiredTarget(EventTargetType.STRING);
 }

--- a/src/main/java/dev/latvian/mods/kubejs/bindings/event/ClientEvents.java
+++ b/src/main/java/dev/latvian/mods/kubejs/bindings/event/ClientEvents.java
@@ -5,6 +5,7 @@ import dev.latvian.mods.kubejs.client.BlockEntityRendererRegistryKubeEvent;
 import dev.latvian.mods.kubejs.client.ClientPlayerKubeEvent;
 import dev.latvian.mods.kubejs.client.DebugInfoKubeEvent;
 import dev.latvian.mods.kubejs.client.EntityRendererRegistryKubeEvent;
+import dev.latvian.mods.kubejs.client.KeybindRegistryKubeEvent;
 import dev.latvian.mods.kubejs.client.LangKubeEvent;
 import dev.latvian.mods.kubejs.client.MenuScreenRegistryKubeEvent;
 import dev.latvian.mods.kubejs.client.ParticleProviderRegistryKubeEvent;
@@ -31,4 +32,7 @@ public interface ClientEvents {
 	TargetedEventHandler<ResourceLocation> ATLAS_SPRITE_REGISTRY = GROUP.client("atlasSpriteRegistry", () -> AtlasSpriteRegistryKubeEvent.class).requiredTarget(EventTargetType.ID);
 	TargetedEventHandler<String> LANG = GROUP.client("lang", () -> LangKubeEvent.class).requiredTarget(EventTargetType.STRING);
 	EventHandler PARTICLE_PROVIDER_REGISTRY = GROUP.client("particleProviderRegistry", () -> ParticleProviderRegistryKubeEvent.class);
+	EventHandler KEYBIND_REGISTRY = GROUP.startup("keybindRegistry", () -> KeybindRegistryKubeEvent.class);
+	TargetedEventHandler<String> KEY_DOWN = GROUP.client("keyDown", () -> ClientPlayerKubeEvent.class).requiredTarget(EventTargetType.STRING);
+	TargetedEventHandler<String> KEY_PRESSED = GROUP.client("keyPressed", () -> ClientPlayerKubeEvent.class).requiredTarget(EventTargetType.STRING);
 }

--- a/src/main/java/dev/latvian/mods/kubejs/client/BuiltinKubeJSClientPlugin.java
+++ b/src/main/java/dev/latvian/mods/kubejs/client/BuiltinKubeJSClientPlugin.java
@@ -6,6 +6,8 @@ import dev.latvian.mods.kubejs.event.EventGroupRegistry;
 import dev.latvian.mods.kubejs.plugin.KubeJSPlugin;
 import dev.latvian.mods.kubejs.script.BindingRegistry;
 import dev.latvian.mods.kubejs.script.PlatformWrapper;
+import dev.latvian.mods.kubejs.script.ScriptManager;
+import dev.latvian.mods.kubejs.script.ScriptType;
 import dev.latvian.mods.kubejs.util.ScheduledEvents;
 import dev.latvian.mods.kubejs.web.LocalWebServerRegistry;
 import dev.latvian.mods.kubejs.web.local.client.KubeJSClientWeb;
@@ -49,5 +51,13 @@ public class BuiltinKubeJSClientPlugin implements KubeJSPlugin {
 				}
 			}
 		}
+	}
+
+	@Override
+	public void afterScriptsLoaded(ScriptManager manager) {
+		if (manager.scriptType != ScriptType.CLIENT) {
+			return;
+		}
+		KubeJSKeybinds.triggerReload();
 	}
 }

--- a/src/main/java/dev/latvian/mods/kubejs/client/KeybindRegistryKubeEvent.java
+++ b/src/main/java/dev/latvian/mods/kubejs/client/KeybindRegistryKubeEvent.java
@@ -1,0 +1,68 @@
+package dev.latvian.mods.kubejs.client;
+
+import com.mojang.blaze3d.platform.InputConstants;
+import dev.latvian.mods.rhino.util.HideFromJS;
+import net.minecraft.client.KeyMapping;
+import net.neoforged.neoforge.client.settings.KeyConflictContext;
+import net.neoforged.neoforge.client.settings.KeyModifier;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class KeybindRegistryKubeEvent implements ClientKubeEvent {
+	private final List<Builder> builders = new ArrayList<>();
+
+	public Builder register(String keybindId) {
+		Builder builder = new Builder(keybindId);
+		builders.add(builder);
+		return builder;
+	}
+
+	@HideFromJS
+	public List<KubeJSKeybinds.KubeKeybind> build() {
+		return builders.stream().map(Builder::create).toList();
+	}
+
+	public static class Builder {
+		private final String id;
+		private KeyConflictContext keyConflictContext = KeyConflictContext.UNIVERSAL;
+		private KeyModifier keyModifier = KeyModifier.NONE;
+		private InputConstants.Type inputType = InputConstants.Type.KEYSYM;
+		private int keyId = 0;
+		private String category = "key.categories.kubejs";
+
+		public Builder(String id) {
+			this.id = id;
+		}
+
+		public Builder keyConflictContext(KeyConflictContext keyConflictContext) {
+			this.keyConflictContext = keyConflictContext;
+			return this;
+		}
+
+		public Builder keyModifier(KeyModifier keyModifier) {
+			this.keyModifier = keyModifier;
+			return this;
+		}
+
+		public Builder inputType(InputConstants.Type inputType) {
+			this.inputType = inputType;
+			return this;
+		}
+
+		public Builder keyId(int keyId) {
+			this.keyId = keyId;
+			return this;
+		}
+
+		public Builder category(String category) {
+			this.category = category;
+			return this;
+		}
+
+		@HideFromJS
+		public KubeJSKeybinds.KubeKeybind create() {
+			return new KubeJSKeybinds.KubeKeybind(id, new KeyMapping("key.kubejs.%s".formatted(id), keyConflictContext, keyModifier, inputType, keyId, category));
+		}
+	}
+}

--- a/src/main/java/dev/latvian/mods/kubejs/client/KeybindRegistryKubeEvent.java
+++ b/src/main/java/dev/latvian/mods/kubejs/client/KeybindRegistryKubeEvent.java
@@ -1,16 +1,22 @@
 package dev.latvian.mods.kubejs.client;
 
 import com.mojang.blaze3d.platform.InputConstants;
+import dev.latvian.mods.kubejs.util.ClassWrapper;
 import dev.latvian.mods.rhino.util.HideFromJS;
 import net.minecraft.client.KeyMapping;
 import net.neoforged.neoforge.client.settings.KeyConflictContext;
 import net.neoforged.neoforge.client.settings.KeyModifier;
+import org.lwjgl.glfw.GLFW;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class KeybindRegistryKubeEvent implements ClientKubeEvent {
 	private final List<Builder> builders = new ArrayList<>();
+
+	public ClassWrapper<GLFW> getGLFW() {
+		return new ClassWrapper<>(GLFW.class);
+	}
 
 	public Builder register(String keybindId) {
 		Builder builder = new Builder(keybindId);

--- a/src/main/java/dev/latvian/mods/kubejs/client/KeybindRegistryKubeEvent.java
+++ b/src/main/java/dev/latvian/mods/kubejs/client/KeybindRegistryKubeEvent.java
@@ -13,10 +13,7 @@ import java.util.List;
 
 public class KeybindRegistryKubeEvent implements ClientKubeEvent {
 	private final List<Builder> builders = new ArrayList<>();
-
-	public ClassWrapper<GLFW> getGLFW() {
-		return new ClassWrapper<>(GLFW.class);
-	}
+	public final ClassWrapper<GLFW> GLFW = new ClassWrapper<>(GLFW.class);
 
 	public Builder register(String keybindId) {
 		Builder builder = new Builder(keybindId);
@@ -34,7 +31,7 @@ public class KeybindRegistryKubeEvent implements ClientKubeEvent {
 		private KeyConflictContext keyConflictContext = KeyConflictContext.UNIVERSAL;
 		private KeyModifier keyModifier = KeyModifier.NONE;
 		private InputConstants.Type inputType = InputConstants.Type.KEYSYM;
-		private int keyId = 0;
+		private int keyId = -1;
 		private String category = "key.categories.kubejs";
 
 		public Builder(String id) {

--- a/src/main/java/dev/latvian/mods/kubejs/client/KubeJSGameClientEventHandler.java
+++ b/src/main/java/dev/latvian/mods/kubejs/client/KubeJSGameClientEventHandler.java
@@ -317,6 +317,7 @@ public class KubeJSGameClientEventHandler {
 	public static void clientTick(ClientTickEvent.Pre event) {
 		var mc = Minecraft.getInstance();
 		KubedexHighlight.INSTANCE.tickPre(mc);
+		KubeJSKeybinds.triggerKeyEvents(mc);
 	}
 
 	@SubscribeEvent

--- a/src/main/java/dev/latvian/mods/kubejs/client/KubeJSKeybinds.java
+++ b/src/main/java/dev/latvian/mods/kubejs/client/KubeJSKeybinds.java
@@ -1,0 +1,71 @@
+package dev.latvian.mods.kubejs.client;
+
+import dev.latvian.mods.kubejs.bindings.event.ClientEvents;
+import dev.latvian.mods.kubejs.script.ScriptType;
+import net.minecraft.client.KeyMapping;
+import net.minecraft.client.Minecraft;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class KubeJSKeybinds {
+	private static final Map<String, KubeKeybind> registeredKeybinds = new HashMap<>();
+	private static final List<KubeKeybindState> listeningKeybinds = new ArrayList<>();
+
+	public static void triggerReload() {
+		listeningKeybinds.clear();
+		ClientEvents.KEY_DOWN.forEachListener(ScriptType.CLIENT, container -> {
+			String target = container.target.toString();
+			if (registeredKeybinds.containsKey(target)) {
+				listeningKeybinds.add(new KubeKeybindState(registeredKeybinds.get(target)));
+			}
+		});
+		ClientEvents.KEY_PRESSED.forEachListener(ScriptType.CLIENT, container -> {
+			String target = container.target.toString();
+			if (registeredKeybinds.containsKey(target)) {
+				listeningKeybinds.add(new KubeKeybindState(registeredKeybinds.get(target)));
+			}
+		});
+	}
+
+	public static void triggerKeyEvents(Minecraft client) {
+		for (KubeKeybindState listeningKeybind : listeningKeybinds) {
+			if (client.kjs$isKeyMappingDown(listeningKeybind.keybind.keyMapping)) {
+				ClientPlayerKubeEvent event = new ClientPlayerKubeEvent(client.player);
+				if (!listeningKeybind.keyDown) {
+					ClientEvents.KEY_PRESSED.post(event, listeningKeybind.keybind.keybindId);
+				}
+				listeningKeybind.keyDown = true;
+				ClientEvents.KEY_DOWN.post(event, listeningKeybind.keybind.keybindId);
+			} else {
+				listeningKeybind.keyDown = false;
+			}
+		}
+	}
+
+	public static KeyMapping getKeybind(String keybindId) {
+		KubeKeybind kubeKeybind = registeredKeybinds.get(keybindId);
+		if (kubeKeybind == null) {
+			return null;
+		}
+		return kubeKeybind.keyMapping;
+	}
+
+	public static void addKeybind(KubeKeybind kubeKeybind) {
+		registeredKeybinds.put(kubeKeybind.keybindId, kubeKeybind);
+	}
+
+	public record KubeKeybind(String keybindId, KeyMapping keyMapping) {
+	}
+
+	private static class KubeKeybindState {
+		final KubeKeybind keybind;
+		boolean keyDown = false;
+
+		private KubeKeybindState(KubeKeybind keybind) {
+			this.keybind = keybind;
+		}
+	}
+}

--- a/src/main/java/dev/latvian/mods/kubejs/client/KubeJSKeybinds.java
+++ b/src/main/java/dev/latvian/mods/kubejs/client/KubeJSKeybinds.java
@@ -5,14 +5,15 @@ import dev.latvian.mods.kubejs.script.ScriptType;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Minecraft;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 
 public class KubeJSKeybinds {
 	private static final Map<String, KubeKeybind> registeredKeybinds = new HashMap<>();
-	private static final List<KubeKeybindState> listeningKeybinds = new ArrayList<>();
+	private static final Set<KubeKeybindState> listeningKeybinds = new HashSet<>();
 
 	public static void triggerReload() {
 		listeningKeybinds.clear();
@@ -40,6 +41,9 @@ public class KubeJSKeybinds {
 				listeningKeybind.keyDown = true;
 				ClientEvents.KEY_DOWN.post(event, listeningKeybind.keybind.keybindId);
 			} else {
+				if (listeningKeybind.keyDown) {
+					ClientEvents.KEY_UP.post(new ClientPlayerKubeEvent(client.player));
+				}
 				listeningKeybind.keyDown = false;
 			}
 		}
@@ -66,6 +70,18 @@ public class KubeJSKeybinds {
 
 		private KubeKeybindState(KubeKeybind keybind) {
 			this.keybind = keybind;
+		}
+
+		@Override
+		public boolean equals(Object object) {
+			if (this == object) return true;
+			if (!(object instanceof KubeKeybindState that)) return false;
+			return Objects.equals(keybind.keybindId, that.keybind.keybindId);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hashCode(keybind.keybindId);
 		}
 	}
 }

--- a/src/main/java/dev/latvian/mods/kubejs/client/KubeJSModClientEventHandler.java
+++ b/src/main/java/dev/latvian/mods/kubejs/client/KubeJSModClientEventHandler.java
@@ -142,6 +142,14 @@ public class KubeJSModClientEventHandler {
 	@SubscribeEvent
 	public static void registerKeyMappings(RegisterKeyMappingsEvent event) {
 		event.register(KubedexHighlight.keyMapping = new KeyMapping("key.kubejs.kubedex", KeyConflictContext.UNIVERSAL, KeyModifier.NONE, InputConstants.Type.KEYSYM, GLFW.GLFW_KEY_K, "key.categories.kubejs"));
+
+		KeybindRegistryKubeEvent kubeEvent = new KeybindRegistryKubeEvent();
+		ClientEvents.KEYBIND_REGISTRY.post(kubeEvent);
+		for (KubeJSKeybinds.KubeKeybind kubeKeybind : kubeEvent.build()) {
+			event.register(kubeKeybind.keyMapping());
+			KubeJSKeybinds.addKeybind(kubeKeybind);
+		}
+		KubeJSKeybinds.triggerReload();
 	}
 
 	@SubscribeEvent

--- a/src/main/java/dev/latvian/mods/kubejs/core/MinecraftClientKJS.java
+++ b/src/main/java/dev/latvian/mods/kubejs/core/MinecraftClientKJS.java
@@ -3,6 +3,7 @@ package dev.latvian.mods.kubejs.core;
 import com.mojang.blaze3d.platform.InputConstants;
 import dev.latvian.mods.kubejs.bindings.event.ItemEvents;
 import dev.latvian.mods.kubejs.client.ClientProperties;
+import dev.latvian.mods.kubejs.client.KubeJSKeybinds;
 import dev.latvian.mods.kubejs.item.ItemClickedKubeEvent;
 import dev.latvian.mods.kubejs.net.FirstClickPayload;
 import dev.latvian.mods.kubejs.script.ConsoleJS;
@@ -81,6 +82,14 @@ public interface MinecraftClientKJS extends MinecraftEnvironmentKJS {
 
 	default boolean kjs$isKeyDown(int key) {
 		return InputConstants.isKeyDown(kjs$self().getWindow().getWindow(), key);
+	}
+
+	default boolean kjs$isKeybindDown(String key) {
+		KeyMapping keyMapping = KubeJSKeybinds.getKeybind(key);
+		if (keyMapping == null) {
+			return false;
+		}
+		return kjs$isKeyMappingDown(keyMapping);
 	}
 
 	default boolean kjs$isKeyMappingDown(KeyMapping key) {


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->

### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->

Added `ClientEvents.keybindRegistry`, `ClientEvents.keyDown`, and `ClientEvents.keyPressed` to register keybinds and detect if a key is down or pressed. Also added `Minecraft.kjs$isKeybindDown` to detect if a key is down in code (e.g. use in left click events).

#### Example Script <!-- Please provide an example script showing that the bug is fixed, or how the feature is used, if applicable -->

##### startup_scripts
```js
// Event to register the keybinds
ClientEvents.keybindRegistry(event => {
    // ID of the keybind, translation key will be `key.kubejs.${id}`
    event.register('quick_buff')
        // GLFW key ID of the default key, default to -1 (Unbound)
        .keyId(event.GLFW.GLFW_KEY_A)
        // Category of the key, default to KubeJS category
        .category('key.categories.kubejs')
        // Some additional setting for key conflict and input type
        .keyConflictContext('universal')
        .inputType('keysym')
})
```

##### client_scripts
```js
// When the key is pressed, it will trigger only once
// even if you hold it for some time.
// ClientEvents.keyDown will be triggered *every tick* instead
// When the key is released, `ClientEvent.keyUp` will be triggered
ClientEvents.keyPressed('quick_buff', event => {
    if (event.player == null) return;
    event.player.playSound('minecraft:item.honey_bottle.drink', 1, 1)
    // Send to the server to notify the key is changed
    // The keypress only happens in client, so network is usually needed
    event.player.sendData('quick_buff', {})
})
```

##### server_scripts
```js
// To process the notification from client side and trigger
// the actual effect
NetworkEvents.dataReceived('quick_buff', event => {
    let inventory = event.player.inventory
    let changed = false;
    inventory.items.forEach(itemStack => {
        if (itemStack.id == "minecraft:potion") {
            let potion = itemStack.get('minecraft:potion_contents')
            let applied = false;
            potion.forEachEffect(effect => {
                if (!effect.getEffect().value().isInstantenous()) {
                    event.player.addEffect(effect)
                    applied = true;
                }
            })
            if (applied) { itemStack.shrink(1); changed = true; }
        }
    })
    if (changed) inventory.setChanged()
})
```


https://github.com/user-attachments/assets/aadf7d44-e8fb-4051-a66e-88f835b607d5

