### PR TITLE
Add new bindings for MobEffectInstance binding

### DIFF
--- a/src/main/java/dev/latvian/mods/kubejs/plugin/builtin/BuiltinKubeJSPlugin.java
+++ b/src/main/java/dev/latvian/mods/kubejs/plugin/builtin/BuiltinKubeJSPlugin.java
@@ -248,6 +248,7 @@ import net.minecraft.world.level.material.MapColor;
 import net.minecraft.world.level.storage.loot.LootContext;
 import net.minecraft.world.level.storage.loot.functions.CopyNameFunction;
 import net.minecraft.world.level.storage.loot.providers.number.NumberProvider;
+import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.common.ItemAbility;
@@ -460,6 +461,8 @@ public class BuiltinKubeJSPlugin implements KubeJSPlugin {
 		bindings.add("BlockProperties", BlockStateProperties.class);
 
 		bindings.add("NativeEvents", NativeEventWrapper.class);
+
+		bindings.add("MobEffects", MobEffects.class);
 	}
 
 	@Override

--- a/src/main/java/dev/latvian/mods/kubejs/plugin/builtin/BuiltinKubeJSPlugin.java
+++ b/src/main/java/dev/latvian/mods/kubejs/plugin/builtin/BuiltinKubeJSPlugin.java
@@ -160,6 +160,7 @@ import dev.latvian.mods.kubejs.util.ScheduledEvents;
 import dev.latvian.mods.kubejs.util.SlotFilter;
 import dev.latvian.mods.kubejs.util.TickDuration;
 import dev.latvian.mods.kubejs.util.TimeJS;
+import dev.latvian.mods.kubejs.util.MobEffectUtil;
 import dev.latvian.mods.kubejs.util.Tristate;
 import dev.latvian.mods.kubejs.util.registrypredicate.RegistryPredicate;
 import dev.latvian.mods.kubejs.web.LocalWebServerRegistry;
@@ -463,6 +464,7 @@ public class BuiltinKubeJSPlugin implements KubeJSPlugin {
 		bindings.add("NativeEvents", NativeEventWrapper.class);
 
 		bindings.add("MobEffects", MobEffects.class);
+		bindings.add("MobEffectInstance", MobEffectUtil.class)
 	}
 
 	@Override

--- a/src/main/java/dev/latvian/mods/kubejs/plugin/builtin/BuiltinKubeJSPlugin.java
+++ b/src/main/java/dev/latvian/mods/kubejs/plugin/builtin/BuiltinKubeJSPlugin.java
@@ -462,7 +462,7 @@ public class BuiltinKubeJSPlugin implements KubeJSPlugin {
 
 		bindings.add("NativeEvents", NativeEventWrapper.class);
 
-		bindings.add("MobEffectInstance", MobEffectUtil.class)
+		bindings.add("MobEffectUtil", MobEffectUtil.class)
 	}
 
 	@Override

--- a/src/main/java/dev/latvian/mods/kubejs/plugin/builtin/BuiltinKubeJSPlugin.java
+++ b/src/main/java/dev/latvian/mods/kubejs/plugin/builtin/BuiltinKubeJSPlugin.java
@@ -158,9 +158,9 @@ import dev.latvian.mods.kubejs.util.RegistryAccessContainer;
 import dev.latvian.mods.kubejs.util.RotationAxis;
 import dev.latvian.mods.kubejs.util.ScheduledEvents;
 import dev.latvian.mods.kubejs.util.SlotFilter;
+import dev.latvian.mods.kubejs.util.MobEffectUtil;
 import dev.latvian.mods.kubejs.util.TickDuration;
 import dev.latvian.mods.kubejs.util.TimeJS;
-import dev.latvian.mods.kubejs.util.MobEffectUtil;
 import dev.latvian.mods.kubejs.util.Tristate;
 import dev.latvian.mods.kubejs.util.registrypredicate.RegistryPredicate;
 import dev.latvian.mods.kubejs.web.LocalWebServerRegistry;
@@ -249,7 +249,6 @@ import net.minecraft.world.level.material.MapColor;
 import net.minecraft.world.level.storage.loot.LootContext;
 import net.minecraft.world.level.storage.loot.functions.CopyNameFunction;
 import net.minecraft.world.level.storage.loot.providers.number.NumberProvider;
