### PR TITLE
Fix FoodBuilder and add functions in ItemComponentFunctions

### DIFF
--- a/src/main/java/dev/latvian/mods/kubejs/component/ItemComponentFunctions.java
+++ b/src/main/java/dev/latvian/mods/kubejs/component/ItemComponentFunctions.java
@@ -1,6 +1,7 @@
 package dev.latvian.mods.kubejs.component;
 
 import dev.latvian.mods.kubejs.color.KubeColor;
+import dev.latvian.mods.kubejs.item.FoodBuilder;
 import dev.latvian.mods.rhino.util.RemapPrefixForJS;
 import dev.latvian.mods.rhino.util.ReturnsSelf;
 import net.minecraft.core.Holder;
@@ -22,6 +23,7 @@ import net.minecraft.world.item.component.Tool;
 import net.minecraft.world.item.component.Unbreakable;
 
 import java.util.List;
+import java.util.function.Consumer;
 
 @RemapPrefixForJS("kjs$")
 @ReturnsSelf
@@ -58,8 +60,15 @@ public interface ItemComponentFunctions extends ComponentFunctions, AttributeMod
 		kjs$override(DataComponents.FOOD, foodProperties);
 	}
 
+	default void kjs$modifyFood(Consumer<FoodBuilder> foodBuilder) {
+		var food = kjs$get(DataComponents.FOOD);
+		FoodBuilder builder = food == null ? new FoodBuilder() : new FoodBuilder(food);
+		foodBuilder.accept(builder);
+		kjs$setFood(builder.build());
+	}
+
 	default void kjs$setFood(int nutrition, float saturation) {
-		kjs$setFood(new FoodProperties.Builder().nutrition(nutrition).saturationModifier(saturation).build());
+		kjs$modifyFood(builder -> builder.nutrition(nutrition).saturation(saturation));
 	}
 
 	default void kjs$setFireResistant() {

--- a/src/main/java/dev/latvian/mods/kubejs/item/FoodBuilder.java
+++ b/src/main/java/dev/latvian/mods/kubejs/item/FoodBuilder.java
@@ -41,6 +41,7 @@ public class FoodBuilder {
 		this.saturation = properties.saturation();
 		this.alwaysEdible = properties.canAlwaysEat();
 		this.eatSeconds = properties.eatSeconds();
+		this.usingConvertsTo = properties.usingConvertsTo();
 		this.effects = new ArrayList<>();
 		this.effects.addAll(properties.effects());
 	}


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->

### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->

Added `kjs$modifyFood` in `ItemComponentFunctions` to allow the use of a `Consumer<FoodBuilder>` to modify the food properties. If the item is not a food, food properties will be created automatically.

Also added `this.usingConvertsTo = properties.usingConvertsTo();` in the `FoodBuilder(FoodProperties properties)` constructor, because that constructor will leave the usingConvertsTo to null and crash.

#### Example Script <!-- Please provide an example script showing that the bug is fixed, or how the feature is used, if applicable -->

```js
ItemEvents.modification(event => {
    event.modify('minecraft:beef', item => {
        item.modifyFood(builder => builder.effect('minecraft:regeneration', 2000, 1, 1.0));
    });
});
```

#### Other details <!-- Any other important information, like if this is likely to break addons -->

`modifyFood` is used because Rhino can't distinguish the record type and the callback. Adding a specific type wrapper might allow consistent naming, but introduce extra code.