### PR TITLE
Add a command for kubejs /kjs quote_style double/single

### DIFF
--- a/src/main/java/dev/latvian/mods/kubejs/CommonProperties.java
+++ b/src/main/java/dev/latvian/mods/kubejs/CommonProperties.java
@@ -40,6 +40,7 @@ public class CommonProperties extends BaseProperties {
 	public int defaultMaxStackSize;
 	public JsonElement creativeModeTabIcon;
 	public JsonElement creativeModeTabName;
+	public boolean useDoubleQuotes;
 
 	private CommonProperties() {
 		super(KubeJSPaths.COMMON_PROPERTIES, "KubeJS Common Properties");
@@ -59,6 +60,7 @@ public class CommonProperties extends BaseProperties {
 		startupErrorReportUrl = get("startup_error_report_url", "");
 		removeSlotLimit = get("remove_slot_limit", false);
 		defaultMaxStackSize = Math.max(0, Math.min(1_000_000_000, get("default_max_stack_size", 0)));
+		useDoubleQuotes = get("use_double_quotes", false);
 
 		creativeModeTabIcon = get("creative_mode_tab_icon", new JsonObject());
 		creativeModeTabName = get("creative_mode_tab_name", JsonNull.INSTANCE);
@@ -68,6 +70,12 @@ public class CommonProperties extends BaseProperties {
 	public void setPackMode(String s) {
 		packMode = s;
 		set("packmode", new JsonPrimitive(s));
+		save();
+	}
+	
+	public void setUseDoubleQuotes(boolean value) {
+		useDoubleQuotes = value;
+		set("use_double_quotes", new JsonPrimitive(value));
 		save();
 	}
 

--- a/src/main/java/dev/latvian/mods/kubejs/command/InformationCommands.java
+++ b/src/main/java/dev/latvian/mods/kubejs/command/InformationCommands.java
@@ -1,5 +1,6 @@
 package dev.latvian.mods.kubejs.command;
 
+import dev.latvian.mods.kubejs.CommonProperties;
 import dev.latvian.mods.kubejs.ingredient.NamespaceIngredient;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.HolderSet;
@@ -27,9 +28,15 @@ public class InformationCommands {
 	}
 
 	private static Component copy(Component c, Component info) {
+		String textToCopy = c.getString();
+		
+		if (textToCopy.startsWith("'") && textToCopy.endsWith("'") && CommonProperties.get().useDoubleQuotes) {
+			textToCopy = "\"" + textToCopy.substring(1, textToCopy.length() - 1) + "\"";
+		}
+		
 		return Component.literal("- ")
 			.withStyle(ChatFormatting.GRAY)
-			.withStyle(Style.EMPTY.withClickEvent(new ClickEvent(ClickEvent.Action.COPY_TO_CLIPBOARD, c.getString())))
+			.withStyle(Style.EMPTY.withClickEvent(new ClickEvent(ClickEvent.Action.COPY_TO_CLIPBOARD, textToCopy)))
 			.withStyle(Style.EMPTY.withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, info.copy().append(" (Click to copy)"))))
 			.append(c);
 	}

--- a/src/main/java/dev/latvian/mods/kubejs/command/InformationCommands.java
+++ b/src/main/java/dev/latvian/mods/kubejs/command/InformationCommands.java
@@ -1,6 +1,5 @@
 package dev.latvian.mods.kubejs.command;
 
-import dev.latvian.mods.kubejs.CommonProperties;
 import dev.latvian.mods.kubejs.ingredient.NamespaceIngredient;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.HolderSet;
@@ -28,15 +27,9 @@ public class InformationCommands {
 	}
 
 	private static Component copy(Component c, Component info) {
-		String textToCopy = c.getString();
-		
-		if (textToCopy.startsWith("'") && textToCopy.endsWith("'") && CommonProperties.get().useDoubleQuotes) {
-			textToCopy = "\"" + textToCopy.substring(1, textToCopy.length() - 1) + "\"";
-		}
-		
 		return Component.literal("- ")
 			.withStyle(ChatFormatting.GRAY)
-			.withStyle(Style.EMPTY.withClickEvent(new ClickEvent(ClickEvent.Action.COPY_TO_CLIPBOARD, textToCopy)))
+			.withStyle(Style.EMPTY.withClickEvent(new ClickEvent(ClickEvent.Action.COPY_TO_CLIPBOARD, c.getString())))
 			.withStyle(Style.EMPTY.withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, info.copy().append(" (Click to copy)"))))
 			.append(c);
 	}

