### PR TITLE
Fix custom mod names with EMI

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/core/mixin/common/mod/EMITooltipMixin.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/core/mixin/common/mod/EMITooltipMixin.java
@@ -1,0 +1,21 @@
+package dev.latvian.mods.kubejs.core.mixin.common.mod;
+
+import dev.latvian.mods.kubejs.script.PlatformWrapper;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Pseudo
+@Mixin(targets = "dev/emi/emi/EmiUtil")
+public abstract class EMITooltipMixin {
+	@Inject(method = "getModName(Ljava/lang/String;)Ljava/lang/String;", at = @At("HEAD"), cancellable = true, remap = false)
+	private static void kjs$modId(String modId, CallbackInfoReturnable<String> cir) {
+		var r = PlatformWrapper.getMods().get(modId);
+
+		if (r != null && !r.getCustomName().isEmpty()) {
+			cir.setReturnValue(r.getCustomName());
+		}
+	}
+}

--- a/common/src/main/resources/kubejs-common.mixins.json
+++ b/common/src/main/resources/kubejs-common.mixins.json
@@ -58,6 +58,7 @@
 		"ScreenMixin",
 		"WindowMixin",
 		"WorldOpenFlowsMixin",
+        "mod.EMITooltipMixin",
 		"mod.ModNameTooltipMixin",
 		"mod.REITooltipMixin"
 	],


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->

### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->

Previously EMI would just show the modid string if it couldn't find the fancy name. Now it works similarly to JEI and REI.

#### Example Script <!-- Please provide an example script showing that the bug is fixed, or how the feature is used, if applicable -->

```js
Platform.mods.setModName("fff", "Flurben's Fantastic Foods")

StartupEvents.registry("item", event => {
  event.create("fff:cassava_seeds")
})
```

#### Other details <!-- Any other important information, like if this is likely to break addons -->

Screenshot of fixed:
<img width="299" height="133" alt="image" src="https://github.com/user-attachments/assets/788df757-d684-493c-a5cb-4ee2fd61b825" />
