### PR TITLE
Added explicit casting function to JavaWrapper

### DIFF
--- a/src/main/java/dev/latvian/mods/kubejs/plugin/builtin/wrapper/JavaWrapper.java
+++ b/src/main/java/dev/latvian/mods/kubejs/plugin/builtin/wrapper/JavaWrapper.java
@@ -44,6 +44,10 @@ public interface JavaWrapper {
 		return Cast.to(cx.createInterfaceAdapter(targetClass, function));
 	}
 
+	static <T> T cast(Context cx, Class<T> targetClass, Object object) {
+		return Cast.to(cx.jsToJava(object, TypeInfo.of(targetClass)));
+	}
+
 	@Nullable
 	@HideFromJS
 	static Class<?> tryLoadClass(String className) {

--- a/src/main/java/dev/latvian/mods/kubejs/plugin/builtin/wrapper/JavaWrapper.java
+++ b/src/main/java/dev/latvian/mods/kubejs/plugin/builtin/wrapper/JavaWrapper.java
@@ -44,6 +44,7 @@ public interface JavaWrapper {
 		return Cast.to(cx.createInterfaceAdapter(targetClass, function));
 	}
 
+	@Info("Cast the object to a target type, use if Rhino can't determine the parameter type due to type erasure.")
 	static <T> T cast(Context cx, Class<T> targetClass, Object object) {
 		return Cast.to(cx.jsToJava(object, TypeInfo.of(targetClass)));
 	}


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->

### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->

Added a function `cast(Class<T>, Object obj)` that manually performs type-wrapping to any given type to avoid problems due to type erasure.

For example, `BlockState` has a such method:

```java
public <T extends Comparable<T>, V extends T> S setValue(Property<T> property, V value)
```

Where `V` is erased to `Object` at runtime, so it is impossible for Rhino to determine the correct type to wrap. Consider such script:

```js
let $CropBlock = Java.loadClass("net.minecraft.world.level.block.CropBlock")

BlockEvents.rightClicked('minecraft:wheat', event => {
    let { block: { pos, blockState }, level, hand } = event
    if (hand != "main_hand") return;

    let age = blockState.getValue($CropBlock.AGE) + 1
    level.setBlock(pos, blockState.setValue($CropBlock.AGE, age), 2)
})
```

The age is a JS value due to the `+1` operation. In Rhino before, it is directly passed into the `setBlock` and cause an error due to the number is a double, and Rhino now will report:

```
Error in 'BlockEvents.rightClicked': dev.latvian.mods.rhino.EvaluatorException: Can't find method dev.latvian.mods.rhino.CachedClassInfo.setValue(net.minecraft.world.level.block.state.properties.IntegerProperty,number).
```

both stop the original logic from working.

Thus, an explicit type wrapping method is added in this PR as `Java.cast`, this allows users to use Rhino's type wrapping to cast a value to any type needed to pass into the method.

#### Example Script <!-- Please provide an example script showing that the bug is fixed, or how the feature is used, if applicable -->

```js
let $CropBlock = Java.loadClass("net.minecraft.world.level.block.CropBlock")
let $Integer = Java.loadClass("java.lang.Integer")

BlockEvents.rightClicked('minecraft:wheat', event => {
    let { block: { pos, blockState }, level, hand } = event
    if (hand != "main_hand") return;

    let age = blockState.getValue($CropBlock.AGE) + 1
    level.setBlock(pos, blockState.setValue($CropBlock.AGE, Java.cast($Integer, age)), 2)
})
```

So, the `age` is casted to `java.lang.Integer` and then Rhino can call the method without problem.

#### Other details <!-- Any other important information, like if this is likely to break addons -->

Similar functions that require such casting exist in Neoforge / Vanilla other than BlockState properties, e.g. DataComponent and Attachment. It might be ok to implement explicit support for blockstate like for DataComponent, but I think it would be better to just let users cast things to correct types directly.