### PR TITLE
Add text translatable fallback method

### DIFF
--- a/src/main/java/dev/latvian/mods/kubejs/core/ComponentKJS.java
+++ b/src/main/java/dev/latvian/mods/kubejs/core/ComponentKJS.java
@@ -77,6 +77,14 @@ public interface ComponentKJS extends Component, WithCodec, WrappedJS {
 		kjs$asIterable().forEach(action);
 	}
 
+	default MutableComponent kjs$fallback(String text) {
+    	TranslatableContents content = this.getContents();
+    	Object[] args = content.getArgs();
+    	if (args == null)
+			return Component.translatableWithFallback(new TranslatableContents(content.getKey(), text, TranslatableContents.NO_ARGS));
+    	return Component.translatableWithFallback(new TranslatableContents(content.getKey(), text, ...args));
+	}
+
 	// region ChatFormatting extensions
 	default MutableComponent kjs$black() {
 		return kjs$self().withStyle(ChatFormatting.BLACK);

--- a/src/main/java/dev/latvian/mods/kubejs/core/ComponentKJS.java
+++ b/src/main/java/dev/latvian/mods/kubejs/core/ComponentKJS.java
@@ -77,14 +77,6 @@ public interface ComponentKJS extends Component, WithCodec, WrappedJS {
 		kjs$asIterable().forEach(action);
 	}
 
-	default MutableComponent kjs$fallback(String text) {
-    	TranslatableContents content = this.getContents();
-    	Object[] args = content.getArgs();
-    	if (args == null)
-			return Component.translatableWithFallback(new TranslatableContents(content.getKey(), text, TranslatableContents.NO_ARGS));
-    	return Component.translatableWithFallback(new TranslatableContents(content.getKey(), text, ...args));
-	}
-
 	// region ChatFormatting extensions
 	default MutableComponent kjs$black() {
 		return kjs$self().withStyle(ChatFormatting.BLACK);

--- a/src/main/java/dev/latvian/mods/kubejs/plugin/builtin/wrapper/TextWrapper.java
+++ b/src/main/java/dev/latvian/mods/kubejs/plugin/builtin/wrapper/TextWrapper.java
@@ -239,6 +239,11 @@ public interface TextWrapper {
 		return Component.translatable(key, objects);
 	}
 
+	@Info("Returns a translatable component of the input key, with args of the objects and a fallback")
+	static MutableComponent translateWithFallback(String key, String fallback, Object... objects) {
+		return Component.translatableWithFallback(key, fallback, objects);
+	}
+
 	@Info("Returns a translatable component of the input key")
 	static MutableComponent translatable(String key) {
 		return Component.translatable(key);
@@ -247,6 +252,11 @@ public interface TextWrapper {
 	@Info("Returns a translatable component of the input key, with args of the objects")
 	static MutableComponent translatable(String key, Object... objects) {
 		return Component.translatable(key, objects);
+	}
+
+	@Info("Returns a translatable component of the input key, with args of the objects and a fallback")
+	static MutableComponent translatableWithFallback(String key, String fallback, Object... objects) {
+		return Component.translatableWithFallback(key, fallback, objects);
 	}
 
 	@Info("Returns a keybinding component of the input keybinding descriptor")

--- a/src/main/java/dev/latvian/mods/kubejs/plugin/builtin/wrapper/TextWrapper.java
+++ b/src/main/java/dev/latvian/mods/kubejs/plugin/builtin/wrapper/TextWrapper.java
@@ -239,12 +239,12 @@ public interface TextWrapper {
 		return Component.translatable(key, objects);
 	}
 
-	@Info("Returns a translatable component of the input key, with args of the objects and a fallback")
+	@Info("Returns a translatable component of the input key, with args of the objects and a fallback translation in case the client does not have one")
 	static MutableComponent translateWithFallback(String key, String fallback) {
 		return Component.translatableWithFallback(key, fallback);
 	}
 
-	@Info("Returns a translatable component of the input key, with args of the objects and a fallback")
+	@Info("Returns a translatable component of the input key, with args of the objects and a fallback translation in case the client does not have one")
 	static MutableComponent translateWithFallback(String key, String fallback, Object... objects) {
 		return Component.translatableWithFallback(key, fallback, objects);
 	}
@@ -259,12 +259,12 @@ public interface TextWrapper {
 		return Component.translatable(key, objects);
 	}
 
-	@Info("Returns a translatable component of the input key, with args of the objects and a fallback")
+	@Info("Returns a translatable component of the input key, with args of the objects and a fallback translation in case the client does not have one")
 	static MutableComponent translatableWithFallback(String key, String fallback) {
 		return Component.translatableWithFallback(key, fallback);
 	}
 
-	@Info("Returns a translatable component of the input key, with args of the objects and a fallback")
+	@Info("Returns a translatable component of the input key, with args of the objects and a fallback translation in case the client does not have one")
 	static MutableComponent translatableWithFallback(String key, String fallback, Object... objects) {
 		return Component.translatableWithFallback(key, fallback, objects);
 	}

--- a/src/main/java/dev/latvian/mods/kubejs/plugin/builtin/wrapper/TextWrapper.java
+++ b/src/main/java/dev/latvian/mods/kubejs/plugin/builtin/wrapper/TextWrapper.java
@@ -240,6 +240,11 @@ public interface TextWrapper {
 	}
 
 	@Info("Returns a translatable component of the input key, with args of the objects and a fallback")
+	static MutableComponent translateWithFallback(String key, String fallback) {
+		return Component.translatableWithFallback(key, fallback);
+	}
+
+	@Info("Returns a translatable component of the input key, with args of the objects and a fallback")
 	static MutableComponent translateWithFallback(String key, String fallback, Object... objects) {
 		return Component.translatableWithFallback(key, fallback, objects);
 	}
@@ -252,6 +257,11 @@ public interface TextWrapper {
 	@Info("Returns a translatable component of the input key, with args of the objects")
 	static MutableComponent translatable(String key, Object... objects) {
 		return Component.translatable(key, objects);
+	}
+
+	@Info("Returns a translatable component of the input key, with args of the objects and a fallback")
+	static MutableComponent translatableWithFallback(String key, String fallback) {
+		return Component.translatableWithFallback(key, fallback);
 	}
 
 	@Info("Returns a translatable component of the input key, with args of the objects and a fallback")


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->

### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->

Add `.fallback(String text)` for `Text.translate()`

#### Example Script <!-- Please provide an example script showing that the bug is fixed, or how the feature is used, if applicable -->

```js
Text.translate("text.kubejs.foo").fallback("FooBar");
Text.translatable("text.kubejs.foo").fallback("FooBar");
```

#### Other details <!-- Any other important information, like if this is likely to break addons -->

This is my first submission, so I may need more suggestions to improve this feature.