-import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.common.ItemAbility;
@@ -463,7 +462,6 @@ public class BuiltinKubeJSPlugin implements KubeJSPlugin {
 
 		bindings.add("NativeEvents", NativeEventWrapper.class);
 
-		bindings.add("MobEffects", MobEffects.class);
 		bindings.add("MobEffectInstance", MobEffectUtil.class)
 	}
 

--- a/src/main/java/dev/latvian/mods/kubejs/util/MobEffectUtil.java
+++ b/src/main/java/dev/latvian/mods/kubejs/util/MobEffectUtil.java
@@ -39,7 +39,7 @@ public class MobEffectUtil {
     }
 
     @Contract("_, _, _, _, _, _ -> new")
-	@Info("Creates an instance for the given effect, duration, amplifier, ambient, visible to the HUD, and to show the icon")
+	@Info("Creates an instance for the given effect, duration, amplifier, ambient, visible to the HUD, and to show the icon on the sceen")
     public static @NotNull MobEffectInstance of(Holder<MobEffect> effect, int duration, int amplifier, boolean ambient, boolean visible, boolean showIcon) {
         return new MobEffectInstance(effect, duration, amplifier, ambient, visible, showIcon);
     }

--- a/src/main/java/dev/latvian/mods/kubejs/util/MobEffectUtil.java
+++ b/src/main/java/dev/latvian/mods/kubejs/util/MobEffectUtil.java
@@ -7,6 +7,11 @@ import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
 public class MobEffectUtil {
+	@Contract("_ -> new")
+	public static @NotNull MobEffectInstance of(MobEffectInstance oldInstance) {
+		return new MobEffectInstance(oldInstance)
+	}
+
     @Contract("_ -> new")
     public static @NotNull MobEffectInstance of(Holder<MobEffect> effect) {
         return new MobEffectInstance(effect);

--- a/src/main/java/dev/latvian/mods/kubejs/util/MobEffectUtil.java
+++ b/src/main/java/dev/latvian/mods/kubejs/util/MobEffectUtil.java
@@ -1,5 +1,6 @@
 package dev.latvian.mods.kubejs.util;
 
+import dev.latvian.mods.kubejs.typings.Info;
 import net.minecraft.core.Holder;
 import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.effect.MobEffectInstance;
@@ -8,31 +9,37 @@ import org.jetbrains.annotations.NotNull;
 
 public class MobEffectUtil {
 	@Contract("_ -> new")
+	@Info("Creates a new instance from the old one")
 	public static @NotNull MobEffectInstance of(MobEffectInstance oldInstance) {
 		return new MobEffectInstance(oldInstance)
 	}
 
     @Contract("_ -> new")
+	@Info("Creates an instance for the given effect")
     public static @NotNull MobEffectInstance of(Holder<MobEffect> effect) {
         return new MobEffectInstance(effect);
     }
 
     @Contract("_, _ -> new")
+	@Info("Creates an instance for the given effect and duration")
     public static @NotNull MobEffectInstance of(Holder<MobEffect> effect, int duration) {
         return new MobEffectInstance(effect, duration);
     }
 
     @Contract("_, _, _ -> new")
+	@Info("Creates an instance for the given effect, duration and amplifier")
     public static @NotNull MobEffectInstance of(Holder<MobEffect> effect, int duration, int amplifier) {
         return new MobEffectInstance(effect, duration, amplifier);
     }
 
     @Contract("_, _, _, _, _ -> new")
+	@Info("Creates an instance for the given effect, duration, amplifier, ambient, and visible to the HUD")
     public static @NotNull MobEffectInstance of(Holder<MobEffect> effect, int duration, int amplifier, boolean ambient, boolean visible) {
         return new MobEffectInstance(effect, duration, amplifier, ambient, visible);
     }
 
     @Contract("_, _, _, _, _, _ -> new")
+	@Info("Creates an instance for the given effect, duration, amplifier, ambient, visible to the HUD, and to show the icon")
     public static @NotNull MobEffectInstance of(Holder<MobEffect> effect, int duration, int amplifier, boolean ambient, boolean visible, boolean showIcon) {
         return new MobEffectInstance(effect, duration, amplifier, ambient, visible, showIcon);
     }

--- a/src/main/java/dev/latvian/mods/kubejs/util/MobEffectUtil.java
+++ b/src/main/java/dev/latvian/mods/kubejs/util/MobEffectUtil.java
@@ -9,19 +9,19 @@ import org.jetbrains.annotations.NotNull;
 
 public class MobEffectUtil {
 	@Contract("_ -> new")
-	@Info("Creates a new instance from the old one")
+	@Info("Copies an existing MobEffectInstance")
 	public static @NotNull MobEffectInstance of(MobEffectInstance oldInstance) {
 		return new MobEffectInstance(oldInstance)
 	}
 
     @Contract("_ -> new")
-	@Info("Creates an instance for the given effect")
+	@Info("Creates an instance for the given effect. Default duration and amplifier is 0")
     public static @NotNull MobEffectInstance of(Holder<MobEffect> effect) {
         return new MobEffectInstance(effect);
     }
 
     @Contract("_, _ -> new")
-	@Info("Creates an instance for the given effect and duration")
+	@Info("Creates an instance for the given effect and duration (in ticks)")
     public static @NotNull MobEffectInstance of(Holder<MobEffect> effect, int duration) {
         return new MobEffectInstance(effect, duration);
     }

--- a/src/main/java/dev/latvian/mods/kubejs/util/MobEffectUtil.java
+++ b/src/main/java/dev/latvian/mods/kubejs/util/MobEffectUtil.java
@@ -1,0 +1,34 @@
+package dev.latvian.mods.kubejs.util;
+
+import net.minecraft.core.Holder;
+import net.minecraft.world.effect.MobEffect;
+import net.minecraft.world.effect.MobEffectInstance;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+
+public class MobEffectUtil {
+    @Contract("_ -> new")
+    public static @NotNull MobEffectInstance of(Holder<MobEffect> effect) {
+        return new MobEffectInstance(effect);
+    }
+
+    @Contract("_, _ -> new")
+    public static @NotNull MobEffectInstance of(Holder<MobEffect> effect, int duration) {
+        return new MobEffectInstance(effect, duration);
+    }
+
+    @Contract("_, _, _ -> new")
+    public static @NotNull MobEffectInstance of(Holder<MobEffect> effect, int duration, int amplifier) {
+        return new MobEffectInstance(effect, duration, amplifier);
+    }
+
+    @Contract("_, _, _, _, _ -> new")
+    public static @NotNull MobEffectInstance of(Holder<MobEffect> effect, int duration, int amplifier, boolean ambient, boolean visible) {
+        return new MobEffectInstance(effect, duration, amplifier, ambient, visible);
+    }
+
+    @Contract("_, _, _, _, _, _ -> new")
+    public static @NotNull MobEffectInstance of(Holder<MobEffect> effect, int duration, int amplifier, boolean ambient, boolean visible, boolean showIcon) {
+        return new MobEffectInstance(effect, duration, amplifier, ambient, visible, showIcon);
+    }
+}


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->

### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->
In my mod, when registering a thing, you can add a list of effects to it. I did not want to add bindings to the `MobEffects` and to make a `MobEffectInstance`.

This PR adds two new bindings to create a `MobEffectInstance`, and also to fetch effects from `MobEffects`.

I'm not sure of `MobEffects` is already a binding, but well, added it sinse I could not find it..

I added a binding for the `MobEffectInstance` for most of the constructors.

#### Example Script <!-- Please provide an example script showing that the bug is fixed, or how the feature is used, if applicable -->
Using `MobEffects.CONFUSION` for example (nausia)
```js
// Using my mod's registry for example
StartupEvents.registry("qstorage:gas", event => {
    event.create("something").effects(
        MobEffectInstance.of("minecraft:absorption"),
        MobEffectInstance.of("minecraft:absorption", 4), // Duration of 4
        MobEffectInstance.of("minecraft:absorption", 4, 5), // Amplifier of 5
        MobEffectInstance.of("minecraft:absorption", 4, 5, false, true), // Not ambient, visible
        MobEffectInstance.of("minecraft:absorption", 4, 5, false, true, true) // Shows the icon
    )
})
```

#### Other details <!-- Any other important information, like if this is likely to break addons -->
This adds two new bindings so I would not need to do it with my mod, and would just be built into KubeJS.

Feel free to make changes.