### PR TITLE
bug: fix empty texture detection logic

### DIFF
--- a/src/main/java/dev/latvian/mods/kubejs/fluid/FluidBuilder.java
+++ b/src/main/java/dev/latvian/mods/kubejs/fluid/FluidBuilder.java
@@ -160,13 +160,13 @@ public class FluidBuilder extends BuilderBase<FlowingFluid> {
 	public void generateAssets(KubeAssetGenerator generator) {
 		var stillTexture = generator.loadTexture(fluidType.stillTexture);
 
-		if (stillTexture != LoadedTexture.EMPTY) {
+		if (!(stillTexture.width <= 0 || stillTexture.height <= 0)) {
 			generator.texture(fluidType.actualStillTexture, stillTexture.tint(fluidType.tint));
 		}
 
 		var flowingTexture = generator.loadTexture(fluidType.flowingTexture);
 
-		if (flowingTexture != LoadedTexture.EMPTY) {
+		if (!(stillTexture.width <= 0 || stillTexture.height <= 0)) {
 			generator.texture(fluidType.actualFlowingTexture, flowingTexture.tint(fluidType.tint));
 		}
 


### PR DESCRIPTION
resolve #1058 

```js
StartupEvents.registry("fluid", (event) => {
  event.create("test_fluid")
});
```

https://github.com/KubeJS-Mods/KubeJS/blob/21cd7e73e27d3dee78114e608fbb9b06d3b4e74f/src/main/java/dev/latvian/mods/kubejs/generator/KubeAssetGenerator.java#L25-L27

https://github.com/KubeJS-Mods/KubeJS/blob/21cd7e73e27d3dee78114e608fbb9b06d3b4e74f/src/main/java/dev/latvian/mods/kubejs/client/LoadedTexture.java#L24-L48

generator.loadTexture(...) always returns a non-null value
it uses [`LoadedTexture.EMPTY`](https://github.com/KubeJS-Mods/KubeJS/blob/21cd7e73e27d3dee78114e608fbb9b06d3b4e74f/src/main/java/dev/latvian/mods/kubejs/client/LoadedTexture.java#L47) to represent an empty texture.

