### PR TITLE
Modify KubeJS dependency declaration in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ repositories {
 You can then declare KubeJS as a regular compile-time dependency in your `dependencies` block:
 
 ```groovy
-api("dev.latvian.mods:kubejs-neoforge:$kubejs_version")
+api("dev.latvian.mods:kubejs-neoforge:$kubejs_version") { transitive = false }
+api("dev.latvian.mods:rhino:$rhino_version")
 interfaceInjectionData("dev.latvian.mods:kubejs-neoforge:$kubejs_version") // optional
 ```
 


### PR DESCRIPTION
The recent commit had "(you should still not be using this transitively)" in the name, so we may as well also tell other devs because I was having issues at first