### PR TITLE
Add new method to BindingRegisty for simple class naming

### DIFF
--- a/src/main/java/dev/latvian/mods/kubejs/script/BindingRegistry.java
+++ b/src/main/java/dev/latvian/mods/kubejs/script/BindingRegistry.java
@@ -12,4 +12,10 @@ public record BindingRegistry(KubeJSContext context, Scriptable scope) {
 			context.addToScope(scope, name, value);
 		}
 	}
+
+	public void add(Class<?> value) {
+		if (value != null) {
+			context.addToScope(scope, value.getSimpleName(), value);
+		}
+	}
 }


### PR DESCRIPTION
### Description 
Lot's of bindings are mostly classes, and most times it's just the class name, and so this can simplify it a bit for adding a binding

#### Example Script
```java
public void registerBindings(BindingRegistry bindings) {
    bindings.add(SomeClassName.class); // This get's registered into kjs as "SomeClassName"
}
```