### PR TITLE
Added util methods to retrieve targeting block / entity directly

### DIFF
--- a/src/main/java/dev/latvian/mods/kubejs/client/highlight/HighlightKubeEvent.java
+++ b/src/main/java/dev/latvian/mods/kubejs/client/highlight/HighlightKubeEvent.java
@@ -2,6 +2,7 @@ package dev.latvian.mods.kubejs.client.highlight;
 
 import dev.latvian.mods.kubejs.client.ClientPlayerKubeEvent;
 import dev.latvian.mods.kubejs.color.KubeColor;
+import dev.latvian.mods.kubejs.level.LevelBlock;
 import dev.latvian.mods.kubejs.typings.Info;
 import net.minecraft.client.Minecraft;
 import net.minecraft.commands.arguments.selector.EntitySelector;
@@ -131,5 +132,16 @@ public class HighlightKubeEvent extends ClientPlayerKubeEvent {
 		} else if (mc.hitResult instanceof BlockHitResult hit && mc.hitResult.getType() == HitResult.Type.BLOCK) {
 			addBlock(hit.getBlockPos(), color);
 		}
+	}
+
+	public LevelBlock getTargetBlock() {
+		if (mc.hitResult instanceof BlockHitResult block && mc.hitResult.getType() == HitResult.Type.BLOCK) {
+			return getLevel().kjs$getBlock(block.getBlockPos());
+		}
+		return null;
+	}
+
+	public Entity getTargetEntity() {
+		return mc.hitResult instanceof EntityHitResult hit ? hit.getEntity() : null;
 	}
 }


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->

### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->

Added `getTargetBlock` and `getTargetEntity` for `HighlightKubeEvent` so users can get the targeting block / entities in a convenient way and apply additional logic without ray tracing.

#### Example Script <!-- Please provide an example script showing that the bug is fixed, or how the feature is used, if applicable -->

```js
ClientEvents.highlight(event => {
    let { player, targetBlock } = event

    if (targetBlock == null || !targetBlock.hasTag("c:ores")) return // So it will only highlight ore blocks

    event.addTargetBlock('gold')
    event.cancelBlockHighlight()
})
```
