### PR TITLE
Remove remapping of Entity.hurt

### DIFF
--- a/src/main/java/dev/latvian/mods/kubejs/core/mixin/EntityMixin.java
+++ b/src/main/java/dev/latvian/mods/kubejs/core/mixin/EntityMixin.java
@@ -143,10 +143,6 @@ public abstract class EntityMixin implements EntityKJS {
 	public abstract void clearFire();
 
 	@Shadow
-	@RemapForJS("attack")
-	public abstract boolean hurt(DamageSource source, float hp);
-
-	@Shadow
 	@RemapForJS("getDistanceSq")
 	public abstract double distanceToSqr(double x, double y, double z);
 


### PR DESCRIPTION
`Entity` already has a method called `attack`, which is used when the entity attacks something. `hurt` is used to damage the entity it is called on, so they have different usages, which makes it confusing that they have the same name in kjs.