### PR TITLE
Maintain slot order of inventory requests in Kubedex

### DIFF
--- a/src/main/java/dev/latvian/mods/kubejs/client/highlight/HighlightRenderer.java
+++ b/src/main/java/dev/latvian/mods/kubejs/client/highlight/HighlightRenderer.java
@@ -60,6 +60,7 @@ import org.joml.Matrix4f;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 public class HighlightRenderer {
@@ -213,7 +214,7 @@ public class HighlightRenderer {
 	@Nullable
 	public ShaderInstance highlightShader;
 
-	public final Set<Slot> hoveredSlots = new HashSet<>();
+	public final Set<Slot> hoveredSlots = new LinkedHashSet<>();
 	public final Reference2IntMap<Entity> highlightedEntities = new Reference2IntLinkedOpenHashMap<>(0);
 	public final Long2IntMap highlightedBlocks = new Long2IntLinkedOpenHashMap(0);
 	public final IntOpenHashSet uniqueColors = new IntOpenHashSet(0);


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->

### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->

It would be better for integrations if the payload of inventory requests kept the order of insertion. For now, it uses `HashSet,` which causes the order to be quite random. Using `LinkedHashSet` shall fix the issue.

Problem:

https://github.com/user-attachments/assets/d19ec8b4-718c-49fd-aaca-26bcee55fb36
