### PR TITLE
InventoryAttachemnt Flexibility

### DIFF
--- a/src/main/java/dev/latvian/mods/kubejs/block/entity/InventoryAttachment.java
+++ b/src/main/java/dev/latvian/mods/kubejs/block/entity/InventoryAttachment.java
@@ -36,7 +36,7 @@ public class InventoryAttachment implements BlockEntityAttachment {
 	}
 
 	public static class Wrapped extends ItemStackHandler implements InventoryKJS {
-		private final InventoryAttachment attachment;
+		protected final InventoryAttachment attachment;
 
 		public Wrapped(InventoryAttachment attachment) {
 			super(attachment.width * attachment.height);
@@ -78,7 +78,11 @@ public class InventoryAttachment implements BlockEntityAttachment {
 		this.height = height;
 		this.blockEntity = blockEntity;
 		this.inputFilter = inputFilter;
-		this.inventory = new Wrapped(this);
+		this.inventory = createInventory();
+	}
+
+	protected Wrapped createInventory() {
+		return new Wrapped(this);
 	}
 
 	@Override


### PR DESCRIPTION
Allows for subclasses of `InventoryAttachment` to have their own implementation of the inventory wrapper without duplicating fields.

I encountered this while porting the [extension](https://github.com/Notenoughmail/KubeJS-TFC/blob/1.21.1/src/main/java/io/github/notenoughmail/kubejstfc/implementation/attachments/TFCInventoryAttachment.java#L47) that has the option to filter items based on TFC's size & weight system.