### PR TITLE
Respect `override_type` of Schemas

### DIFF
--- a/src/main/java/dev/latvian/mods/kubejs/recipe/KubeRecipe.java
+++ b/src/main/java/dev/latvian/mods/kubejs/recipe/KubeRecipe.java
@@ -515,7 +515,7 @@ public class KubeRecipe implements RecipeLikeKJS, CustomJavaToJsWrapper {
 			}
 
 			if (newRecipe) {
-				json.addProperty("type", getSerializationTypeFunction().schemaType.serializerKey.location().toString());
+				json.addProperty("type", getSerializationTypeFunction().schemaType.serializerType);
 			}
 
 			if (type.event.stageSerializer != null && json.has(KubeJSCraftingRecipe.STAGE_KEY) && !type.idString.equals("recipestages:stage")) {

--- a/src/main/java/dev/latvian/mods/kubejs/recipe/schema/RecipeSchemaType.java
+++ b/src/main/java/dev/latvian/mods/kubejs/recipe/schema/RecipeSchemaType.java
@@ -14,6 +14,7 @@ public class RecipeSchemaType {
 	public final ResourceLocation id;
 	public final RecipeSchema schema;
 	public final ResourceKey<RecipeSerializer<?>> serializerKey;
+	public final String serializerType;
 	public RecipeSchemaType parent;
 	protected Optional<RecipeSerializer<?>> serializer;
 
@@ -22,6 +23,7 @@ public class RecipeSchemaType {
 		this.id = id;
 		this.schema = schema;
 		this.serializerKey = ResourceKey.create(Registries.RECIPE_SERIALIZER, schema.typeOverride == null ? id : schema.typeOverride);
+		serializerType = serializerKey.location().toString();
 	}
 
 	public RecipeSerializer<?> getSerializer() {


### PR DESCRIPTION
Turns out the `override_type` value is completely ignored currently, meaning simple alias recipe types (e.g. `tfc:shaped` --> `tfc:advanced_shaped_crafting`) are impossible without a custom `KubeRecipe` implementation