### PR TITLE
Dont freeze my pc anymore please thanks

### DIFF
--- a/src/main/java/dev/latvian/mods/kubejs/server/DataExport.java
+++ b/src/main/java/dev/latvian/mods/kubejs/server/DataExport.java
@@ -206,7 +206,7 @@ public class DataExport {
 				} catch (Exception ex) {
 					ex.printStackTrace();
 				}
-			}, Util.ioPool());
+			}, Util.backgroundExecutor());
 		}
 
 		CompletableFuture.allOf(arr).join();


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->

### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->

Previously running `/kubejs export debug` caused my CPU usage to spike insanely high, using thousands of threads and freezing my entire pc. Changing this one line fixed this issue for me

#### Example Script <!-- Please provide an example script showing that the bug is fixed, or how the feature is used, if applicable -->

Using the latest KJS build from Curseforge. (I cant get a better image since my pc is unresponsive, so this is the best I can get).

My CPU is maxed out with over 60000 threads being used, export takes hours and freezes the entire pc in the process

![before](https://github.com/user-attachments/assets/4b166929-4489-49f8-8685-1994cde19d71)

After changing this one line 

CPU is barely used, tiny spike with no more than 5000 threads at once. Export is done after ~30 seconds

![after](https://github.com/user-attachments/assets/3e8fd1b7-0125-4b01-b152-15aa6cfb2a6d)