### PR TITLE
fix: register FoodProperties type wrapper to fix Connector mod compatibility 

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/BuiltinKubeJSPlugin.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/BuiltinKubeJSPlugin.java
@@ -48,6 +48,7 @@ import dev.latvian.mods.kubejs.fluid.FluidBuilder;
 import dev.latvian.mods.kubejs.fluid.FluidStackJS;
 import dev.latvian.mods.kubejs.fluid.FluidWrapper;
 import dev.latvian.mods.kubejs.integration.rei.REIEvents;
+import dev.latvian.mods.kubejs.item.FoodBuilder;  
 import dev.latvian.mods.kubejs.item.InputItem;
 import dev.latvian.mods.kubejs.item.ItemBuilder;
 import dev.latvian.mods.kubejs.item.ItemStackJS;
@@ -151,6 +152,7 @@ import net.minecraft.util.valueproviders.IntProvider;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.MobCategory;
 import net.minecraft.world.item.ArmorMaterial;
+import net.minecraft.world.food.FoodProperties;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
@@ -450,6 +452,7 @@ public class BuiltinKubeJSPlugin extends KubeJSPlugin {
 		typeWrappers.registerSimple(NumberProvider.class, UtilsJS::numberProviderOf);
 		typeWrappers.registerSimple(LootContext.EntityTarget.class, o -> o == null ? null : LootContext.EntityTarget.getByName(o.toString().toLowerCase()));
 		typeWrappers.registerSimple(CopyNameFunction.NameSource.class, o -> o == null ? null : CopyNameFunction.NameSource.getByName(o.toString().toLowerCase()));
+		typeWrappers.register(FoodProperties.class, FoodBuilder::of);
 
 		// KubeJS //
 		typeWrappers.registerSimple(Map.class, MapJS::of);

--- a/common/src/main/java/dev/latvian/mods/kubejs/item/FoodBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/item/FoodBuilder.java
@@ -5,11 +5,15 @@ import dev.architectury.hooks.item.food.FoodPropertiesHooks;
 import dev.latvian.mods.kubejs.registry.RegistryInfo;
 import dev.latvian.mods.kubejs.typings.Info;
 import dev.latvian.mods.kubejs.typings.Param;
+import dev.latvian.mods.rhino.BaseFunction;  
+import dev.latvian.mods.rhino.Context;  
+import dev.latvian.mods.rhino.NativeJavaObject;  
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.food.FoodProperties;
 import org.apache.commons.lang3.tuple.Pair;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.function.Consumer;
@@ -39,7 +43,23 @@ public class FoodBuilder {
 			effects.add(Pair.of(pair::getFirst, pair.getSecond()));
 		});
 	}
-
+    
+    @Nullable  
+	public static FoodProperties of(Context cx, @Nullable Object o) {  
+		if (o == null) {  
+			return null;  
+		} else if (o instanceof FoodProperties fp) {  
+			return fp;  
+		} else if (o instanceof BaseFunction func) {  
+			Consumer consumer = (Consumer) NativeJavaObject.createInterfaceAdapter(cx, Consumer.class, func);  
+			var builder = new FoodBuilder();  
+			consumer.accept(builder);  
+			return builder.build();  
+		} else {  
+			return null;  
+		}  
+	}
+    
 	@Info("Sets the hunger restored.")
 	public FoodBuilder hunger(int h) {
 		hunger = h;


### PR DESCRIPTION
Fix https://github.com/KubeJS-Mods/KubeJS/issues/1105

<!-- These comments won't appear in the final PR, so you can just leave them here -->

### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->

Register a type wrapper for FoodProperties in BuiltinKubeJSPlugin.registerTypeWrappers(). When the incoming value is a JS function (BaseFunction), use FoodBuilder to construct the FoodProperties; when the incoming value is already a FoodProperties, return it directly.

This way, even if Connector widens the field to public and Rhino takes the direct field assignment path, the type wrapper will correctly convert the arrow function.

#### Example Script <!-- Please provide an example script showing that the bug is fixed, or how the feature is used, if applicable -->

```js
ItemEvents.modification(event => {
    event.modify('minecraft:rabbit_foot', item => {
      item.foodProperties = food => {
          food.hunger(2)
          food.saturation(0.1)
          food.fastToEat()
      }
    })
  })
```

#### Other details <!-- Any other important information, like if this is likely to break addons -->
The error cause I have said in the issue
Hope you can merged my PR,thanks⭐