### PR TITLE
Fix error on empty ItemStack in key-pattern cleanup.

### DIFF
--- a/src/main/java/dev/latvian/mods/kubejs/recipe/schema/postprocessing/KeyPatternCleanupPostProcessor.java
+++ b/src/main/java/dev/latvian/mods/kubejs/recipe/schema/postprocessing/KeyPatternCleanupPostProcessor.java
@@ -3,6 +3,7 @@ package dev.latvian.mods.kubejs.recipe.schema.postprocessing;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import dev.latvian.mods.kubejs.KubeJS;
+import dev.latvian.mods.kubejs.error.KubeRuntimeException;
 import dev.latvian.mods.kubejs.recipe.KubeRecipe;
 import dev.latvian.mods.kubejs.recipe.RecipeKey;
 import dev.latvian.mods.kubejs.recipe.component.IngredientComponent;
@@ -48,7 +49,7 @@ public record KeyPatternCleanupPostProcessor(String patternName, String keyName,
 				airs.add(entry.key().charValue());
 				itr.remove();
 			} else if (component.isEmpty(Cast.to(entry.value()))) {
-				throw new dev.latvian.mods.kubejs.error.KubeRuntimeException(
+				throw new KubeRuntimeException(
 					"Empty stack for key '" + keyName + "' at '" + entry.key().charValue() + "' in recipe " + recipe.getOrCreateId()
 				).source(recipe.sourceLine);
 			}


### PR DESCRIPTION
Throw KubeRuntimeException when a key entry resolves to an empty stack in KeyPatternCleanupPostProcessor.process. Null entries are still treated as air and stripped from the key/pattern. This prevents silent fallback from type wrappers that coerce bad inputs to ItemStack.EMPTY and surfaces misconfigurations during validation.

#### Example 

```js
ServerEvents.recipes(event => {
    // "minecraft:empty_bucket does not exist and will trigger an empty ItemStack error instead of air fallback
    event.shaped("minecraft:apple",
        [
            "XXX",
            "XOX",
            "XXX"
        ],
        {
            "X": "minecraft:acacia_boat",
            "O": "minecraft:empty_bucket"
        }
    )
})
```

