### PR TITLE
Add null safety to SendDataFromClient/ServerPayload constructors

### DIFF
--- a/src/main/java/dev/latvian/mods/kubejs/net/SendDataFromClientPayload.java
+++ b/src/main/java/dev/latvian/mods/kubejs/net/SendDataFromClientPayload.java
@@ -9,8 +9,16 @@ import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.server.level.ServerPlayer;
 import net.neoforged.neoforge.network.handling.IPayloadContext;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
 
 public record SendDataFromClientPayload(String channel, CompoundTag data) implements CustomPacketPayload {
+	public SendDataFromClientPayload(String channel, @Nullable CompoundTag data) {
+		this.channel = channel;
+		this.data = Objects.requireNonNullElseGet(data, CompoundTag::new);
+	}
+
 	public static final StreamCodec<ByteBuf, SendDataFromClientPayload> STREAM_CODEC = StreamCodec.composite(
 		ByteBufCodecs.STRING_UTF8, SendDataFromClientPayload::channel,
 		ByteBufCodecs.COMPOUND_TAG, SendDataFromClientPayload::data,

--- a/src/main/java/dev/latvian/mods/kubejs/net/SendDataFromServerPayload.java
+++ b/src/main/java/dev/latvian/mods/kubejs/net/SendDataFromServerPayload.java
@@ -7,8 +7,16 @@ import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.neoforged.neoforge.network.handling.IPayloadContext;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
 
 public record SendDataFromServerPayload(String channel, CompoundTag data) implements CustomPacketPayload {
+	public SendDataFromServerPayload(String channel, @Nullable CompoundTag data) {
+		this.channel = channel;
+		this.data = Objects.requireNonNullElseGet(data, CompoundTag::new);
+	}
+
 	public static final StreamCodec<ByteBuf, SendDataFromServerPayload> STREAM_CODEC = StreamCodec.composite(
 		ByteBufCodecs.STRING_UTF8, SendDataFromServerPayload::channel,
 		ByteBufCodecs.COMPOUND_TAG, SendDataFromServerPayload::data,


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->

### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->

Add null safety to SendDataFromClient/ServerPayload constructors to fix a codec error.

<img width="1920" height="1080" alt="img" src="https://github.com/user-attachments/assets/968bbfdc-90de-476c-88ea-5cda62e679c3" />

#### Example Script <!-- Please provide an example script showing that the bug is fixed, or how the feature is used, if applicable -->

server side:
```js
ItemEvents.rightClicked((event) => {
  event.player.sendData("kubejs:hello_world", { message: "Hello, World!" });
  event.player.sendData("kubejs:hello_world"); // It should no longer cause the error
});
```

client side:
```js
NetworkEvents.dataReceived('kubejs:hello_world', (event) => {
  if (event.data.message) {
    event.player.tell(event.data.message);
  } else {
    event.player.tell('!!!Hello, World!!!');
  }
});
```

<img width="1920" height="1080" alt="img" src="https://github.com/user-attachments/assets/fcf44211-72ef-462d-8b7a-2c5da8cb944b" />

#### Other details <!-- Any other important information, like if this is likely to break addons -->