### PR TITLE
Avoid redundant pattern matches in `BlockStatePredicate#RegexMatch`

### DIFF
--- a/src/main/java/dev/latvian/mods/kubejs/block/state/BlockStatePredicate.java
+++ b/src/main/java/dev/latvian/mods/kubejs/block/state/BlockStatePredicate.java
@@ -324,10 +324,9 @@ public sealed interface BlockStatePredicate extends Predicate<BlockState>, Repla
 		public RegexMatch(Pattern p) {
 			pattern = p;
 			matchedBlocks = new LinkedHashSet<>();
-			for (var state : BlockWrapper.getAllBlockStates()) {
-				var block = state.getBlock();
+			for (var block : BuiltInRegistries.BLOCK) {
 				if (!matchedBlocks.contains(block) && pattern.matcher(block.kjs$getId()).find()) {
-					matchedBlocks.add(state.getBlock());
+					matchedBlocks.add(block);
 				}
 			}
 		}


### PR DESCRIPTION
The current implementation here tests the pattern against a given block once for every one of its states. This is redundant; it suffices to just loop over the registry and check each block once.