### PR TITLE
Entity-related changes

### DIFF
--- a/src/main/java/dev/latvian/mods/kubejs/core/ClientPlayerKJS.java
+++ b/src/main/java/dev/latvian/mods/kubejs/core/ClientPlayerKJS.java
@@ -1,20 +1,28 @@
 package dev.latvian.mods.kubejs.core;
 
 import dev.latvian.mods.kubejs.player.PlayerStatsJS;
+import dev.latvian.mods.kubejs.typings.Info;
+import dev.latvian.mods.kubejs.typings.ThisIs;
 import dev.latvian.mods.kubejs.util.NotificationToastData;
+import dev.latvian.mods.rhino.util.HideFromJS;
 import dev.latvian.mods.rhino.util.RemapPrefixForJS;
 import net.minecraft.client.player.AbstractClientPlayer;
+import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.nbt.CompoundTag;
 import org.jetbrains.annotations.Nullable;
 
 @RemapPrefixForJS("kjs$")
 public interface ClientPlayerKJS extends PlayerKJS {
 	@Override
+	@HideFromJS
 	default AbstractClientPlayer kjs$self() {
 		return (AbstractClientPlayer) this;
 	}
 
-	default boolean isSelf() {
+	@Override
+	@ThisIs(LocalPlayer.class)
+	@Info("Checks, whether the entity is a reference to yourself - that is - the client player you are controlling.")
+	default boolean kjs$isSelf() {
 		return false;
 	}
 

--- a/src/main/java/dev/latvian/mods/kubejs/core/ClientPlayerKJS.java
+++ b/src/main/java/dev/latvian/mods/kubejs/core/ClientPlayerKJS.java
@@ -7,7 +7,6 @@ import dev.latvian.mods.kubejs.util.NotificationToastData;
 import dev.latvian.mods.rhino.util.HideFromJS;
 import dev.latvian.mods.rhino.util.RemapPrefixForJS;
 import net.minecraft.client.player.AbstractClientPlayer;
-import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.nbt.CompoundTag;
 import org.jetbrains.annotations.Nullable;
 
@@ -19,11 +18,10 @@ public interface ClientPlayerKJS extends PlayerKJS {
 		return (AbstractClientPlayer) this;
 	}
 
-	@Override
-	@ThisIs(LocalPlayer.class)
-	@Info("Checks, whether the entity is a reference to yourself - that is - the client player you are controlling.")
-	default boolean kjs$isSelf() {
-		return false;
+	@ThisIs(AbstractClientPlayer.class)
+	@Info("Checks if the entity is a client-side player.")
+	default boolean kjs$isClientPlayer() {
+		return true;
 	}
 
 	@Override

--- a/src/main/java/dev/latvian/mods/kubejs/core/EntityKJS.java
+++ b/src/main/java/dev/latvian/mods/kubejs/core/EntityKJS.java
@@ -1,12 +1,14 @@
 package dev.latvian.mods.kubejs.core;
 
 import com.mojang.authlib.GameProfile;
-import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import dev.latvian.mods.kubejs.entity.KubeRayTraceResult;
 import dev.latvian.mods.kubejs.level.LevelBlock;
 import dev.latvian.mods.kubejs.player.EntityArrayList;
 import dev.latvian.mods.kubejs.script.ScriptType;
 import dev.latvian.mods.kubejs.script.ScriptTypeHolder;
+import dev.latvian.mods.kubejs.typings.Info;
+import dev.latvian.mods.kubejs.typings.Param;
+import dev.latvian.mods.kubejs.typings.ThisIs;
 import dev.latvian.mods.kubejs.util.UtilsJS;
 import dev.latvian.mods.rhino.util.HideFromJS;
 import dev.latvian.mods.rhino.util.RemapPrefixForJS;
@@ -19,12 +21,16 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.server.commands.TeleportCommand;
 import net.minecraft.server.level.ServerLevel;
-import net.minecraft.sounds.SoundEvent;
+import net.minecraft.util.Mth;
+import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.MobCategory;
+import net.minecraft.world.entity.PathfinderMob;
 import net.minecraft.world.entity.decoration.ItemFrame;
+import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.projectile.ProjectileUtil;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
@@ -39,7 +45,9 @@ import java.util.Set;
 import java.util.function.Predicate;
 
 @RemapPrefixForJS("kjs$")
+//@SuppressWarnings("unused")
 public interface EntityKJS extends WithPersistentData, MessageSenderKJS, ScriptTypeHolder {
+	@HideFromJS
 	default Entity kjs$self() {
 		return (Entity) this;
 	}
@@ -57,8 +65,21 @@ public interface EntityKJS extends WithPersistentData, MessageSenderKJS, ScriptT
 		return kjs$self().getType().kjs$getId();
 	}
 
+	@ThisIs(LocalClientPlayerKJS.class)
+	@Info("Checks, whether the entity is a reference to yourself - that is - the client player you are controlling.")
+	default boolean kjs$isSelf() {
+		return false;
+	}
+
+	@Nullable
 	default GameProfile kjs$getProfile() {
-		return new GameProfile(kjs$self().getUUID(), kjs$self().getScoreboardName());
+		return null;
+	}
+
+	@Info("Gets the entity's custom name, or entity ID if entity has no custom name.")
+	default String kjs$getUsername() {
+		Component customName = kjs$self().getCustomName();
+		return customName != null ? customName.getString() : kjs$getType();
 	}
 
 	@Override
@@ -71,12 +92,18 @@ public interface EntityKJS extends WithPersistentData, MessageSenderKJS, ScriptT
 		return kjs$self().getDisplayName();
 	}
 
+	@Info(value = "Sends a message in chat to the entity.", params = {
+		@Param(name = "message", value = "A text component. It may be a string, which will be implicitly wrapped into a text component."),
+	})
 	@Override
 	default void kjs$tell(Component message) {
 		kjs$self().sendSystemMessage(message);
 	}
 
 	@Override
+	@Info(value = "Runs the specified console command with permission level of the entity.", params = {
+		@Param(name = "command", value = "The console command. Slash at the beginning is optional."),
+	})
 	default void kjs$runCommand(String command) {
 		if (kjs$getLevel() instanceof ServerLevel level) {
 			level.getServer().getCommands().performPrefixedCommand(kjs$self().createCommandSourceStack(), command);
@@ -84,45 +111,71 @@ public interface EntityKJS extends WithPersistentData, MessageSenderKJS, ScriptT
 	}
 
 	@Override
+	@Info(value = "Runs the specified console command with permission level of the entity. The command won't output any logs in chat nor console.", params = {
+		@Param(name = "command", value = "The console command. Slash at the beginning is optional."),
+	})
 	default void kjs$runCommandSilent(String command) {
 		if (kjs$getLevel() instanceof ServerLevel level) {
 			level.getServer().getCommands().performPrefixedCommand(kjs$self().createCommandSourceStack().withSuppressedOutput(), command);
 		}
 	}
 
+	@ThisIs(Player.class)
+	@Info("Checks if the entity is a player entity.")
 	default boolean kjs$isPlayer() {
 		return false;
 	}
 
 	@Nullable
+	@Info("""
+		Gets the item stack corresponding to either:
+		- the item contained in the item entity,
+		- the item in the item frame.
+		Will be `null` if the entity is neither an item entity nor an item frame.
+		""")
 	default ItemStack kjs$getItem() {
 		return null;
 	}
 
+	@ThisIs(ItemFrame.class)
+	@Info("Checks if the entity is an item frame entity.")
 	default boolean kjs$isFrame() {
 		return this instanceof ItemFrame;
 	}
 
+	@ThisIs(ItemEntity.class)
+	@Info("Checks if the entity is an item entity.")
+	default boolean kjs$isItem() {
+		return this instanceof ItemEntity;
+	}
+
+	@ThisIs(LivingEntity.class)
+	@Info("Checks if the entity is a `LivingEntity`.")
 	default boolean kjs$isLiving() {
 		return false;
 	}
 
+	@Info("Checks if the entity is a monster.")
 	default boolean kjs$isMonster() {
 		return !kjs$self().getType().getCategory().isFriendly();
 	}
 
+	@Info("Checks if the entity is an animal.")
 	default boolean kjs$isAnimal() {
 		return kjs$self().getType().getCategory().isPersistent();
 	}
 
+	@Info("Checks if the entity is an ambient creature.")
 	default boolean kjs$isAmbientCreature() {
 		return kjs$self().getType().getCategory() == MobCategory.AMBIENT;
 	}
 
+	@Info("Checks if the entity is a water creature.")
 	default boolean kjs$isWaterCreature() {
 		return kjs$self().getType().getCategory() == MobCategory.WATER_CREATURE;
 	}
 
+	@Info("Checks if the entity is a peaceful creature (not a monster).")
 	default boolean kjs$isPeacefulCreature() {
 		return kjs$self().getType().getCategory().isFriendly();
 	}
@@ -166,42 +219,100 @@ public interface EntityKJS extends WithPersistentData, MessageSenderKJS, ScriptT
 		kjs$self().setDeltaMovement(m.x, m.y, z);
 	}
 
-	default void kjs$teleportTo(ResourceLocation dimension, double x, double y, double z, float yaw, float pitch) {
-		var previousLevel = kjs$getLevel();
-		var level = kjs$getServer().getLevel(ResourceKey.create(Registries.DIMENSION, dimension));
-
-		if (level == null) {
-			throw new IllegalArgumentException("Invalid dimension!");
-		}
-
+	@Info(value = "Teleports an entity to specified coordinates.", params = {
+		@Param(name = "x", value = "The `x` target coordinate."),
+		@Param(name = "y", value = "The `y` target coordinate."),
+		@Param(name = "z", value = "The `z` target coordinate."),
+	})
+	default void kjs$teleportTo(double x, double y, double z) throws IllegalArgumentException {
+		Entity self = kjs$self();
 		if (!Level.isInSpawnableBounds(BlockPos.containing(x, y, z))) {
-			throw new IllegalArgumentException("Invalid coordinates!");
-		} else if (Float.isNaN(yaw) || Float.isNaN(pitch)) {
-			throw new IllegalArgumentException("Invalid rotation!");
+			throw new IllegalArgumentException("The provided coordinates are out of bounds.");
 		}
+		kjs$self().teleportTo(x, y, z);
+	}
 
-		if (level == previousLevel) {
-			kjs$setPositionAndRotation(x, y, z, yaw, pitch);
-			return;
+	private void checkDestinationValidity(BlockPos blockPos, float yaw, float pitch) throws IllegalArgumentException {
+		if (!Level.isInSpawnableBounds(blockPos)) {
+			throw new IllegalArgumentException("The provided coordinates are out of bounds.");
 		}
-
-		try {
-			TeleportCommand.performTeleport(
-				kjs$self().createCommandSourceStack(),
-				kjs$self(),
-				level,
-				x, y, z,
-				Set.of(),
-				yaw, pitch,
-				null
-			);
-		} catch (CommandSyntaxException e) {
-			throw new IllegalArgumentException(e.getRawMessage().getString());
+		if (Float.isNaN(yaw)) {
+			throw new IllegalArgumentException("Yaw is not a number.");
+		}
+		if (Float.isNaN(pitch)) {
+			throw new IllegalArgumentException("Pitch is not a number.");
 		}
 	}
 
+	@Info(value = "Teleports an entity to a specified `ServerLevel`, to specified coordinates and rotation.", params = {
+		@Param(name = "level", value = "A `ServerLevel` to teleport the entity to."),
+		@Param(name = "x", value = "The `x` target coordinate."),
+		@Param(name = "y", value = "The `y` target coordinate."),
+		@Param(name = "z", value = "The `z` target coordinate."),
+		@Param(name = "yaw", value = "The entity's target yaw."),
+		@Param(name = "pitch", value = "The entity's target pitch.")
+	})
+	default boolean kjs$teleportToLevel(ServerLevel level, double x, double y, double z, float yaw, float pitch) throws IllegalArgumentException {
+		Entity self = kjs$self();
+		Level previousLevel = kjs$getLevel();
+
+		checkDestinationValidity(BlockPos.containing(x, y, z), yaw, pitch);
+
+		if (level == previousLevel) {
+			kjs$setPositionAndRotation(x, y, z, yaw, pitch);
+			return true;
+		}
+
+		float adjustedYaw = Mth.wrapDegrees(yaw);
+		float adjustedPitch = Mth.wrapDegrees(pitch);
+
+		boolean teleportSucceeded = self.teleportTo(level, x, y, z, Set.of(), adjustedYaw, adjustedPitch);
+		if (!teleportSucceeded) {
+			return false;
+		}
+
+		if (self instanceof LivingEntity livingEntity && !livingEntity.isFallFlying()) {
+			livingEntity.setDeltaMovement(livingEntity.getDeltaMovement().multiply(1.0, 0.0, 1.0));
+			livingEntity.setOnGround(true);
+		}
+		if (self instanceof PathfinderMob pathfinderMob) {
+			pathfinderMob.getNavigation().stop();
+		}
+		return true;
+	}
+
+	@Info(value = "Teleports an entity to a dimension of specified ID, to specified coordinates and rotation.", params = {
+		@Param(name = "dimension", value = "A `ResourceLocation` of the target dimension. It can be a string representing the dimension ID."),
+		@Param(name = "x", value = "The `x` target coordinate."),
+		@Param(name = "y", value = "The `y` target coordinate."),
+		@Param(name = "z", value = "The `z` target coordinate."),
+		@Param(name = "yaw", value = "The entity's target yaw."),
+		@Param(name = "pitch", value = "The entity's target pitch.")
+	})
+	default boolean kjs$teleportTo(ResourceLocation dimension, double x, double y, double z, float yaw, float pitch) throws IllegalArgumentException {
+		ServerLevel level = kjs$getServer().getLevel(ResourceKey.create(Registries.DIMENSION, dimension));
+
+		if (level == null) {
+			throw new IllegalArgumentException("The provided dimension ID is invalid.");
+		}
+
+		return kjs$teleportToLevel(level, x, y, z, yaw, pitch);
+	}
+
+	@Info(value = "Teleports an entity to a dimension of specified ID, to specified coordinates and rotation.", params = {
+		@Param(name = "x", value = "The `x` target coordinate."),
+		@Param(name = "y", value = "The `y` target coordinate."),
+		@Param(name = "z", value = "The `z` target coordinate."),
+		@Param(name = "yaw", value = "The entity's target yaw."),
+		@Param(name = "pitch", value = "The entity's target pitch.")
+	})
+	default void kjs$teleportTo(double x, double y, double z, float yaw, float pitch) throws IllegalArgumentException {
+		checkDestinationValidity(BlockPos.containing(x, y, z), yaw, pitch);
+		kjs$setPositionAndRotation(x, y, z, yaw, pitch);
+	}
+
 	default void kjs$setPosition(LevelBlock block) {
-		kjs$teleportTo(block.getDimension(), block.getX(), block.getY(), block.getZ(), kjs$self().getYRot(), kjs$self().getXRot());
+		kjs$teleportTo(block.getX(), block.getY(), block.getZ());
 	}
 
 	default void kjs$setPositionAndRotation(double x, double y, double z, float yaw, float pitch) {
@@ -216,20 +327,35 @@ public interface EntityKJS extends WithPersistentData, MessageSenderKJS, ScriptT
 		kjs$setPositionAndRotation(kjs$self().getX(), kjs$self().getY(), kjs$self().getZ(), yaw, pitch);
 	}
 
+	@Info("Gets a list of all passengers of the entity.")
 	default EntityArrayList kjs$getPassengers() {
 		return new EntityArrayList(kjs$self().getPassengers());
 	}
 
-	default String kjs$getTeamId() {
+	@Info("Gets the name of the team entity is in, or `''` (empty string) if the entity is not part of any team")
+	default String kjs$getTeamName() {
 		var team = kjs$self().getTeam();
 		return team == null ? "" : team.getName();
 	}
 
-	default boolean kjs$isOnScoreboardTeam(String teamId) {
-		Team team = kjs$self().getCommandSenderWorld().getScoreboard().getPlayerTeam(teamId);
+	@Info("Checks, whether the entity is part of any team.")
+	default boolean kjs$isOnScoreboardTeam() {
+		return kjs$self().getTeam() != null;
+	}
+
+	@Info(value = "Checks, whether the entity is part of a team called `teamName`.", params = {
+		@Param(name = "teamName", value = "The name of the team to check.")
+	})
+	default boolean kjs$isOnScoreboardTeam(String teamName) {
+		Team team = kjs$self().getCommandSenderWorld().getScoreboard().getPlayerTeam(teamName);
 		return team != null && kjs$self().isAlliedTo(team);
 	}
 
+	@Info("""
+		Gets the entity's facing direction.
+		If the entity faces more than 45 degrees up or down, the resulting facing direction is respectively `up` or `down`.
+		Otherwise, the resulting facing direction is determined by whichever cardinal direction is closer to entity's yaw.
+		""")
 	default Direction kjs$getFacing() {
 		if (kjs$self().getXRot() > 45F) {
 			return Direction.DOWN;
@@ -240,6 +366,7 @@ public interface EntityKJS extends WithPersistentData, MessageSenderKJS, ScriptT
 		return kjs$self().getDirection();
 	}
 
+	@Info("Gets a block at the position of the entity.")
 	default LevelBlock kjs$getBlock() {
 		return kjs$getLevel().kjs$getBlock(kjs$self().blockPosition());
 	}
@@ -277,32 +404,35 @@ public interface EntityKJS extends WithPersistentData, MessageSenderKJS, ScriptT
 		return kjs$self();
 	}
 
-	default void kjs$playSound(SoundEvent id, float volume, float pitch) {
-		kjs$getLevel().playSound(null, kjs$self().getX(), kjs$self().getY(), kjs$self().getZ(), id, kjs$self().getSoundSource(), volume, pitch);
-	}
-
-	default void kjs$playSound(SoundEvent id) {
-		kjs$playSound(id, 1F, 1F);
-	}
-
 	default void kjs$spawn() {
 		kjs$getLevel().addFreshEntity(kjs$self());
 	}
 
-	default void kjs$attack(float hp) {
-		kjs$self().hurt(kjs$self().damageSources().generic(), hp);
+	default boolean kjs$damage(float hp) {
+		return kjs$self().hurt(kjs$self().damageSources().generic(), hp);
 	}
 
-	default double kjs$getDistance(double x, double y, double z) {
-		return Math.sqrt(kjs$self().distanceToSqr(x, y, z));
+	// Alias to not break old scripts
+	@Info("Replaced by `entity.damage(hp)`")
+	@Deprecated
+	default boolean kjs$attack(float hp) {
+		return kjs$damage(hp);
 	}
 
-	default double kjs$getDistanceSq(BlockPos pos) {
+	@Info("Replaced by `entity.damage(damageSource, hp)`")
+	@Deprecated
+	default boolean kjs$attack(DamageSource source, float hp) {
+		return kjs$self().hurt(source, hp);
+	}
+
+	@Info("Measures the distance of entity to block at specified `BlockPos`.")
+	default double kjs$distanceToBlock(BlockPos pos) {
+		return Math.sqrt(kjs$distanceToBlockSqr(pos));
+	}
+
+	@Info("Measures the **square** of a distance of entity to the block at specified `BlockPos`.")
+	default double kjs$distanceToBlockSqr(BlockPos pos) {
 		return kjs$self().distanceToSqr(pos.getX() + 0.5D, pos.getY() + 0.5D, pos.getZ() + 0.5D);
-	}
-
-	default double kjs$getDistance(BlockPos pos) {
-		return Math.sqrt(kjs$getDistanceSq(pos));
 	}
 
 	default KubeRayTraceResult kjs$rayTrace(double distance, boolean fluids) {

--- a/src/main/java/dev/latvian/mods/kubejs/core/EntityKJS.java
+++ b/src/main/java/dev/latvian/mods/kubejs/core/EntityKJS.java
@@ -12,6 +12,8 @@ import dev.latvian.mods.kubejs.typings.ThisIs;
 import dev.latvian.mods.kubejs.util.UtilsJS;
 import dev.latvian.mods.rhino.util.HideFromJS;
 import dev.latvian.mods.rhino.util.RemapPrefixForJS;
+import net.minecraft.client.player.AbstractClientPlayer;
+import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.registries.Registries;
@@ -22,6 +24,7 @@ import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.util.Mth;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.Entity;
@@ -64,13 +67,14 @@ public interface EntityKJS extends WithPersistentData, MessageSenderKJS, ScriptT
 		return kjs$self().getType().kjs$getId();
 	}
 
-	@ThisIs(LocalClientPlayerKJS.class)
+	@ThisIs(LocalPlayer.class)
 	@Info("Checks, whether the entity is a reference to yourself - that is - the client player you are controlling.")
 	default boolean kjs$isSelf() {
 		return false;
 	}
 
 	@Nullable
+	@Info("If the entity is a player, gets the player's profile, otherwise returns `null`.")
 	default GameProfile kjs$getProfile() {
 		return null;
 	}
@@ -122,6 +126,18 @@ public interface EntityKJS extends WithPersistentData, MessageSenderKJS, ScriptT
 	@ThisIs(Player.class)
 	@Info("Checks if the entity is a player entity.")
 	default boolean kjs$isPlayer() {
+		return false;
+	}
+
+	@ThisIs(ServerPlayer.class)
+	@Info("Checks if the entity is a server-side player.")
+	default boolean kjs$isServerPlayer() {
+		return false;
+	}
+
+	@ThisIs(AbstractClientPlayer.class)
+	@Info("Checks if the entity is a client-side player.")
+	default boolean kjs$isClientPlayer() {
 		return false;
 	}
 

--- a/src/main/java/dev/latvian/mods/kubejs/core/EntityKJS.java
+++ b/src/main/java/dev/latvian/mods/kubejs/core/EntityKJS.java
@@ -413,8 +413,19 @@ public interface EntityKJS extends WithPersistentData, MessageSenderKJS, ScriptT
 		kjs$getLevel().addFreshEntity(kjs$self());
 	}
 
+	@Info(value = "Damages an entity by a given amount of HP dealing generic damage.", params = {
+		@Param(name = "hp", value = "The amount of damage to deal."),
+	})
 	default boolean kjs$damage(float hp) {
 		return kjs$self().hurt(kjs$self().damageSources().generic(), hp);
+	}
+
+	@Info(value = "Damages an entity by a given amount of HP dealing a specific type of damage.", params = {
+		@Param(name = "hp", value = "The amount of damage to deal."),
+		@Param(name = "source", value = "The damage source. It may be a string specifying a damage source, like `'minecraft:cramming'`.")
+	})
+	default boolean kjs$damage(float hp, DamageSource source) {
+		return kjs$self().hurt(source, hp);
 	}
 
 	// Alias to not break old scripts
@@ -424,10 +435,10 @@ public interface EntityKJS extends WithPersistentData, MessageSenderKJS, ScriptT
 		return kjs$damage(hp);
 	}
 
-	@Info("Replaced by `entity.damage(damageSource, hp)`")
+	@Info("Replaced by `entity.damage(hp, damageSource)`")
 	@Deprecated
 	default boolean kjs$attack(DamageSource source, float hp) {
-		return kjs$self().hurt(source, hp);
+		return kjs$damage(hp, source);
 	}
 
 	@Info("Measures the distance of entity to block at specified `BlockPos`.")

--- a/src/main/java/dev/latvian/mods/kubejs/core/EntityKJS.java
+++ b/src/main/java/dev/latvian/mods/kubejs/core/EntityKJS.java
@@ -45,7 +45,6 @@ import java.util.Set;
 import java.util.function.Predicate;
 
 @RemapPrefixForJS("kjs$")
-//@SuppressWarnings("unused")
 public interface EntityKJS extends WithPersistentData, MessageSenderKJS, ScriptTypeHolder {
 	@HideFromJS
 	default Entity kjs$self() {
@@ -332,6 +331,12 @@ public interface EntityKJS extends WithPersistentData, MessageSenderKJS, ScriptT
 		return new EntityArrayList(kjs$self().getPassengers());
 	}
 
+	@Deprecated
+	@Info("Replaced by `entity.getTeamName()`")
+	default String kjs$getTeamId() {
+		return kjs$getTeamName();
+	}
+
 	@Info("Gets the name of the team entity is in, or `''` (empty string) if the entity is not part of any team")
 	default String kjs$getTeamName() {
 		var team = kjs$self().getTeam();
@@ -433,6 +438,34 @@ public interface EntityKJS extends WithPersistentData, MessageSenderKJS, ScriptT
 	@Info("Measures the **square** of a distance of entity to the block at specified `BlockPos`.")
 	default double kjs$distanceToBlockSqr(BlockPos pos) {
 		return kjs$self().distanceToSqr(pos.getX() + 0.5D, pos.getY() + 0.5D, pos.getZ() + 0.5D);
+	}
+
+	@Info("Measures the distance of entity to the point at specified `x`, `y` and `z`.")
+	default double kjs$distanceTo(double x, double y, double z) {
+		return Math.sqrt(kjs$self().distanceToSqr(x, y, z));
+	}
+
+	@Info("Measures the distance of entity to the point at specified 3D position vector.")
+	default double kjs$distanceTo(Vec3 position) {
+		return Math.sqrt(kjs$self().distanceToSqr(position));
+	}
+
+	@Deprecated
+	@Info("Replaced by `entity.distanceToSqr(x, y, z)`.")
+	default double kjs$getDistanceSq(double x, double y, double z) {
+		return kjs$self().distanceToSqr(x, y, z);
+	}
+
+	@Deprecated
+	@Info("Replaced by `entity.distanceTo(x, y, z)`.")
+	default double kjs$getDistance(double x, double y, double z) {
+		return kjs$distanceTo(x, y, z);
+	}
+
+	@Deprecated
+	@Info("Replaced by `entity.distanceToBlockSqr(pos)`.")
+	default double kjs$getDistanceSq(BlockPos pos) {
+		return kjs$distanceToBlockSqr(pos);
 	}
 
 	default KubeRayTraceResult kjs$rayTrace(double distance, boolean fluids) {

--- a/src/main/java/dev/latvian/mods/kubejs/core/ItemEntityKJS.java
+++ b/src/main/java/dev/latvian/mods/kubejs/core/ItemEntityKJS.java
@@ -1,5 +1,8 @@
 package dev.latvian.mods.kubejs.core;
 
+import dev.latvian.mods.kubejs.typings.Info;
+import dev.latvian.mods.kubejs.typings.ThisIs;
+import dev.latvian.mods.rhino.util.HideFromJS;
 import dev.latvian.mods.rhino.util.RemapPrefixForJS;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.ItemStack;
@@ -8,15 +11,26 @@ import org.jetbrains.annotations.Nullable;
 @RemapPrefixForJS("kjs$")
 public interface ItemEntityKJS extends EntityKJS {
 	@Override
+	@HideFromJS
 	default ItemEntity kjs$self() {
 		return (ItemEntity) this;
 	}
 
 	@Override
 	@Nullable
+	@Info("""
+		Gets the item stack corresponding to the item contained in the item entity.
+		Will be `null` if the contained stack is empty.
+		""")
 	default ItemStack kjs$getItem() {
 		var stack = kjs$self().getItem();
 		return stack.isEmpty() ? null : stack;
+	}
+
+	@Override
+	@ThisIs(ItemEntity.class)
+	default boolean kjs$isItem() {
+		return true;
 	}
 
 	default int kjs$getLifespan() {

--- a/src/main/java/dev/latvian/mods/kubejs/core/ItemFrameEntityKJS.java
+++ b/src/main/java/dev/latvian/mods/kubejs/core/ItemFrameEntityKJS.java
@@ -1,5 +1,8 @@
 package dev.latvian.mods.kubejs.core;
 
+import dev.latvian.mods.kubejs.typings.Info;
+import dev.latvian.mods.kubejs.typings.ThisIs;
+import dev.latvian.mods.rhino.util.HideFromJS;
 import dev.latvian.mods.rhino.util.RemapPrefixForJS;
 import net.minecraft.world.entity.decoration.ItemFrame;
 import net.minecraft.world.item.ItemStack;
@@ -8,17 +11,24 @@ import org.jetbrains.annotations.Nullable;
 @RemapPrefixForJS("kjs$")
 public interface ItemFrameEntityKJS extends EntityKJS {
 	@Override
+	@HideFromJS
 	default ItemFrame kjs$self() {
 		return (ItemFrame) this;
 	}
 
 	@Override
+	@ThisIs(ItemFrame.class)
+	@Info("Checks if the entity is an item frame entity.")
 	default boolean kjs$isFrame() {
 		return true;
 	}
 
 	@Override
 	@Nullable
+	@Info("""
+		Gets the item stack corresponding to the item in the item frame.
+		Will be `null` if the contained stack is empty.
+		""")
 	default ItemStack kjs$getItem() {
 		var stack = kjs$self().getItem();
 		return stack.isEmpty() ? null : stack;

--- a/src/main/java/dev/latvian/mods/kubejs/core/LevelKJS.java
+++ b/src/main/java/dev/latvian/mods/kubejs/core/LevelKJS.java
@@ -5,6 +5,8 @@ import dev.latvian.mods.kubejs.level.ExplosionProperties;
 import dev.latvian.mods.kubejs.level.LevelBlock;
 import dev.latvian.mods.kubejs.script.ScriptType;
 import dev.latvian.mods.kubejs.script.ScriptTypeHolder;
+import dev.latvian.mods.kubejs.typings.Info;
+import dev.latvian.mods.kubejs.typings.Param;
 import dev.latvian.mods.rhino.util.RemapForJS;
 import dev.latvian.mods.rhino.util.RemapPrefixForJS;
 import net.minecraft.core.BlockPos;
@@ -60,6 +62,9 @@ public interface LevelKJS extends WithAttachedData<Level>, ScriptTypeHolder, Ent
 	}
 
 	@Override
+	@Info(value = "Each entity in the level (world) runs the specified console command with their permission level.", params = {
+		@Param(name = "command", value = "The console command. Slash at the beginning is optional."),
+	})
 	default void kjs$runCommand(String command) {
 		for (var entity : kjs$self().players()) {
 			entity.kjs$runCommand(command);
@@ -67,6 +72,9 @@ public interface LevelKJS extends WithAttachedData<Level>, ScriptTypeHolder, Ent
 	}
 
 	@Override
+	@Info(value = "Each entity in the level (world) runs the specified console command with their permission level. The command won't output any logs in chat nor console", params = {
+		@Param(name = "command", value = "The console command. Slash at the beginning is optional."),
+	})
 	default void kjs$runCommandSilent(String command) {
 		for (var entity : kjs$self().players()) {
 			entity.kjs$runCommandSilent(command);

--- a/src/main/java/dev/latvian/mods/kubejs/core/LevelKJS.java
+++ b/src/main/java/dev/latvian/mods/kubejs/core/LevelKJS.java
@@ -62,7 +62,7 @@ public interface LevelKJS extends WithAttachedData<Level>, ScriptTypeHolder, Ent
 	}
 
 	@Override
-	@Info(value = "Each entity in the level (world) runs the specified console command with their permission level.", params = {
+	@Info(value = "Each player in the level (world) runs the specified console command with their permission level.", params = {
 		@Param(name = "command", value = "The console command. Slash at the beginning is optional."),
 	})
 	default void kjs$runCommand(String command) {
@@ -72,7 +72,7 @@ public interface LevelKJS extends WithAttachedData<Level>, ScriptTypeHolder, Ent
 	}
 
 	@Override
-	@Info(value = "Each entity in the level (world) runs the specified console command with their permission level. The command won't output any logs in chat nor console", params = {
+	@Info(value = "Each player in the level (world) runs the specified console command with their permission level. The command won't output any logs in chat nor console", params = {
 		@Param(name = "command", value = "The console command. Slash at the beginning is optional."),
 	})
 	default void kjs$runCommandSilent(String command) {

--- a/src/main/java/dev/latvian/mods/kubejs/core/LivingEntityKJS.java
+++ b/src/main/java/dev/latvian/mods/kubejs/core/LivingEntityKJS.java
@@ -6,6 +6,10 @@ import dev.latvian.mods.kubejs.entity.KubeRayTraceResult;
 import dev.latvian.mods.kubejs.item.FoodEatenKubeEvent;
 import dev.latvian.mods.kubejs.item.ItemPredicate;
 import dev.latvian.mods.kubejs.plugin.builtin.event.ItemEvents;
+import dev.latvian.mods.kubejs.typings.Info;
+import dev.latvian.mods.kubejs.typings.Param;
+import dev.latvian.mods.kubejs.typings.ThisIs;
+import dev.latvian.mods.rhino.util.HideFromJS;
 import dev.latvian.mods.rhino.util.RemapPrefixForJS;
 import net.minecraft.core.Holder;
 import net.minecraft.resources.ResourceLocation;
@@ -31,33 +35,36 @@ public interface LivingEntityKJS extends EntityKJS {
 	ResourceLocation KJS_PLAYER_CUSTOM_SPEED = KubeJS.id("player.speed.modifier");
 
 	@Override
+	@HideFromJS
 	default LivingEntity kjs$self() {
 		return (LivingEntity) this;
 	}
 
-	default void kjs$foodEaten(ItemStack is, FoodProperties food) {
-		if (this instanceof LivingEntity entity) {
-			var event = new FoodEatenKubeEvent(entity, is);
-			var i = is.getItem();
-			var b = i.kjs$getItemBuilder();
+	default void kjs$foodEaten(ItemStack eatenStack, FoodProperties food) {
+		var event = new FoodEatenKubeEvent(kjs$self(), eatenStack);
+		var item = eatenStack.getItem();
+		var itemBuilder = item.kjs$getItemBuilder();
 
-			if (b != null && b.foodBuilder != null && b.foodBuilder.eaten != null) {
-				b.foodBuilder.eaten.accept(event);
-			}
+		if (itemBuilder != null && itemBuilder.foodBuilder != null && itemBuilder.foodBuilder.eaten != null) {
+			itemBuilder.foodBuilder.eaten.accept(event);
+		}
 
-			var key = i.kjs$getKey();
+		var key = item.kjs$getKey();
 
-			if (ItemEvents.FOOD_EATEN.hasListeners(key)) {
-				ItemEvents.FOOD_EATEN.post(entity, key, event);
-			}
+		if (ItemEvents.FOOD_EATEN.hasListeners(key)) {
+			ItemEvents.FOOD_EATEN.post(kjs$self(), key, event);
 		}
 	}
 
 	@Override
+	@ThisIs(LivingEntity.class)
 	default boolean kjs$isLiving() {
 		return true;
 	}
 
+	@Info(value = "Sets the entity's maximum health to specified HP.", params = {
+		@Param(name = "hp", value = "The new maximum health of the entity.")
+	})
 	default void kjs$setMaxHealth(float hp) {
 		kjs$self().getAttribute(Attributes.MAX_HEALTH).setBaseValue(hp);
 	}
@@ -176,8 +183,8 @@ public interface LivingEntityKJS extends EntityKJS {
 		kjs$damageHeldItem(InteractionHand.MAIN_HAND, 1);
 	}
 
-	default boolean kjs$isHoldingInAnyHand(ItemPredicate i) {
-		return i.test(kjs$self().getItemInHand(InteractionHand.MAIN_HAND)) || i.test(kjs$self().getItemInHand(InteractionHand.OFF_HAND));
+	default boolean kjs$isHoldingInAnyHand(ItemPredicate itemPredicate) {
+		return itemPredicate.test(kjs$self().getItemInHand(InteractionHand.MAIN_HAND)) || itemPredicate.test(kjs$self().getItemInHand(InteractionHand.OFF_HAND));
 	}
 
 	default double kjs$getTotalMovementSpeed() {

--- a/src/main/java/dev/latvian/mods/kubejs/core/LocalClientPlayerKJS.java
+++ b/src/main/java/dev/latvian/mods/kubejs/core/LocalClientPlayerKJS.java
@@ -65,6 +65,7 @@ public interface LocalClientPlayerKJS extends ClientPlayerKJS {
 	}
 
 	@Override
+	@Info("Checks, whether the player is currently mining a block.")
 	default boolean kjs$isMiningBlock() {
 		return Minecraft.getInstance().gameMode.isDestroying();
 	}

--- a/src/main/java/dev/latvian/mods/kubejs/core/LocalClientPlayerKJS.java
+++ b/src/main/java/dev/latvian/mods/kubejs/core/LocalClientPlayerKJS.java
@@ -4,7 +4,11 @@ import dev.latvian.mods.kubejs.client.KubeSessionData;
 import dev.latvian.mods.kubejs.client.NotificationToast;
 import dev.latvian.mods.kubejs.net.SendDataFromClientPayload;
 import dev.latvian.mods.kubejs.player.PlayerStatsJS;
+import dev.latvian.mods.kubejs.typings.Info;
+import dev.latvian.mods.kubejs.typings.Param;
+import dev.latvian.mods.kubejs.typings.ThisIs;
 import dev.latvian.mods.kubejs.util.NotificationToastData;
+import dev.latvian.mods.rhino.util.HideFromJS;
 import dev.latvian.mods.rhino.util.RemapPrefixForJS;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
@@ -16,6 +20,7 @@ import org.jetbrains.annotations.Nullable;
 @RemapPrefixForJS("kjs$")
 public interface LocalClientPlayerKJS extends ClientPlayerKJS {
 	@Override
+	@HideFromJS
 	default LocalPlayer kjs$self() {
 		return (LocalPlayer) this;
 	}
@@ -25,17 +30,25 @@ public interface LocalClientPlayerKJS extends ClientPlayerKJS {
 	}
 
 	@Override
+	@Info(value = "Runs the specified console command client-side with the player's permission level.", params = {
+		@Param(name = "command", value = "The console command. Slash at the beginning is optional."),
+	})
 	default void kjs$runCommand(String command) {
 		kjs$self().connection.sendCommand(command);
 	}
 
 	@Override
+	@Info(value = "Runs the specified console command client-side with the player's permission level. The command won't output any logs in chat nor console.", params = {
+		@Param(name = "command", value = "The console command. Slash at the beginning is optional."),
+	})
 	default void kjs$runCommandSilent(String command) {
 		kjs$self().connection.sendCommand(command);
 	}
 
 	@Override
-	default boolean isSelf() {
+	@ThisIs(LocalPlayer.class)
+	@Info("Checks, whether the entity is a reference to yourself - that is - the client player you are controlling.")
+	default boolean kjs$isSelf() {
 		return true;
 	}
 

--- a/src/main/java/dev/latvian/mods/kubejs/core/MessageSenderKJS.java
+++ b/src/main/java/dev/latvian/mods/kubejs/core/MessageSenderKJS.java
@@ -1,5 +1,7 @@
 package dev.latvian.mods.kubejs.core;
 
+import dev.latvian.mods.kubejs.typings.Info;
+import dev.latvian.mods.kubejs.typings.Param;
 import dev.latvian.mods.rhino.util.RemapPrefixForJS;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
@@ -15,6 +17,9 @@ public interface MessageSenderKJS {
 		return kjs$getName();
 	}
 
+	@Info(value = "Sends a message in chat to something.", params = {
+		@Param(name = "message", value = "A text component. It may be a string, which will be implicitly wrapped into a text component."),
+	})
 	default void kjs$tell(Component message) {
 		throw new NoMixinException();
 	}
@@ -22,9 +27,15 @@ public interface MessageSenderKJS {
 	default void kjs$setStatusMessage(Component message) {
 	}
 
+	@Info(value = "Runs the specified console command.", params = {
+		@Param(name = "command", value = "The console command. Slash at the beginning is optional."),
+	})
 	default void kjs$runCommand(String command) {
 	}
 
+	@Info(value = "Runs the specified console command. The command won't output any logs in chat nor console.", params = {
+		@Param(name = "command", value = "The console command. Slash at the beginning is optional."),
+	})
 	default void kjs$runCommandSilent(String command) {
 		kjs$runCommand(command);
 	}

--- a/src/main/java/dev/latvian/mods/kubejs/core/MinecraftClientKJS.java
+++ b/src/main/java/dev/latvian/mods/kubejs/core/MinecraftClientKJS.java
@@ -9,6 +9,8 @@ import dev.latvian.mods.kubejs.plugin.builtin.event.ItemEvents;
 import dev.latvian.mods.kubejs.plugin.builtin.wrapper.GLFWInputWrapper;
 import dev.latvian.mods.kubejs.script.ConsoleJS;
 import dev.latvian.mods.kubejs.script.ScriptType;
+import dev.latvian.mods.kubejs.typings.Info;
+import dev.latvian.mods.kubejs.typings.Param;
 import dev.latvian.mods.rhino.util.HideFromJS;
 import dev.latvian.mods.rhino.util.RemapPrefixForJS;
 import net.minecraft.client.KeyMapping;
@@ -48,11 +50,17 @@ public interface MinecraftClientKJS extends MinecraftEnvironmentKJS {
 	}
 
 	@Override
+	@Info(value = "Runs the specified console command client-side with the player's permission level.", params = {
+		@Param(name = "command", value = "The console command. Slash at the beginning is optional."),
+	})
 	default void kjs$runCommand(String command) {
 		kjs$self().player.kjs$runCommand(command);
 	}
 
 	@Override
+	@Info(value = "Runs the specified console command client-side with the player's permission level. The command won't output any logs in chat nor console.", params = {
+		@Param(name = "command", value = "The console command. Slash at the beginning is optional."),
+	})
 	default void kjs$runCommandSilent(String command) {
 		kjs$self().player.kjs$runCommandSilent(command);
 	}

--- a/src/main/java/dev/latvian/mods/kubejs/core/MinecraftServerKJS.java
+++ b/src/main/java/dev/latvian/mods/kubejs/core/MinecraftServerKJS.java
@@ -8,6 +8,8 @@ import dev.latvian.mods.kubejs.player.EntityArrayList;
 import dev.latvian.mods.kubejs.script.ConsoleJS;
 import dev.latvian.mods.kubejs.server.ChangesForChat;
 import dev.latvian.mods.kubejs.server.DataExport;
+import dev.latvian.mods.kubejs.typings.Info;
+import dev.latvian.mods.kubejs.typings.Param;
 import dev.latvian.mods.rhino.util.HideFromJS;
 import dev.latvian.mods.rhino.util.RemapPrefixForJS;
 import net.minecraft.ChatFormatting;
@@ -61,11 +63,17 @@ public interface MinecraftServerKJS extends WithAttachedData<MinecraftServer>, W
 	}
 
 	@Override
+	@Info(value = "Runs the specified console command.", params = {
+		@Param(name = "command", value = "The console command. Slash at the beginning is optional."),
+	})
 	default void kjs$runCommand(String command) {
 		kjs$self().getCommands().performPrefixedCommand(kjs$self().createCommandSourceStack(), command);
 	}
 
 	@Override
+	@Info(value = "Runs the specified console command. The command won't output any logs in chat nor console.", params = {
+		@Param(name = "command", value = "The console command. Slash at the beginning is optional."),
+	})
 	default void kjs$runCommandSilent(String command) {
 		kjs$self().getCommands().performPrefixedCommand(kjs$self().createCommandSourceStack().withSuppressedOutput(), command);
 	}

--- a/src/main/java/dev/latvian/mods/kubejs/core/PlayerKJS.java
+++ b/src/main/java/dev/latvian/mods/kubejs/core/PlayerKJS.java
@@ -19,6 +19,8 @@ import net.minecraft.world.item.ItemStack;
 import net.neoforged.neoforge.common.util.FakePlayer;
 import org.jetbrains.annotations.Nullable;
 
+import javax.annotation.Nonnull;
+
 @RemapPrefixForJS("kjs$")
 public interface PlayerKJS extends LivingEntityKJS, DataSenderKJS, WithAttachedData<Player> {
 	@Override
@@ -53,9 +55,16 @@ public interface PlayerKJS extends LivingEntityKJS, DataSenderKJS, WithAttachedD
 	}
 
 	@Override
-	@Nullable
+	@Nonnull
+	@Info("Gets the player's profile.")
 	default GameProfile kjs$getProfile() {
 		return kjs$self().getGameProfile();
+	}
+
+	@Override
+	@Info("Gets the player's username.")
+	default String kjs$getUsername() {
+		return kjs$self().getGameProfile().getName();
 	}
 
 	default InventoryKJS kjs$getInventory() {

--- a/src/main/java/dev/latvian/mods/kubejs/core/PlayerKJS.java
+++ b/src/main/java/dev/latvian/mods/kubejs/core/PlayerKJS.java
@@ -5,7 +5,10 @@ import dev.latvian.mods.kubejs.item.ItemHandlerUtils;
 import dev.latvian.mods.kubejs.player.KubeJSInventoryListener;
 import dev.latvian.mods.kubejs.player.PlayerStatsJS;
 import dev.latvian.mods.kubejs.stages.Stages;
+import dev.latvian.mods.kubejs.typings.Info;
+import dev.latvian.mods.kubejs.typings.ThisIs;
 import dev.latvian.mods.kubejs.util.NotificationToastData;
+import dev.latvian.mods.rhino.util.HideFromJS;
 import dev.latvian.mods.rhino.util.RemapPrefixForJS;
 import net.minecraft.network.chat.Component;
 import net.minecraft.util.Mth;
@@ -19,6 +22,7 @@ import org.jetbrains.annotations.Nullable;
 @RemapPrefixForJS("kjs$")
 public interface PlayerKJS extends LivingEntityKJS, DataSenderKJS, WithAttachedData<Player> {
 	@Override
+	@HideFromJS
 	default Player kjs$self() {
 		return (Player) this;
 	}
@@ -36,15 +40,20 @@ public interface PlayerKJS extends LivingEntityKJS, DataSenderKJS, WithAttachedD
 	}
 
 	@Override
+	@ThisIs(Player.class)
+	@Info("Checks if the entity is a player entity.")
 	default boolean kjs$isPlayer() {
 		return true;
 	}
 
+	@ThisIs(FakePlayer.class)
+	@Info("Checks if the player is fake.")
 	default boolean kjs$isFake() {
 		return this instanceof FakePlayer;
 	}
 
 	@Override
+	@Nullable
 	default GameProfile kjs$getProfile() {
 		return kjs$self().getGameProfile();
 	}
@@ -96,8 +105,8 @@ public interface PlayerKJS extends LivingEntityKJS, DataSenderKJS, WithAttachedD
 	default void kjs$spawn() {
 	}
 
-	default void kjs$addFood(int f, float m) {
-		kjs$self().getFoodData().eat(f, m);
+	default void kjs$addFood(int hunger, float saturation) {
+		kjs$self().getFoodData().eat(hunger, saturation);
 	}
 
 	default int kjs$getFoodLevel() {
@@ -124,8 +133,8 @@ public interface PlayerKJS extends LivingEntityKJS, DataSenderKJS, WithAttachedD
 		kjs$self().giveExperiencePoints(xp);
 	}
 
-	default void kjs$addXPLevels(int l) {
-		kjs$self().giveExperienceLevels(l);
+	default void kjs$addXPLevels(int levels) {
+		kjs$self().giveExperienceLevels(levels);
 	}
 
 	default void kjs$setXp(int xp) {
@@ -139,11 +148,11 @@ public interface PlayerKJS extends LivingEntityKJS, DataSenderKJS, WithAttachedD
 		return kjs$self().totalExperience;
 	}
 
-	default void kjs$setXpLevel(int l) {
+	default void kjs$setXpLevel(int levels) {
 		kjs$self().totalExperience = 0;
 		kjs$self().experienceProgress = 0F;
 		kjs$self().experienceLevel = 0;
-		kjs$self().giveExperienceLevels(l);
+		kjs$self().giveExperienceLevels(levels);
 	}
 
 	default int kjs$getXpLevel() {

--- a/src/main/java/dev/latvian/mods/kubejs/core/ServerPlayerKJS.java
+++ b/src/main/java/dev/latvian/mods/kubejs/core/ServerPlayerKJS.java
@@ -11,6 +11,7 @@ import dev.latvian.mods.kubejs.net.SendDataFromServerPayload;
 import dev.latvian.mods.kubejs.net.SetActivePostShaderPayload;
 import dev.latvian.mods.kubejs.player.PlayerStatsJS;
 import dev.latvian.mods.kubejs.util.NotificationToastData;
+import dev.latvian.mods.rhino.util.HideFromJS;
 import dev.latvian.mods.rhino.util.RemapPrefixForJS;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
@@ -37,6 +38,7 @@ import java.util.function.Consumer;
 @RemapPrefixForJS("kjs$")
 public interface ServerPlayerKJS extends PlayerKJS {
 	@Override
+	@HideFromJS
 	default ServerPlayer kjs$self() {
 		return (ServerPlayer) this;
 	}

--- a/src/main/java/dev/latvian/mods/kubejs/core/ServerPlayerKJS.java
+++ b/src/main/java/dev/latvian/mods/kubejs/core/ServerPlayerKJS.java
@@ -10,6 +10,9 @@ import dev.latvian.mods.kubejs.net.NotificationPayload;
 import dev.latvian.mods.kubejs.net.SendDataFromServerPayload;
 import dev.latvian.mods.kubejs.net.SetActivePostShaderPayload;
 import dev.latvian.mods.kubejs.player.PlayerStatsJS;
+import dev.latvian.mods.kubejs.typings.Info;
+import dev.latvian.mods.kubejs.typings.Param;
+import dev.latvian.mods.kubejs.typings.ThisIs;
 import dev.latvian.mods.kubejs.util.NotificationToastData;
 import dev.latvian.mods.rhino.util.HideFromJS;
 import dev.latvian.mods.rhino.util.RemapPrefixForJS;
@@ -30,6 +33,8 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.GameType;
 import org.jetbrains.annotations.Nullable;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Optional;
@@ -41,6 +46,12 @@ public interface ServerPlayerKJS extends PlayerKJS {
 	@HideFromJS
 	default ServerPlayer kjs$self() {
 		return (ServerPlayer) this;
+	}
+
+	@ThisIs(ServerPlayer.class)
+	@Info("Checks if the entity is a server-side player.")
+	default boolean kjs$isServerPlayer() {
+		return true;
 	}
 
 	@Override
@@ -56,6 +67,7 @@ public interface ServerPlayerKJS extends PlayerKJS {
 	}
 
 	@Override
+	@Info("Checks, whether the player is currently mining a block.")
 	default boolean kjs$isMiningBlock() {
 		return kjs$self().gameMode.isDestroyingBlock;
 	}
@@ -66,25 +78,47 @@ public interface ServerPlayerKJS extends PlayerKJS {
 		kjs$self().connection.teleport(x, y, z, yaw, pitch);
 	}
 
+	@Info(value = """
+		Switches the player's gamemode between Creative and Survival.
+		To change the player's gamemode to a mode other than Creative or Survival, use `setGameMode`.
+		""", params = {
+		@Param(name = "mode", value = """
+			`true` to change the player's gamemode to Creative.
+			`false` to change the player's gamemode to Survival.
+			""")
+	})
 	default void kjs$setCreativeMode(boolean mode) {
 		kjs$self().setGameMode(mode ? GameType.CREATIVE : GameType.SURVIVAL);
 	}
 
+	@Info("Checks, whether the player is a server operator.")
 	default boolean kjs$isOp() {
 		return kjs$self().server.getPlayerList().isOp(kjs$self().getGameProfile());
 	}
 
+	@Info(value = "Kicks the player from the server with the provided reason.", params = {
+		@Param(name = "reason", value = "A text component, containing the kick reason. It may be a string, which will be implicitly wrapped into a text component.")
+	})
 	default void kjs$kick(Component reason) {
 		kjs$self().connection.disconnect(reason);
 	}
 
+	@Info("Kicks the player from the server with a generic reason.")
 	default void kjs$kick() {
 		kjs$kick(Component.translatable("multiplayer.disconnect.kicked"));
 	}
 
-	default void kjs$ban(String banner, String reason, long expiresInMillis) {
-		var date = new Date();
-		var userlistbansentry = new UserBanListEntry(kjs$self().getGameProfile(), date, banner, new Date(date.getTime() + (expiresInMillis <= 0L ? 315569260000L : expiresInMillis)), reason);
+	@Info(value = "Bans the player from the server.", params = {
+		@Param(name = "banner", value = "A string, that specifies who/what banned the player."),
+		@Param(name = "reason", value = "A string, that contains the ban reason."),
+		@Param(name = "banDuration", value = "Duration of a ban. Negative durations will result in a 10-year ban.")
+	})
+	default void kjs$ban(String banner, String reason, Duration banDuration) {
+		final long TEN_YEARS_SECONDS = 315569520;
+		var start = Instant.now();
+		var end = start.plus(banDuration);
+
+		var userlistbansentry = new UserBanListEntry(kjs$self().getGameProfile(), Date.from(start), banner, Date.from(start.isBefore(end) ? end : start.plus(Duration.ofSeconds(TEN_YEARS_SECONDS))), reason);
 		kjs$self().server.getPlayerList().getBans().add(userlistbansentry);
 		kjs$kick(Component.translatable("multiplayer.disconnect.banned"));
 	}
@@ -251,6 +285,7 @@ public interface ServerPlayerKJS extends PlayerKJS {
 		}
 	}
 
+	@Info("Heals the player to full, and fully restores hunger and saturation.")
 	default void kjs$heal() {
 		kjs$self().heal(kjs$self().getMaxHealth());
 		kjs$self().getFoodData().eat(20, 1F);

--- a/src/main/java/dev/latvian/mods/kubejs/core/mixin/EntityMixin.java
+++ b/src/main/java/dev/latvian/mods/kubejs/core/mixin/EntityMixin.java
@@ -37,6 +37,7 @@ import java.util.UUID;
 public abstract class EntityMixin implements EntityKJS {
 	@Shadow
 	public abstract void playerTouch(Player arg);
+
 	@Unique
 	private CompoundTag kjs$persistentData;
 
@@ -117,6 +118,16 @@ public abstract class EntityMixin implements EntityKJS {
 	@Shadow
 	@RemapForJS("setPitch")
 	public abstract void setXRot(float pitch);
+
+	@Shadow
+	@RemapForJS("setBodyYaw")
+	@Info("Sets the entity's body yaw.")
+	public abstract void setYBodyRot(float yBodyRot);
+
+	@Shadow
+	@RemapForJS("getBodyYaw")
+	@Info("Gets the entity's body yaw (if the entity is a `LivingEntity`), or the entity's visual rotation (if the entity is an item entity or an item frame).")
+	public abstract float getVisualRotationYInDegrees();
 
 	@Shadow
 	@RemapForJS("setMotion")

--- a/src/main/java/dev/latvian/mods/kubejs/core/mixin/EntityMixin.java
+++ b/src/main/java/dev/latvian/mods/kubejs/core/mixin/EntityMixin.java
@@ -4,13 +4,20 @@ import dev.latvian.mods.kubejs.core.EntityKJS;
 import dev.latvian.mods.rhino.util.HideFromJS;
 import dev.latvian.mods.rhino.util.RemapForJS;
 import dev.latvian.mods.rhino.util.RemapPrefixForJS;
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.RelativeMovement;
+import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.ItemLike;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -21,6 +28,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 @Mixin(Entity.class)
@@ -28,7 +36,6 @@ import java.util.UUID;
 public abstract class EntityMixin implements EntityKJS {
 	@Shadow
 	public abstract void playerTouch(Player arg);
-
 	@Unique
 	private CompoundTag kjs$persistentData;
 
@@ -86,9 +93,9 @@ public abstract class EntityMixin implements EntityKJS {
 	@RemapForJS("getStringUuid")
 	public abstract String getStringUUID();
 
-	@Shadow
-	@RemapForJS("getUsername")
-	public abstract String getScoreboardName();
+//	@Shadow
+//	@RemapForJS("getUsername")
+//	public abstract String getScoreboardName();
 
 	@Shadow
 	@RemapForJS("isGlowing")
@@ -126,6 +133,9 @@ public abstract class EntityMixin implements EntityKJS {
 	@RemapForJS("addMotion")
 	public abstract void push(double x, double y, double z);
 
+	/**
+	 * Replaced in JS by {@link EntityKJS#kjs$getPassengers()}.
+	 */
 	@Shadow
 	@HideFromJS
 	public abstract List<Entity> getPassengers();
@@ -134,22 +144,38 @@ public abstract class EntityMixin implements EntityKJS {
 	@RemapForJS("isOnSameTeam")
 	public abstract boolean isAlliedTo(Entity e);
 
+	/**
+	 * KubeJS adds {@link EntityKJS#kjs$getFacing()} which also can specify whether the entity is looking down or up.
+	 */
 	@Shadow
 	@RemapForJS("getHorizontalFacing")
 	public abstract Direction getDirection();
 
+//	@Shadow
+//	@RemapForJS("extinguish")
+//	public abstract void clearFire();
+
 	@Shadow
 	@RemapForJS("extinguish")
-	public abstract void clearFire();
+	public abstract void extinguishFire();
 
 	@Shadow
-	@RemapForJS("attack")
+	@RemapForJS("damage")
 	public abstract boolean hurt(DamageSource source, float hp);
 
-	@Shadow
-	@RemapForJS("getDistanceSq")
-	public abstract double distanceToSqr(double x, double y, double z);
+//	@Shadow
+//	@RemapForJS("getDistanceSq")
+//	public abstract double distanceToSqr(double x, double y, double z);
 
+	// The remaps:
+	// distanceToSqr(double x, double y, double z) - remains as is
+	// distanceToSqr(Vec3 vector) - remains as is
+	// distanceToSqr(Entity entity) - remapped to distanceToEntitySqr
+	// distanceToBlockSqr(BlockPos block) is added by EntityKJS
+
+	/**
+	 * {@link EntityKJS#kjs$getType()} returns a string in JS.
+	 */
 	@Shadow
 	@RemapForJS("getEntityType")
 	public abstract EntityType<?> getType();
@@ -162,7 +188,47 @@ public abstract class EntityMixin implements EntityKJS {
 	@RemapForJS("distanceToEntity")
 	public abstract float distanceTo(Entity arg);
 
+	/**
+	 * Replaced in JS by {@link EntityKJS#kjs$teleportTo(double, double, double)}.
+	 */
+	@Shadow
+	@HideFromJS
+	public abstract void teleportTo(double x, double y, double z);
+
+	/**
+	 * Hidden, most similar equivalent usable by JS is
+	 * {@link EntityKJS#kjs$teleportToLevel(ServerLevel, double, double, double, float, float)}.
+	 */
+	@Shadow
+	@HideFromJS
+	public abstract boolean teleportTo(ServerLevel level, double x, double y, double z, Set<RelativeMovement> relativeMovements, float yaw, float pitch);
+
+	/**
+	 * Replaced in JS by {@link EntityKJS#kjs$getLevel()}.
+	 */
 	@Shadow
 	@HideFromJS
 	public abstract Level level();
+
+	/**
+	 * Disambiguates {@link Entity#spawnAtLocation(ItemStack)} in JS.
+	 */
+	@Shadow
+	@HideFromJS
+	public abstract ItemEntity spawnAtLocation(ItemLike item);
+
+	/**
+	 * Disambiguates {@link Entity#spawnAtLocation(ItemStack, float)} in JS.
+	 */
+	@Shadow
+	@HideFromJS
+	public abstract ItemEntity spawnAtLocation(ItemLike item, int offsetY);
+
+
+	/**
+	 * Disambiguates {@link Entity#moveTo(Vec3, float, float)} in JS.
+	 */
+	@Shadow
+	@RemapForJS("moveToBlockPos")
+	public abstract void moveTo(BlockPos pos, float yRot, float xRot);
 }

--- a/src/main/java/dev/latvian/mods/kubejs/core/mixin/EntityMixin.java
+++ b/src/main/java/dev/latvian/mods/kubejs/core/mixin/EntityMixin.java
@@ -152,8 +152,11 @@ public abstract class EntityMixin implements EntityKJS {
 	@RemapForJS("extinguish")
 	public abstract void extinguishFire();
 
+	/**
+	 * Replaced by
+	 */
 	@Shadow
-	@RemapForJS("damage")
+	@HideFromJS
 	public abstract boolean hurt(DamageSource source, float hp);
 
 	// The remaps:

--- a/src/main/java/dev/latvian/mods/kubejs/core/mixin/EntityMixin.java
+++ b/src/main/java/dev/latvian/mods/kubejs/core/mixin/EntityMixin.java
@@ -1,6 +1,7 @@
 package dev.latvian.mods.kubejs.core.mixin;
 
 import dev.latvian.mods.kubejs.core.EntityKJS;
+import dev.latvian.mods.kubejs.typings.Info;
 import dev.latvian.mods.rhino.util.HideFromJS;
 import dev.latvian.mods.rhino.util.RemapForJS;
 import dev.latvian.mods.rhino.util.RemapPrefixForJS;
@@ -93,10 +94,6 @@ public abstract class EntityMixin implements EntityKJS {
 	@RemapForJS("getStringUuid")
 	public abstract String getStringUUID();
 
-//	@Shadow
-//	@RemapForJS("getUsername")
-//	public abstract String getScoreboardName();
-
 	@Shadow
 	@RemapForJS("isGlowing")
 	public abstract boolean isCurrentlyGlowing();
@@ -151,10 +148,6 @@ public abstract class EntityMixin implements EntityKJS {
 	@RemapForJS("getHorizontalFacing")
 	public abstract Direction getDirection();
 
-//	@Shadow
-//	@RemapForJS("extinguish")
-//	public abstract void clearFire();
-
 	@Shadow
 	@RemapForJS("extinguish")
 	public abstract void extinguishFire();
@@ -162,10 +155,6 @@ public abstract class EntityMixin implements EntityKJS {
 	@Shadow
 	@RemapForJS("damage")
 	public abstract boolean hurt(DamageSource source, float hp);
-
-//	@Shadow
-//	@RemapForJS("getDistanceSq")
-//	public abstract double distanceToSqr(double x, double y, double z);
 
 	// The remaps:
 	// distanceToSqr(double x, double y, double z) - remains as is
@@ -181,11 +170,21 @@ public abstract class EntityMixin implements EntityKJS {
 	public abstract EntityType<?> getType();
 
 	@Shadow
+	@Info("Measures the **square** of a distance of entity to the point at specified 3D position vector.")
+	public abstract double distanceToSqr(Vec3 vec);
+
+	@Shadow
+	@Info("Measures the distance of entity to the point at specified `x`, `y` and `z`.")
+	public abstract double distanceToSqr(double x, double y, double z);
+
+	@Shadow
 	@RemapForJS("distanceToEntitySqr")
+	@Info("Measures the **square** of a distance of entity to another entity.")
 	public abstract double distanceToSqr(Entity arg);
 
 	@Shadow
 	@RemapForJS("distanceToEntity")
+	@Info("Measures the distance of entity to another entity.")
 	public abstract float distanceTo(Entity arg);
 
 	/**

--- a/src/main/java/dev/latvian/mods/kubejs/core/mixin/PlayerMixin.java
+++ b/src/main/java/dev/latvian/mods/kubejs/core/mixin/PlayerMixin.java
@@ -7,6 +7,7 @@ import dev.latvian.mods.kubejs.plugin.KubeJSPlugin;
 import dev.latvian.mods.kubejs.plugin.KubeJSPlugins;
 import dev.latvian.mods.kubejs.stages.StageEvents;
 import dev.latvian.mods.kubejs.stages.Stages;
+import dev.latvian.mods.kubejs.typings.Info;
 import dev.latvian.mods.kubejs.util.AttachedData;
 import dev.latvian.mods.rhino.util.RemapForJS;
 import dev.latvian.mods.rhino.util.RemapPrefixForJS;
@@ -68,4 +69,12 @@ public abstract class PlayerMixin implements PlayerKJS {
 
 		return kjs$inventoryChangeListener;
 	}
+
+	@Shadow
+	@Info("Checks, whether the player is in Spectator mode.")
+	public abstract boolean isSpectator();
+
+	@Shadow
+	@Info("Checks, whether the player is in Creative mode.")
+	public abstract boolean isCreative();
 }

--- a/src/main/java/dev/latvian/mods/kubejs/core/mixin/ServerPlayerMixin.java
+++ b/src/main/java/dev/latvian/mods/kubejs/core/mixin/ServerPlayerMixin.java
@@ -2,12 +2,15 @@ package dev.latvian.mods.kubejs.core.mixin;
 
 import com.mojang.authlib.GameProfile;
 import dev.latvian.mods.kubejs.core.ServerPlayerKJS;
+import dev.latvian.mods.kubejs.typings.Info;
+import dev.latvian.mods.kubejs.typings.Param;
 import dev.latvian.mods.rhino.util.RemapForJS;
 import dev.latvian.mods.rhino.util.RemapPrefixForJS;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.stats.ServerStatsCounter;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.GameType;
 import net.minecraft.world.level.Level;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -22,4 +25,10 @@ public abstract class ServerPlayerMixin extends Player implements ServerPlayerKJ
 	@Shadow
 	@RemapForJS("getStatsCounter")
 	public abstract ServerStatsCounter getStats();
+
+	@Shadow
+	@Info(value = "Changes the player's gamemode.", params = {
+		@Param(name = "gameMode", value = "One of: `'survival'`, `'creative'`, `'adventure'`, `'spectator'`.")
+	})
+	public abstract boolean setGameMode(GameType gameMode);
 }

--- a/src/main/java/dev/latvian/mods/kubejs/player/EntityArrayList.java
+++ b/src/main/java/dev/latvian/mods/kubejs/player/EntityArrayList.java
@@ -136,7 +136,8 @@ public class EntityArrayList extends ArrayList<Entity> implements MessageSenderK
 		""", params = {
 		@Param(name = "filter", value = "The predicate - a function that takes an argument of `Entity` and returns a boolean.")
 	})
-	public EntityArrayList oneFilter(Predicate<Entity> filter) {
+	// FIXME: Inaccessible from JS due to order of operations in Rhino, this method is used by other filter methods
+	public EntityArrayList filter(Predicate<Entity> filter) {
 		if (isEmpty()) {
 			return this;
 		}
@@ -146,7 +147,6 @@ public class EntityArrayList extends ArrayList<Entity> implements MessageSenderK
 		for (var entity : this) {
 			if (filter.test(entity)) {
 				list.add(entity);
-				break;
 			}
 		}
 
@@ -159,7 +159,7 @@ public class EntityArrayList extends ArrayList<Entity> implements MessageSenderK
 		""", params = {
 		@Param(name = "filterList", value = "The list of predicates - functions that take one argument of `Entity` and return boolean values.")
 	})
-	public EntityArrayList filter(List<Predicate<Entity>> filterList) {
+	public EntityArrayList filterList(List<Predicate<Entity>> filterList) {
 		if (isEmpty() || filterList.isEmpty()) {
 			return this;
 		}
@@ -181,7 +181,7 @@ public class EntityArrayList extends ArrayList<Entity> implements MessageSenderK
 		@Param(name = "selector", value = "The entity selector. It may be a string representing the entity selector as seen in commands, such as `'@e[distance=..25]'`")
 	})
 	public EntityArrayList filterSelector(EntitySelector selector) {
-		return filter(selector.contextFreePredicates);
+		return filterList(selector.contextFreePredicates);
 	}
 
 	@Info(value = """
@@ -218,19 +218,19 @@ public class EntityArrayList extends ArrayList<Entity> implements MessageSenderK
 
 	@Info("Results in an entity list containing only players.")
 	public EntityArrayList filterPlayers() {
-		return oneFilter(e -> e instanceof Player);
+		return filter(e -> e instanceof Player);
 	}
 
 	@Info("Results in an entity list containing only item entities.")
 	public EntityArrayList filterItems() {
-		return oneFilter(e -> e instanceof ItemEntity);
+		return filter(e -> e instanceof ItemEntity);
 	}
 
 	@Info(value = "Filters the entity list based on the type of the entity. Only entities whose type is equal to the provided one will end up in the resulting list.", params = {
 		@Param(name = "type", value = "The entity type. It may be a string representing an entity ID, like `'minecraft:creeper'`.")
 	})
 	public EntityArrayList filterType(EntityType<?> type) {
-		return oneFilter(e -> e.getType() == type);
+		return filter(e -> e.getType() == type);
 	}
 
 	@Override

--- a/src/main/java/dev/latvian/mods/kubejs/player/EntityArrayList.java
+++ b/src/main/java/dev/latvian/mods/kubejs/player/EntityArrayList.java
@@ -134,7 +134,7 @@ public class EntityArrayList extends ArrayList<Entity> implements MessageSenderK
 		Filters the entity list by passing each entity through a given predicate.
 		Entities that pass the predicate will end up in the resulting entity list.
 		""", params = {
-		@Param(name = "filter", value = "The predicate - a function that takes no arguments and returns a boolean.")
+		@Param(name = "filter", value = "The predicate - a function that takes an argument of `Entity` and returns a boolean.")
 	})
 	public EntityArrayList oneFilter(Predicate<Entity> filter) {
 		if (isEmpty()) {
@@ -157,7 +157,7 @@ public class EntityArrayList extends ArrayList<Entity> implements MessageSenderK
 		Filters the entity list by passing each entity through all predicates in provided list.
 		Entities that pass at least one of the predicates will end up in the resulting entity list.
 		""", params = {
-		@Param(name = "filterList", value = "The list of predicates - functions that take no arguments and return boolean values.")
+		@Param(name = "filterList", value = "The list of predicates - functions that take one argument of `Entity` and return boolean values.")
 	})
 	public EntityArrayList filter(List<Predicate<Entity>> filterList) {
 		if (isEmpty() || filterList.isEmpty()) {

--- a/src/main/java/dev/latvian/mods/kubejs/player/EntityArrayList.java
+++ b/src/main/java/dev/latvian/mods/kubejs/player/EntityArrayList.java
@@ -2,6 +2,8 @@ package dev.latvian.mods.kubejs.player;
 
 import dev.latvian.mods.kubejs.core.DataSenderKJS;
 import dev.latvian.mods.kubejs.core.MessageSenderKJS;
+import dev.latvian.mods.kubejs.typings.Info;
+import dev.latvian.mods.kubejs.typings.Param;
 import dev.latvian.mods.rhino.util.RemapPrefixForJS;
 import net.minecraft.commands.arguments.selector.EntitySelector;
 import net.minecraft.core.BlockPos;
@@ -66,6 +68,9 @@ public class EntityArrayList extends ArrayList<Entity> implements MessageSenderK
 	}
 
 	@Override
+	@Info(value = "Sends a message in chat to every entity in the list.", params = {
+		@Param(name = "message", value = "A text component. It may be a string, which will be implicitly wrapped into a text component."),
+	})
 	public void kjs$tell(Component message) {
 		for (var entity : this) {
 			entity.kjs$tell(message);
@@ -80,6 +85,9 @@ public class EntityArrayList extends ArrayList<Entity> implements MessageSenderK
 	}
 
 	@Override
+	@Info(value = "Each entity in the list runs the specified console command with their permission level.", params = {
+		@Param(name = "command", value = "The console command. Slash at the beginning is optional."),
+	})
 	public void kjs$runCommand(String command) {
 		for (var entity : this) {
 			entity.kjs$runCommand(command);
@@ -87,6 +95,9 @@ public class EntityArrayList extends ArrayList<Entity> implements MessageSenderK
 	}
 
 	@Override
+	@Info(value = "Each entity in the list runs the specified console command with their permission level. The command won't output any logs in chat nor console", params = {
+		@Param(name = "command", value = "The console command. Slash at the beginning is optional."),
+	})
 	public void kjs$runCommandSilent(String command) {
 		for (var entity : this) {
 			entity.kjs$runCommandSilent(command);
@@ -100,22 +111,31 @@ public class EntityArrayList extends ArrayList<Entity> implements MessageSenderK
 		}
 	}
 
+	@Info("Kills every entity in the list.")
 	public void kill() {
 		for (var entity : this) {
 			entity.kill();
 		}
 	}
 
+	@Info("Plays a sound from each entity in the list, unless the entity is silent.")
 	public void playSound(SoundEvent id, float volume, float pitch) {
 		for (var entity : this) {
-			entity.level().playSound(null, entity.getX(), entity.getY(), entity.getZ(), id, entity.getSoundSource(), volume, pitch);
+			entity.playSound(id, volume, pitch);
 		}
 	}
 
+	@Info("Plays a sound from each entity in the list, unless the entity is silent.")
 	public void playSound(SoundEvent id) {
 		playSound(id, 1F, 1F);
 	}
 
+	@Info(value = """
+		Filters the entity list by passing each entity through a given predicate.
+		Entities that pass the predicate will end up in the resulting entity list.
+		""", params = {
+		@Param(name = "filter", value = "The predicate - a function that takes no arguments and returns a boolean.")
+	})
 	public EntityArrayList oneFilter(Predicate<Entity> filter) {
 		if (isEmpty()) {
 			return this;
@@ -133,6 +153,12 @@ public class EntityArrayList extends ArrayList<Entity> implements MessageSenderK
 		return list;
 	}
 
+	@Info(value = """
+		Filters the entity list by passing each entity through all predicates in provided list.
+		Entities that pass at least one of the predicates will end up in the resulting entity list.
+		""", params = {
+		@Param(name = "filterList", value = "The list of predicates - functions that take no arguments and return boolean values.")
+	})
 	public EntityArrayList filter(List<Predicate<Entity>> filterList) {
 		if (isEmpty() || filterList.isEmpty()) {
 			return this;
@@ -151,10 +177,22 @@ public class EntityArrayList extends ArrayList<Entity> implements MessageSenderK
 		return list;
 	}
 
+	@Info(value = "Filters the entity list based on the provided `EntitySelector`.", params = {
+		@Param(name = "selector", value = "The entity selector. It may be a string representing the entity selector as seen in commands, such as `'@e[distance=..25]'`")
+	})
 	public EntityArrayList filterSelector(EntitySelector selector) {
 		return filter(selector.contextFreePredicates);
 	}
 
+	@Info(value = """
+		Filters the entity list based on distance to the given point.
+		Entities that are closer than `distance` away from the point specified by `x`, `y` and `z` coordinates will end up in the resulting list.
+		""", params = {
+		@Param(name = "x", value = "The `x` coordinate of the point."),
+		@Param(name = "y", value = "The `y` coordinate of the point."),
+		@Param(name = "z", value = "The `z` coordinate of the point."),
+		@Param(name = "distance", value = "The maximum distance of entities from the point.")
+	})
 	public EntityArrayList filterDistance(double x, double y, double z, double distance) {
 		var list = new EntityArrayList(size());
 
@@ -167,23 +205,42 @@ public class EntityArrayList extends ArrayList<Entity> implements MessageSenderK
 		return list;
 	}
 
+	@Info(value = """
+		Filters the entity list based on distance to the given block position.
+		Entities that are closer than `distance` away from the center of the block will end up in the resulting list.
+		""", params = {
+		@Param(name = "pos", value = "The `BlockPos` - that is the center of the block at specified position. It can be a 3-element array of integers, such as `[64, 25, 39]`."),
+		@Param(name = "distance", value = "The maximum distance of entities from the point.")
+	})
 	public EntityArrayList filterDistance(BlockPos pos, double distance) {
 		return filterDistance(pos.getX() + 0.5D, pos.getY() + 0.5D, pos.getZ() + 0.5D, distance);
 	}
 
+	@Info("Results in an entity list containing only players.")
 	public EntityArrayList filterPlayers() {
 		return oneFilter(e -> e instanceof Player);
 	}
 
+	@Info("Results in an entity list containing only item entities.")
 	public EntityArrayList filterItems() {
 		return oneFilter(e -> e instanceof ItemEntity);
 	}
 
+	@Info(value = "Filters the entity list based on the type of the entity. Only entities whose type is equal to the provided one will end up in the resulting list.", params = {
+		@Param(name = "type", value = "The entity type. It may be a string representing an entity ID, like `'minecraft:creeper'`.")
+	})
 	public EntityArrayList filterType(EntityType<?> type) {
 		return oneFilter(e -> e.getType() == type);
 	}
 
 	@Override
+	@Info(value = "Sends NBT data to every player in the list.", params = {
+		@Param(name = "channel", value = "String. Represents the network channel."),
+		@Param(name = "data", value = """
+			The NBT compound tag containing data to send. May be `null`.
+			It may be a JS object containing data or string representing stringified NBT.
+			""")
+	})
 	public void kjs$sendData(String channel, @Nullable CompoundTag data) {
 		for (var entity : this) {
 			if (entity instanceof Player player) {
@@ -194,6 +251,7 @@ public class EntityArrayList extends ArrayList<Entity> implements MessageSenderK
 
 	@Override
 	@Nullable
+	@Info("Gets the first entity on the list, or `null` if the list is empty.")
 	public Entity getFirst() {
 		return isEmpty() ? null : get(0);
 	}

--- a/src/main/java/dev/latvian/mods/kubejs/typings/ThisIs.java
+++ b/src/main/java/dev/latvian/mods/kubejs/typings/ThisIs.java
@@ -1,0 +1,24 @@
+package dev.latvian.mods.kubejs.typings;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation that typing generation mods can use to declare type guards.
+ * <p>
+ * Use this on <code>boolean</code>-returning methods that can guarantee that if the method returns <code>true</code>,
+ * the current instance may be treated as the provided class type.
+ * </p>
+ * <p>
+ * Type guards can help narrow down types in conditional blocks.
+ * </p>
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface ThisIs {
+	Class<?> value();
+}


### PR DESCRIPTION
# Description 
This PR adds changes related to entities, namely:
- Changed the semantics of `EntityKJS#kjs$getUsername`, since hmm, what's the username of an entity?
- Restored `Entity#getScoreboardName` to its original form.
- Restored `Entity#clearFire` and remapped `Entity#extinguishFire` to `extinguish`.
- Changed the remap of `Entity#hurt` from `attack` to `damage`. The original `attack` name still exists on `EntityKJS`, but it's marked as `@Deprecated`. Addresses what #1064 tried to do, while still creating a more descriptive name.
- Changed remaps of various `distanceTo` and `distanceToSqr` to be consistent with each other, while not being ambiguous with each other. All old remaps stay and are marked as `@Deprecated`.

| Original name (in `Entity`)                   | Old remap / name                            | New remap / name                    |
| --------------------------------------------- | ------------------------------------------- | ----------------------------------- |
| `distanceToSqr(double x, double y, double z)` | `getDistanceSq`                             | `distanceToSqr` (reverted)          |
| `distanceToSqr(Vec3 position)`                | `distanceToSqr`                             | `distanceToSqr` (stays as-is)       |
| `distanceToSqr(Entity entity)`                | `distanceToEntitySqr`                       | `distanceToEntitySqr` (stays as-is) |
| -                                             | `getDistanceSq(BlockPos pos)`               | `distanceToBlockSqr`                |
| -                                             | `getDistance(double x, double y, double z)` | `distanceTo`                        |
| -                                             | -                                           | `distanceTo(Vec3 position)`         |
| `distanceTo(Entity entity)`                   | `distanceToEntity`                          | `distanceToEntity` (stays as-is)    |
| -                                             | `getDistance(BlockPos pos)`                 | `distanceToBlock`                   |

- Changed the name of `EntityKJS#kjs$getTeamId` to `EntityKJS#kjs$getTeamName`. Again, old name exists, but `@Deprecated`.
- Changed `EntityKJS#kjs$getProfile` to return `null` in case of entities that aren't players - game profiles only make sense on players.
- Removed `EntityKJS#kjs$playSound` - changes nothing, because `Entity` already has `playSound` which respects the entity's silence state.
- Changed the `EntityKJS#kjs$teleportTo` method overloads to no longer use command stack, nor execute the logic from `TeleportCommand` (`/tp` command). Rationale:
  - `teleportTo` should not be just an alias for a command
  - NeoForge events should not affect the outcome of the teleport - the inversion of control here is simply not in place here, as you already are in control of your script, so losing control due to a random NeoForge teleport **command** event listener would create surprising behavior.
- Also, the errors thrown by `EntityKJS#kjs$teleportTo` are more descriptive - they now actually tell what's the problem.
- Added the `EntityKJS#kjs$teleportToLevel` method - needed because the type wrapper can't discern between `ServerLevel` and `ResourceLocation` - avoids unnecessary ID lookup if you already have a reference to a server level - this isn't hard to do.
- Added the `EntityKJS#kjs$isItem` method - checks whether the entity is an item entity. (Now you should reconsider what happens when both `isItem` and `getItem` exist at once...)
- Added `@Info` documentations in various places.
- `@HideFromJS`'d various `kjs$self` methods - these are useless in JS, they are more useful in Java to get the appropriate `this` for method calls.
- Added a new annotation interface: `@ThisIs`, which can help in creation of type guards for type dumping mods.
- Changed some single letter variable names in method descriptors to be... more descriptive, in case type dumping mods can read them.

<!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->

## Example Script

## Server script
Adds a `/test` command.
```js
/** @import { $MinecraftServer } from "net.minecraft.server.MinecraftServer" */

ServerEvents.commandRegistry((event) => {
  event.register(
    event.commands.literal("test").executes((ctx) => {
      const things = {
        player: ctx.source.player,
        server: ctx.source.server,
        level: ctx.source.level,
      };
      global.testFunction(things);
      return 1;
    }),
  );
});
```

## Startup script (so it can be reloaded quickly)
```js
// @ts-check
/** @import { $MinecraftServer } from "net.minecraft.server.MinecraftServer" */
/** @import { $ServerPlayer } from "net.minecraft.server.level.ServerPlayer" */
/** @import { $ServerLevel } from "net.minecraft.server.level.ServerLevel" */
/** @import { $Entity } from "net.minecraft.world.entity.Entity" */

/** @param {{player: $ServerPlayer, server: $MinecraftServer, level: $ServerLevel}} things */
global.testFunction = function (things) {
  const { player, server, level } = things;

  player.setPositionAndRotation(0.5, -60, 0.5, 0, 0);

  /** @type {[$Entity, $Entity]} */
  const armorStands = [null, null];
  const playerPos = new Vec3d(player.x, player.y, player.z);
  const steps = {
    "Spawning armor stands..."() {
      armorStands[0] = level.createEntity("minecraft:armor_stand");
      armorStands[0].moveTo(playerPos.add([0, 0, 5]));
      armorStands[0].spawn();

      armorStands[1] = level.createEntity("minecraft:armor_stand");
      armorStands[1].moveTo(playerPos.add([3, 0, 5]));
      armorStands[1].spawn();
    },
    "Distance between stands is:"() {
      player.tell(String(armorStands[0].distanceToEntity(armorStands[1])));
      player.tell(`Square: ${armorStands[0].distanceToEntitySqr(armorStands[1])}`);
    },
    "Distance between block I'm standing is:"() {
      player.tell("Stand in front:");
      player.tell(String(armorStands[0].distanceToBlock(player.onPos)));
      player.tell(`Square: ${armorStands[0].distanceToBlockSqr(player.onPos)}`);
      player.tell("Stand on the side:");
      player.tell(String(armorStands[1].distanceToBlock(player.onPos)));
      player.tell(`Square: ${armorStands[1].distanceToBlockSqr(player.onPos)}`);
    },
    "Distance between center stand and (0, -56, 0) is:"() {
      player.tell(String(armorStands[0].distanceTo(0, -56, 0)));
      player.tell(`Square: ${armorStands[0].distanceToSqr(0, -56, 0)}`);
      player.tell("Vec3 version...");
      player.tell(String(armorStands[0].distanceTo([0, -56, 0])));
      player.tell(`Square: ${armorStands[0].distanceToSqr([0, -56, 0])}`);
    },
    "The profile of armor stand shall be null"() {
      player.tell(String(armorStands[0].profile));
    },
    "Let's make the armor stand on the side prettier."() {
      armorStands[1].customName = Text.ofString("Lilac").bold().color("#D891EF");
      armorStands[1].customNameVisible = true;
    },
    "Usernames:"() {
      player.tell(`Front: ${armorStands[0].username}`);
      player.tell(`Side: ${armorStands[1].username}`);
    },
    "Oink:"() {
      armorStands[0].playSound("minecraft:entity.pig.ambient");
    },
    "Moo:"() {
      armorStands[1].playSound("minecraft:entity.cow.ambient");
    },
    "Teleport to level:"() {
      const { x, y, z, yaw, pitch } = armorStands[0];
      armorStands[0].teleportToLevel(server.overworld(), x, y + 5, z, yaw + 90, pitch);
    },
    "Teleport:"() {
      const { x, y, z, yaw, pitch } = armorStands[1];
      armorStands[1].teleportTo("minecraft:overworld", x, y + 4, z, yaw - 90, pitch);
    },
    "Setting the front armor stand on fire:"() {
      armorStands[0].remainingFireTicks = 60;
    },
    "Extinguishing it:"() {
      armorStands[0].extinguish();
    },
  };

  /**
   * @param {ArrayIterator<[string, () => void]>} iterator
   */
  function doAfter40Ticks(iterator) {
    server.scheduleInTicks(40, () => {
      const nextStep = iterator.next();
      if (nextStep.done) return;
      /** @type {[string, () => void]} */
      const [name, callback] = nextStep.value;
      player.tell("");
      player.tell(name);
      callback();
      doAfter40Ticks(iterator);
    });
  }

  const stepEntries = Object.entries(steps)[Symbol.iterator]();
  server.runCommandSilent("/kill @e[type=minecraft:armor_stand]");
  doAfter40Ticks(stepEntries);
};
```

## Other details <!-- Any other important information, like if this is likely to break addons -->
Added a new documentation annotation interface: `@ThisIs`.
Type dumping mods such as ProbeJS can use it to create type guards.

So, let's say, currently there's a method on Entity called:
```ts
declare class Entity {
  isPlayer(): boolean
  get player(): boolean
}
```
If the boolean-returning method is annotated as `@ThisIs(Player.class)`, the return type may be dumped instead as:
```ts
declare class Entity {
  isPlayer(): this is Player
  get player(): boolean
}
```
With this type guard in place, TS will automatically treat the instance as instance of the specified type inside conditional branches:
```ts
declare const entity: Entity;
if (entity.isPlayer()) {
  // give is only on players, and with this change TS will suggest it!
  entity.give("2x minecraft:apple");
}
```

> [!CAUTION]
> Do not emit type guards on beans!
> ```ts
> declare class Entity {
>   isPlayer(): this is Player
>   get player(): this is Player // ❌ invalid syntax!
> }
> ```