--- a/src/main/java/dev/latvian/mods/kubejs/command/KubeJSCommands.java
+++ b/src/main/java/dev/latvian/mods/kubejs/command/KubeJSCommands.java
@@ -198,6 +198,15 @@ public class KubeJSCommands {
 					.executes(context -> packmode(context.getSource(), StringArgumentType.getString(context, "name")))
 				)
 			)
+			.then(Commands.literal("quote_style")
+				.executes(context -> toggleQuoteStyle(context.getSource()))
+				.then(Commands.literal("single")
+					.executes(context -> setQuoteStyle(context.getSource(), false))
+				)
+				.then(Commands.literal("double")
+					.executes(context -> setQuoteStyle(context.getSource(), true))
+				)
+			)
 			.then(Commands.literal("persistent-data")
 				.requires(spOrOP)
 				.then(PersistentDataCommands.addPersistentDataCommands(Commands.literal("server"), ctx -> Set.of(ctx.getSource().getServer())))
@@ -544,6 +553,21 @@ public class KubeJSCommands {
 			source.sendSuccess(() -> Component.literal("Set packmode to: " + packmode), true);
 		}
 
+		return 1;
+	}
+	
+	private static int toggleQuoteStyle(CommandSourceStack source) {
+		boolean current = CommonProperties.get().useDoubleQuotes;
+		CommonProperties.get().setUseDoubleQuotes(!current);
+		String newStyle = CommonProperties.get().useDoubleQuotes ? "double" : "single";
+		source.sendSuccess(() -> Component.literal("Quote style switched to: " + newStyle + " quotes"), true);
+		return 1;
+	}
+	
+	private static int setQuoteStyle(CommandSourceStack source, boolean useDoubleQuotes) {
+		CommonProperties.get().setUseDoubleQuotes(useDoubleQuotes);
+		String style = useDoubleQuotes ? "double" : "single";
+		source.sendSuccess(() -> Component.literal("Quote style set to: " + style + " quotes"), true);
 		return 1;
 	}
 

--- a/src/main/java/dev/latvian/mods/kubejs/command/KubeJSCommands.java
+++ b/src/main/java/dev/latvian/mods/kubejs/command/KubeJSCommands.java
@@ -561,7 +561,6 @@ public class KubeJSCommands {
 		CommonProperties.get().setUseDoubleQuotes(!current);
 		String newStyle = CommonProperties.get().useDoubleQuotes ? "double" : "single";
 		source.sendSuccess(() -> Component.literal("Quote style switched to: " + newStyle + " quotes"), true);
-		source.sendSuccess(() -> Component.literal("Please use /kubejs hand again to apply the new quote style to chat messages.").withStyle(ChatFormatting.YELLOW), false);
 		return 1;
 	}
 	
@@ -569,7 +568,6 @@ public class KubeJSCommands {
 		CommonProperties.get().setUseDoubleQuotes(useDoubleQuotes);
 		String style = useDoubleQuotes ? "double" : "single";
 		source.sendSuccess(() -> Component.literal("Quote style set to: " + style + " quotes"), true);
-		source.sendSuccess(() -> Component.literal("Please use /kubejs hand again to apply the new quote style to chat messages.").withStyle(ChatFormatting.YELLOW), false);
 		return 1;
 	}
 

--- a/src/main/java/dev/latvian/mods/kubejs/command/KubeJSCommands.java
+++ b/src/main/java/dev/latvian/mods/kubejs/command/KubeJSCommands.java
@@ -561,6 +561,7 @@ public class KubeJSCommands {
 		CommonProperties.get().setUseDoubleQuotes(!current);
 		String newStyle = CommonProperties.get().useDoubleQuotes ? "double" : "single";
 		source.sendSuccess(() -> Component.literal("Quote style switched to: " + newStyle + " quotes"), true);
+		source.sendSuccess(() -> Component.literal("Please use /kubejs hand again to apply the new quote style to chat messages.").withStyle(ChatFormatting.YELLOW), false);
 		return 1;
 	}
 	
