### PR TITLE
Create a mixin plugin

### DIFF
--- a/src/main/java/dev/latvian/mods/kubejs/KubeJSMixinPlugin.java
+++ b/src/main/java/dev/latvian/mods/kubejs/KubeJSMixinPlugin.java
@@ -1,0 +1,55 @@
+package dev.latvian.mods.kubejs;
+
+import net.neoforged.fml.loading.LoadingModList;
+import org.jetbrains.annotations.NotNull;
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+import java.util.List;
+import java.util.Set;
+
+public class KubeJSMixinPlugin implements IMixinConfigPlugin {
+    @Override
+    public void onLoad(String mixinPackage) {
+
+    }
+
+    @Override
+    public String getRefMapperConfig() {
+        return null;
+    }
+
+    @Override
+    public boolean shouldApplyMixin(@NotNull String targetClassName, @NotNull String mixinClassName) {
+        if (targetClassName.contains("mezz/modnametooltip")) {
+            return LoadingModList.get().getModFileById("modnametooltip") != null;
+        }
+
+        if (targetClassName.contains("me/shedaniel/rei")) {
+            return LoadingModList.get().getModFileById("roughlyenoughitems") != null;
+        }
+
+        return true;
+    }
+
+    @Override
+    public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {
+
+    }
+
+    @Override
+    public List<String> getMixins() {
+        return null;
+    }
+
+    @Override
+    public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+
+    }
+
+    @Override
+    public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+
+    }
+}

--- a/src/main/resources/kubejs.mixins.json
+++ b/src/main/resources/kubejs.mixins.json
@@ -2,6 +2,7 @@
 	"required": true,
 	"minVersion": "0.8",
 	"package": "dev.latvian.mods.kubejs.core.mixin",
+	"plugin": "dev.latvian.mods.kubejs.KubeJSMixinPlugin",
 	"compatibilityLevel": "JAVA_21",
 	"mixins": [
 		"AdvancementNodeMixin",


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->

### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->
Normally during the "mixin apply phase," if the user does not have `modnametooltip` or `roughlyenoughitems` installed, Mixins would error/warn that the class does not exist, and continue doing the mixins.

This PR just checks if the mods are installed, and allow the mixin to be applied or not if the mod is present or not.

#### Other details <!-- Any other important information, like if this is likely to break addons -->
Nothing will be broken.