### PR TITLE
Fix `DataComponentWrapper` incorrectly handling component removal

### DIFF
--- a/src/main/java/dev/latvian/mods/kubejs/component/DataComponentWrapper.java
+++ b/src/main/java/dev/latvian/mods/kubejs/component/DataComponentWrapper.java
@@ -186,7 +186,7 @@ public interface DataComponentWrapper {
 				boolean remove = reader.canRead() && reader.peek() == '!';
 
 				if (remove) {
-					reader.skipWhitespace();
+					reader.skip();
 				}
 
 				var dataComponentType = readComponentType(reader);


### PR DESCRIPTION
### Description
`DataComponentWrapper` incorrectly handles "!" prefix inside a data component notation, causing item string parsing to fail.
```java
Failed to read item stack from music_disc_cat[!jukebox_playable]: Unknown item component 'minecraft:' at position 15: ..._disc_cat[<--[HERE]
```

This happens because instead of removing "!" prefix before proceeding to component type parsing, `skipWhitespace` is called, leaving "!" prefix untouched. This PR simply swaps incorrect call with a `skip` function.

#### Example Script

```js
Item.of('music_disc_cat[!jukebox_playable]')
```