@@ -568,6 +569,7 @@ public class KubeJSCommands {
 		CommonProperties.get().setUseDoubleQuotes(useDoubleQuotes);
 		String style = useDoubleQuotes ? "double" : "single";
 		source.sendSuccess(() -> Component.literal("Quote style set to: " + style + " quotes"), true);
+		source.sendSuccess(() -> Component.literal("Please use /kubejs hand again to apply the new quote style to chat messages.").withStyle(ChatFormatting.YELLOW), false);
 		return 1;
 	}
 

--- a/src/main/java/dev/latvian/mods/kubejs/core/mixin/ClickEventMixin.java
+++ b/src/main/java/dev/latvian/mods/kubejs/core/mixin/ClickEventMixin.java
@@ -1,16 +1,29 @@
 package dev.latvian.mods.kubejs.core.mixin;
 
 import com.mojang.serialization.Codec;
+import dev.latvian.mods.kubejs.CommonProperties;
 import dev.latvian.mods.kubejs.util.WithCodec;
 import dev.latvian.mods.rhino.Context;
 import net.minecraft.network.chat.ClickEvent;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(ClickEvent.class)
 public abstract class ClickEventMixin implements WithCodec {
 	@Shadow
 	public abstract String getValue();
+	
+	@Inject(method = "getValue", at = @At("RETURN"), cancellable = true)
+	private void kubejs$getValueWithQuoteStyle(CallbackInfoReturnable<String> cir) {
+		String value = cir.getReturnValue();
+		
+		if (CommonProperties.get().useDoubleQuotes && value != null && value.startsWith("'") && value.endsWith("'")) {
+			cir.setReturnValue("\"" + value.substring(1, value.length() - 1) + "\"");
+		}
+	}
 
 	@Override
 	public Codec<?> getCodec(Context cx) {

--- a/src/main/java/dev/latvian/mods/kubejs/core/mixin/ClickEventMixin.java
+++ b/src/main/java/dev/latvian/mods/kubejs/core/mixin/ClickEventMixin.java
@@ -1,29 +1,16 @@
 package dev.latvian.mods.kubejs.core.mixin;
 
 import com.mojang.serialization.Codec;
-import dev.latvian.mods.kubejs.CommonProperties;
 import dev.latvian.mods.kubejs.util.WithCodec;
 import dev.latvian.mods.rhino.Context;
 import net.minecraft.network.chat.ClickEvent;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(ClickEvent.class)
 public abstract class ClickEventMixin implements WithCodec {
 	@Shadow
 	public abstract String getValue();
-	
-	@Inject(method = "getValue", at = @At("RETURN"), cancellable = true)
-	private void kubejs$getValueWithQuoteStyle(CallbackInfoReturnable<String> cir) {
-		String value = cir.getReturnValue();
-		
-		if (CommonProperties.get().useDoubleQuotes && value != null && value.startsWith("'") && value.endsWith("'")) {
-			cir.setReturnValue("\"" + value.substring(1, value.length() - 1) + "\"");
-		}
-	}
 
 	@Override
 	public Codec<?> getCodec(Context cx) {


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->

### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->

Used to choose between double quotes or single quotes when copying item ID or Tag.

Because I have found that many players find it tedious to format between double and single quotes when copying things similar to ItemId while writing KubeJS code

#### Example Script <!-- Please provide an example script showing that the bug is fixed, or how the feature is used, if applicable -->

```mcfunction
/kubejs quote_style double
```

```mcfunction
/kubejs quote_style single
```

Use double style to display after pressing ctr+v in the editor
```js
Item.of("minecraft:diamond")
```
Use single style to display after pressing Ctrl+V in the editor
```js
Item.of('minecraft:dimaond')
```
#### Other details <!-- Any other important information, like if this is likely to break addons -->