### PR TITLE
Fix the doors builder

### DIFF
--- a/src/main/java/dev/latvian/mods/kubejs/block/custom/DoorBlockBuilder.java
+++ b/src/main/java/dev/latvian/mods/kubejs/block/custom/DoorBlockBuilder.java
@@ -32,8 +32,16 @@ import java.util.Map;
 
 @ReturnsSelf
 public class DoorBlockBuilder extends ShapedBlockBuilder {
-	public static final ResourceLocation[] TRAPDOOR_TAGS = {
-		BlockTags.TRAPDOORS.location(),
+	public static final ResourceLocation[] DOOR_TAGS = {
+		BlockTags.DOORS.location()
+	};
+
+	public static final ResourceLocation[] MINEABLE_AXE_TAGS = {
+		BlockTags.MINEABLE_WITH_AXE.location(),
+	};
+
+	public static final ResourceLocation[] WOODEN_DOOR_TAGS = {
+		BlockTags.WOODEN_DOORS.location()
 	};
 
 	private static final Map<String, ResourceLocation> MODELS = Map.of(
@@ -54,7 +62,8 @@ public class DoorBlockBuilder extends ShapedBlockBuilder {
 		renderType(BlockRenderType.CUTOUT);
 		noValidSpawns(true);
 		notSolid();
-		tagBoth(TRAPDOOR_TAGS);
+		tagBoth(DOOR_TAGS);
+		tagBoth(MINEABLE_AXE_TAGS);
 		textures.put("top", newID("block/", "_top").toString());
 		textures.put("bottom", newID("block/", "_bottom").toString());
 		hardness(3F);
@@ -63,6 +72,11 @@ public class DoorBlockBuilder extends ShapedBlockBuilder {
 
 	public DoorBlockBuilder behaviour(BlockSetType wt) {
 		behaviour = wt;
+		return this;
+	}
+
+	public DoorBlockBuilder wooden() {
+		tagBoth(WOODEN_DOOR_TAGS);
 		return this;
 	}
 

--- a/src/main/java/dev/latvian/mods/kubejs/block/custom/DoorBlockBuilder.java
+++ b/src/main/java/dev/latvian/mods/kubejs/block/custom/DoorBlockBuilder.java
@@ -36,10 +36,6 @@ public class DoorBlockBuilder extends ShapedBlockBuilder {
 		BlockTags.DOORS.location()
 	};
 
-	public static final ResourceLocation[] MINEABLE_AXE_TAGS = {
-		BlockTags.MINEABLE_WITH_AXE.location(),
-	};
-
 	public static final ResourceLocation[] WOODEN_DOOR_TAGS = {
 		BlockTags.WOODEN_DOORS.location()
 	};
@@ -63,7 +59,6 @@ public class DoorBlockBuilder extends ShapedBlockBuilder {
 		noValidSpawns(true);
 		notSolid();
 		tagBoth(DOOR_TAGS);
-		tagBoth(MINEABLE_AXE_TAGS);
 		textures.put("top", newID("block/", "_top").toString());
 		textures.put("bottom", newID("block/", "_bottom").toString());
 		hardness(3F);


### PR DESCRIPTION
### Description
Fixes the following issue: https://github.com/KubeJS-Mods/KubeJS/issues/990

#### Example Script <!-- Please provide an example script showing that the bug is fixed, or how the feature is used, if applicable -->

```js
StartupEvents.registry('block', event => {
  event.create('unwooden_door', 'door')
    .soundType('polished_tuff')
    .hardness(3.0)
    .resistance(3.0)
    .requiresTool(true)
    .mapColor('terracotta_white')

      event.create('wooden_door', 'door')
        .soundType('polished_tuff')
        .hardness(3.0)
        .resistance(3.0)
        .requiresTool(true)
        .mapColor('terracotta_white')
        .wooden() // Tell KubeJS that this door is wooden
})
```

#### Other details
When you do `/kubejs hand`, these are the tags: 
Unwooden door: 
![image](https://github.com/user-attachments/assets/b2ab3d91-84b5-4846-9278-1b35fb2d24be)
<br>
Wooden door: 
![image](https://github.com/user-attachments/assets/f94d3102-c609-4440-8e44-0629aed4eab2)
