### PR TITLE
Fix default eating time in FoodBuilder.java

### DIFF
--- a/src/main/java/dev/latvian/mods/kubejs/item/FoodBuilder.java
+++ b/src/main/java/dev/latvian/mods/kubejs/item/FoodBuilder.java
@@ -31,7 +31,7 @@ public class FoodBuilder {
 		this.nutrition = 0;
 		this.saturation = 0;
 		this.alwaysEdible = false;
-		this.eatSeconds = 0.6F;
+		this.eatSeconds = 1.6F;
 		this.usingConvertsTo = Optional.empty();
 		this.effects = new ArrayList<>();
 	}


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->

### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->

Fixes an apparent bug where the default eating time is comically short; _less_ than the default time for foods that are `fastToEat`, and updates them to match the Minecraft default of 1.6 seconds

#### Example Script <!-- Please provide an example script showing that the bug is fixed, or how the feature is used, if applicable -->

```js
    event.create("sliced_bread").food((food) => {
        food.nutrition(4).saturation(0.25); // this now takes 1.6 seconds
    });

    event.create("cooked_warped_fungus").food((food) => {
         food.nutrition(2).saturation(0.25).fastToEat(); // This takes 0.8 seconds, which now matches the comment on line 77 of FoodBuilder.java
    });
```


#### Other details <!-- Any other important information, like if this is likely to break addons -->
Relevant comment from line 77 of FoodBuilder.java
```java
	@Info("Sets the food is fast to eat (having half of the eating time).")
	public FoodBuilder fastToEat() {
		return eatSeconds(0.8F);
	}
```