### PR TITLE
Fix items with subtypes being put into all tabs

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/item/custom/BasicItemJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/item/custom/BasicItemJS.java
@@ -37,6 +37,7 @@ public class BasicItemJS extends Item {
 	private final Multimap<ResourceLocation, AttributeModifier> modifiers;
 	private boolean modified = false;
 	private final Function<ItemStackJS, Collection<ItemStackJS>> subtypes;
+	private final CreativeModeTab group;
 
 	public BasicItemJS(ItemBuilder p) {
 		super(p.createItemProperties());
@@ -47,11 +48,12 @@ public class BasicItemJS extends Item {
 		subtypes = p.subtypes;
 		attributes = ArrayListMultimap.create();
 		modifiers = p.attributes;
+		group = p.group;
 	}
 
 	@Override
 	public void fillItemCategory(CreativeModeTab category, NonNullList<ItemStack> stacks) {
-		if (subtypes != null) {
+		if (subtypes != null && category == group) {
 			for (var stack : subtypes.apply(ItemStackJS.of(this))) {
 				stacks.add(stack.getItemStack());
 			}


### PR DESCRIPTION
This PR fixes an old but previously unreported issue where items using .subtypes(...) would appear in every creative tab, including the trash slot.

The issue was caused by the fillItemCategory(...) method in BasicItemJS not properly checking whether the current creative tab matched the one the item was assigned to. As a result, NBT variants generated via .subtypes() were injected into every tab.

Seems like this has been a bug for a while, but gone unreported cause no one uses subtypes() 😅

This change ensures that variants are only added to the correct creative tab, as intended by the group(...) assignment in scripts.