### PR TITLE
Post after recipes

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/core/MinecraftServerKJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/core/MinecraftServerKJS.java
@@ -5,6 +5,7 @@ import dev.latvian.mods.kubejs.net.SendDataFromServerMessage;
 import dev.latvian.mods.kubejs.player.AdvancementJS;
 import dev.latvian.mods.kubejs.player.EntityArrayList;
 import dev.latvian.mods.kubejs.server.DataExport;
+import dev.latvian.mods.kubejs.server.KubeJSReloadListener;
 import dev.latvian.mods.kubejs.util.ConsoleJS;
 import dev.latvian.mods.rhino.util.HideFromJS;
 import dev.latvian.mods.rhino.util.RemapPrefixForJS;
@@ -100,6 +101,8 @@ public interface MinecraftServerKJS extends WithAttachedData<MinecraftServer>, W
 
 	@HideFromJS
 	default void kjs$afterResourcesLoaded(boolean reload) {
+		KubeJSReloadListener.postAfterRecipes();
+
 		if (reload) {
 			DataExport.exportData();
 		}

--- a/common/src/main/java/dev/latvian/mods/kubejs/server/KubeJSReloadListener.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/server/KubeJSReloadListener.java
@@ -4,17 +4,10 @@ import dev.latvian.mods.kubejs.bindings.event.ServerEvents;
 import dev.latvian.mods.kubejs.recipe.AfterRecipesLoadedEventJS;
 import dev.latvian.mods.kubejs.script.ScriptType;
 import net.minecraft.server.ReloadableServerResources;
-import net.minecraft.server.packs.resources.ResourceManager;
-import net.minecraft.server.packs.resources.ResourceManagerReloadListener;
 
-public class KubeJSReloadListener implements ResourceManagerReloadListener {
+public class KubeJSReloadListener {
 	public static ReloadableServerResources resources;
 	public static Object recipeContext; // Forge
-
-	@Override
-	public void onResourceManagerReload(ResourceManager resourceManager) {
-		postAfterRecipes();
-	}
 
 	public static void postAfterRecipes() {
 		var recipeManager = resources == null ? null : resources.getRecipeManager();

--- a/common/src/main/java/dev/latvian/mods/kubejs/server/KubeJSReloadListener.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/server/KubeJSReloadListener.java
@@ -13,6 +13,10 @@ public class KubeJSReloadListener implements ResourceManagerReloadListener {
 
 	@Override
 	public void onResourceManagerReload(ResourceManager resourceManager) {
+		postAfterRecipes();
+	}
+
+	public static void postAfterRecipes() {
 		var recipeManager = resources == null ? null : resources.getRecipeManager();
 
 		if (recipeManager != null && ServerEvents.RECIPES_AFTER_LOADED.hasListeners()) {


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->

### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->
Fixes #327 for 2001

The code for `ServerEvents.afterRecipes` has existed for a long time. It used to get fired from `KubeJSReloadListener`, which implements `ResourceManagerReloadListener`.

Back in 1.17, `KubeJSReloadListener` was actually registered via a @ModifyArg in `SimpleReloadableResourceManagerMixin`. However, this injection was commented out in the port to 1.18 (rev 4e139f3c ) and later removed entirely.

Ever since then the event has not fired.

This PR fires the event from `MinecraftServerKJS.kjs$afterResourcesLoaded`, which is the canonical place for "the recipes are done loading"; it's where the "Reloaded with no KubeJS errors!" gets sent.

The PR also cleans up the `ResourceManagerReloadListener` implementation because that's dead code and just creates confusion.

#### Example Script <!-- Please provide an example script showing that the bug is fixed, or how the feature is used, if applicable -->

```js
ServerEvents.afterRecipes(event => {
	console.log(`afterRecipes fired successfully`)
})
```

#### Other details <!-- Any other important information, like if this is likely to break addons -->
Tested with Minecraft 1.20.1, Forge 47.4.13, KubeJS 2001.6.5
I haven't looked at other versions.