### PR TITLE
Remove assumptions about the concrete type of builders

### DIFF
--- a/src/main/java/dev/latvian/mods/kubejs/KubeJSModEventHandler.java
+++ b/src/main/java/dev/latvian/mods/kubejs/KubeJSModEventHandler.java
@@ -121,7 +121,9 @@ public class KubeJSModEventHandler {
 
 	@SubscribeEvent
 	public static void registerCapabilities(RegisterCapabilitiesEvent event) {
-		for (var info : RegistryObjectStorage.BLOCK_ENTITY.objects.values().stream().map(b -> ((BlockEntityBuilder) b).info).toList()) {
+		for (var info : RegistryObjectStorage.BLOCK_ENTITY.objects.values().stream()
+			.filter(BlockEntityBuilder.class::isInstance)
+			.map(b -> ((BlockEntityBuilder) b).info).toList()) {
 			for (var attachment : info.attachments.values()) {
 				for (var capability : attachment.factory().getCapabilities()) {
 					event.registerBlockEntity(capability, (BlockEntityType<KubeBlockEntity>) info.entityType, new KubeEntityCapabilityProvider(capability, attachment));

--- a/src/main/java/dev/latvian/mods/kubejs/server/ServerScriptManager.java
+++ b/src/main/java/dev/latvian/mods/kubejs/server/ServerScriptManager.java
@@ -145,13 +145,15 @@ public class ServerScriptManager extends ScriptManager {
 			furnaceFuelsJson.add(entry.getKey().kjs$getId(), json);
 		}
 
-		for (var item : RegistryObjectStorage.ITEM) {
-			long b = ((ItemBuilder) item).burnTime;
+		for (var builder : RegistryObjectStorage.ITEM) {
+			if (builder instanceof ItemBuilder item) {
+				long b = item.burnTime;
 
-			if (b > 0L) {
-				var json = new JsonObject();
-				json.addProperty("burn_time", b);
-				furnaceFuelsJson.add(item.id.toString(), json);
+				if (b > 0L) {
+					var json = new JsonObject();
+					json.addProperty("burn_time", b);
+					furnaceFuelsJson.add(builder.id.toString(), json);
+				}
 			}
 		}
 


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->

### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->
Removes assumptions about the concrete type of builders as they are not always true due to `CustomBuilderObject`

#### Example Script <!-- Please provide an example script showing that the bug is fixed, or how the feature is used, if applicable -->
Any use of event.createCustom for items or block entities, like so:
```js
const $UniversalBucketItem = Java.loadClass('de.cech12.bucketlib.api.item.UniversalBucketItem');

StartupEvents.registry('item', e => {
    e.createCustom('fluid_cell', () => new $UniversalBucketItem(
        new $UniversalBucketItem.Properties()
            .stacksTo(64)
            .disableEntityObtaining()
            .disableMilking()
        )
    );
});
```

#### Other details <!-- Any other important information, like if this is likely to break addons -->
Original report and example script from the discord: [support-1.21 - crash when trying to create a world due to event.createCustom](https://discord.com/channels/303440391124942858/1339788140411617331/1339788140411617331)
Other usages found and reviewed with regex `Builder\) [a-zA-Z$]+`