### PR TITLE
Custom fluid implementation and small bugfix backport

### DIFF
--- a/src/main/java/dev/latvian/mods/kubejs/client/LoadedTexture.java
+++ b/src/main/java/dev/latvian/mods/kubejs/client/LoadedTexture.java
@@ -6,6 +6,7 @@ import dev.latvian.mods.kubejs.color.KubeColor;
 import it.unimi.dsi.fastutil.ints.Int2IntArrayMap;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.Mth;
+import net.neoforged.fml.ModList;
 import org.jetbrains.annotations.Nullable;
 
 import javax.imageio.ImageIO;
@@ -37,6 +38,20 @@ public class LoadedTexture {
 					try (var in = new BufferedInputStream(Files.newInputStream(path1))) {
 						var metaPath = KubeJS.thisMod.getModInfo().getOwningFile().getFile().findResource("assets", "kubejs", "textures", id.getPath() + ".png.mcmeta");
 						return new LoadedTexture(ImageIO.read(in), Files.exists(metaPath) ? Files.readAllBytes(metaPath) : null);
+					}
+				}
+			} else {
+				var modContainer = ModList.get().getModContainerById(id.getNamespace());
+
+				if (modContainer.isPresent()) {
+					var modFile = modContainer.get().getModInfo().getOwningFile().getFile();
+					var path2 = modFile.findResource("assets", id.getNamespace(), "textures", id.getPath() + ".png");
+
+					if (Files.exists(path2)) {
+						try (var in = new BufferedInputStream(Files.newInputStream(path2))) {
+							var metaPath = modFile.findResource("assets", id.getNamespace(), "textures", id.getPath() + ".png.mcmeta");
+							return new LoadedTexture(ImageIO.read(in), Files.exists(metaPath) ? Files.readAllBytes(metaPath) : null);
+						}
 					}
 				}
 			}

--- a/src/main/java/dev/latvian/mods/kubejs/fluid/FluidBuilder.java
+++ b/src/main/java/dev/latvian/mods/kubejs/fluid/FluidBuilder.java
@@ -166,7 +166,7 @@ public class FluidBuilder extends BuilderBase<FlowingFluid> {
 
 		var flowingTexture = generator.loadTexture(fluidType.flowingTexture);
 
-		if (!(stillTexture.width <= 0 || stillTexture.height <= 0)) {
+		if (!(flowingTexture.width <= 0 || flowingTexture.height <= 0)) {
 			generator.texture(fluidType.actualFlowingTexture, flowingTexture.tint(fluidType.tint));
 		}
 

--- a/src/main/java/dev/latvian/mods/kubejs/fluid/FluidBuilder.java
+++ b/src/main/java/dev/latvian/mods/kubejs/fluid/FluidBuilder.java
@@ -2,7 +2,6 @@ package dev.latvian.mods.kubejs.fluid;
 
 import dev.latvian.mods.kubejs.KubeJS;
 import dev.latvian.mods.kubejs.block.BlockRenderType;
-import dev.latvian.mods.kubejs.client.LoadedTexture;
 import dev.latvian.mods.kubejs.color.KubeColor;
 import dev.latvian.mods.kubejs.color.SimpleColor;
 import dev.latvian.mods.kubejs.generator.KubeAssetGenerator;


### PR DESCRIPTION
Added a small implementation for the texture loader to also look in the base game assets and mods' assets for textures, if they are not found in the KubeJS assets folder.
Backported a small bugfix from 26.1