### PR TITLE
Added non-conflicting methods delegating tests to `Holder.is`

### DIFF
--- a/src/main/java/dev/latvian/mods/kubejs/core/mixin/HolderMixin.java
+++ b/src/main/java/dev/latvian/mods/kubejs/core/mixin/HolderMixin.java
@@ -1,39 +1,46 @@
 package dev.latvian.mods.kubejs.core.mixin;
 
+import dev.latvian.mods.kubejs.typings.Param;
+import dev.latvian.mods.kubejs.util.Cast;
+import dev.latvian.mods.rhino.util.HideFromJS;
+import dev.latvian.mods.rhino.util.RemapForJS;
 import dev.latvian.mods.rhino.util.RemapPrefixForJS;
 import net.minecraft.core.Holder;
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 
+import java.util.Optional;
 import java.util.function.Predicate;
 
 @Mixin(Holder.class)
 @RemapPrefixForJS("kjs$")
 public interface HolderMixin<T> {
 	@Shadow
+	@HideFromJS
 	boolean is(TagKey<T> tagKey);
 
 	@Shadow
+	@HideFromJS
 	boolean is(ResourceKey<T> resourceKey);
 
 	@Shadow
+	@Deprecated
+	@HideFromJS
+	boolean is(Holder<T> holder);
+
+	@Shadow
+	@RemapForJS("test")
 	boolean is(Predicate<ResourceKey<T>> predicate);
 
-	@Unique
-	default boolean kjs$matchTag(TagKey<T> tagKey) {
-		return is(tagKey);
-	}
+	@Shadow
+	Optional<ResourceKey<T>> unwrapKey();
 
 	@Unique
-	default boolean kjs$matchKey(ResourceKey<T> resourceKey) {
-		return is(resourceKey);
-	}
-
-	@Unique
-	default boolean kjs$matchPredicate(Predicate<ResourceKey<T>> predicate) {
-		return is(predicate);
+	default boolean kjs$isTag(ResourceLocation tagKey) {
+		return this.unwrapKey().map(resourceKey -> is(TagKey.create(resourceKey.registryKey(), tagKey))).orElse(false);
 	}
 }

--- a/src/main/java/dev/latvian/mods/kubejs/core/mixin/HolderMixin.java
+++ b/src/main/java/dev/latvian/mods/kubejs/core/mixin/HolderMixin.java
@@ -1,5 +1,6 @@
 package dev.latvian.mods.kubejs.core.mixin;
 
+import dev.latvian.mods.kubejs.typings.Info;
 import dev.latvian.mods.kubejs.typings.Param;
 import dev.latvian.mods.kubejs.util.Cast;
 import dev.latvian.mods.rhino.util.HideFromJS;
@@ -33,13 +34,19 @@ public interface HolderMixin<T> {
 	boolean is(Holder<T> holder);
 
 	@Shadow
+	@Info("Tests the resource key held by the holder using a predicate.")
 	@RemapForJS("test")
 	boolean is(Predicate<ResourceKey<T>> predicate);
 
 	@Shadow
 	Optional<ResourceKey<T>> unwrapKey();
 
+	@Shadow
+	@Info("Test if the holder holds an object registered with given resource location.")
+	boolean is(ResourceLocation location);
+
 	@Unique
+	@Info("Test if a tag matches the object this holder holds.")
 	default boolean kjs$isTag(ResourceLocation tagKey) {
 		return this.unwrapKey().map(resourceKey -> is(TagKey.create(resourceKey.registryKey(), tagKey))).orElse(false);
 	}

--- a/src/main/java/dev/latvian/mods/kubejs/core/mixin/HolderMixin.java
+++ b/src/main/java/dev/latvian/mods/kubejs/core/mixin/HolderMixin.java
@@ -1,0 +1,39 @@
+package dev.latvian.mods.kubejs.core.mixin;
+
+import dev.latvian.mods.rhino.util.RemapPrefixForJS;
+import net.minecraft.core.Holder;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.tags.TagKey;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+
+import java.util.function.Predicate;
+
+@Mixin(Holder.class)
+@RemapPrefixForJS("kjs$")
+public interface HolderMixin<T> {
+	@Shadow
+	boolean is(TagKey<T> tagKey);
+
+	@Shadow
+	boolean is(ResourceKey<T> resourceKey);
+
+	@Shadow
+	boolean is(Predicate<ResourceKey<T>> predicate);
+
+	@Unique
+	default boolean kjs$matchTag(TagKey<T> tagKey) {
+		return is(tagKey);
+	}
+
+	@Unique
+	default boolean kjs$matchKey(ResourceKey<T> resourceKey) {
+		return is(resourceKey);
+	}
+
+	@Unique
+	default boolean kjs$matchPredicate(Predicate<ResourceKey<T>> predicate) {
+		return is(predicate);
+	}
+}

--- a/src/main/resources/kubejs.mixins.json
+++ b/src/main/resources/kubejs.mixins.json
@@ -29,6 +29,7 @@
 		"FluidMixin",
 		"FluidStackMixin",
 		"GameRulesMixin",
+		"HolderMixin",
 		"IBlockStateExtensionMixin",
 		"IItemHandlerMixin",
 		"IngredientMixin",


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->

### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->

`Holder<T>` is often used in the game coding, however it contains 5 overrides of `is` method each with different parameter type, which will cause Rhino to just not work for most of the time, since many of these types are overlapping in type wrapping (e.g. `TagKey`, `ResourceKey` and `ResourceLocation`.

This PR leaves only `is(ResourceLocation)` to test if the resource location is the one holder holds, and renamed `is(Predicate<ResourceKey>)` to `test(Predicate<ResourceKey>)`, and added `isTag(ResourceLocation)` to test if the holder has a key represented by the resource location.

#### Example Script <!-- Please provide an example script showing that the bug is fixed, or how the feature is used, if applicable -->

```js
PlayerEvents.tick(event => {
    let player = event.player
    if (player.tickCount % 80 == 0) {
        let level = event.level
        let biome = level.getBiome(player.block.pos)
        console.info(biome.is("minecraft:snowy_taiga"))
        console.info(biome.isTag("c:is_cold"))
    }
})
```

#### Other details <!-- Any other important information, like if this is likely to break addons -->

- Other `is` overrides are all tagged `@HideFromJS`
- A separate `isTag` is needed instead of remapping names due to Rhino is unable to wrap the tag from type `TagKey<T>`.