### PR TITLE
Reworks `ItemBuilder` and `ItemModificationKubeEvent` for integration with IItemExtension and modification of items

### DIFF
--- a/src/main/java/dev/latvian/mods/kubejs/core/ItemKJS.java
+++ b/src/main/java/dev/latvian/mods/kubejs/core/ItemKJS.java
@@ -1,6 +1,6 @@
 package dev.latvian.mods.kubejs.core;
 
-import dev.latvian.mods.kubejs.item.ItemBuilder;
+import dev.latvian.mods.kubejs.item.ItemBehavior;
 import dev.latvian.mods.kubejs.item.ItemStackKey;
 import dev.latvian.mods.rhino.util.HideFromJS;
 import dev.latvian.mods.rhino.util.RemapForJS;
@@ -33,11 +33,11 @@ public interface ItemKJS extends IngredientSupplierKJS, RegistryObjectKJS<Item> 
 	}
 
 	@Nullable
-	default ItemBuilder kjs$getItemBuilder() {
+	default ItemBehavior kjs$getItemBehavior() {
 		throw new NoMixinException();
 	}
 
-	default void kjs$setItemBuilder(ItemBuilder b) {
+	default void kjs$setItemBehavior(ItemBehavior b) {
 		throw new NoMixinException();
 	}
 

--- a/src/main/java/dev/latvian/mods/kubejs/core/LivingEntityKJS.java
+++ b/src/main/java/dev/latvian/mods/kubejs/core/LivingEntityKJS.java
@@ -43,10 +43,10 @@ public interface LivingEntityKJS extends EntityKJS {
 	default void kjs$foodEaten(ItemStack eatenStack, FoodProperties food) {
 		var event = new FoodEatenKubeEvent(kjs$self(), eatenStack);
 		var item = eatenStack.getItem();
-		var itemBuilder = item.kjs$getItemBuilder();
+		var behavior = item.kjs$getItemBehavior();
 
-		if (itemBuilder != null && itemBuilder.foodBuilder != null && itemBuilder.foodBuilder.eaten != null) {
-			itemBuilder.foodBuilder.eaten.accept(event);
+		if (behavior != null && behavior.foodEaten != null) {
+			behavior.foodEaten.accept(event);
 		}
 
 		var key = item.kjs$getKey();

--- a/src/main/java/dev/latvian/mods/kubejs/core/mixin/IItemExtensionMixin.java
+++ b/src/main/java/dev/latvian/mods/kubejs/core/mixin/IItemExtensionMixin.java
@@ -1,0 +1,134 @@
+package dev.latvian.mods.kubejs.core.mixin;
+
+import dev.latvian.mods.kubejs.KubeJS;
+import dev.latvian.mods.kubejs.core.ItemKJS;
+import dev.latvian.mods.kubejs.item.ItemBehavior;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.monster.EnderMan;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.enchantment.EnchantmentInstance;
+import net.minecraft.world.level.Level;
+import net.neoforged.neoforge.common.ItemAbility;
+import net.neoforged.neoforge.common.extensions.IItemExtension;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.List;
+
+@Mixin(value = IItemExtension.class, priority = 999)
+public interface IItemExtensionMixin {
+	@Unique
+	private ItemBehavior kjs$getItemBehavior() {
+		return this instanceof ItemKJS kjs ? kjs.kjs$getItemBehavior() : null;
+	}
+
+	@Inject(method = "isPiglinCurrency", at = @At("HEAD"), cancellable = true)
+	private void isPiglinCurrency(ItemStack stack, CallbackInfoReturnable<Boolean> cir) {
+		ItemBehavior behavior = kjs$getItemBehavior();
+		if (behavior != null && behavior.isPiglinCurrency != null) {
+			cir.setReturnValue(behavior.isPiglinCurrency.test(stack));
+		}
+	}
+
+	@Inject(method = "isEnderMask", at = @At("HEAD"), cancellable = true)
+	private void isEnderMask(ItemStack stack, Player player, EnderMan endermanEntity, CallbackInfoReturnable<Boolean> cir) {
+		ItemBehavior behavior = kjs$getItemBehavior();
+		if (behavior != null && behavior.isEnderMask != null) {
+			cir.setReturnValue(behavior.isEnderMask.test(stack, player, endermanEntity));
+		}
+	}
+
+	@Inject(method = "makesPiglinsNeutral", at = @At("HEAD"), cancellable = true)
+	private void makesPiglinsNeutral(ItemStack stack, LivingEntity wearer, CallbackInfoReturnable<Boolean> cir) {
+		ItemBehavior behavior = kjs$getItemBehavior();
+		if (behavior != null && behavior.makesPiglinsNeutral != null) {
+			cir.setReturnValue(behavior.makesPiglinsNeutral.test(stack, wearer));
+		}
+	}
+
+	@Inject(method = "getCraftingRemainingItem", at = @At("HEAD"), cancellable = true)
+	private void getCraftingRemainingItem(ItemStack itemStack, CallbackInfoReturnable<ItemStack> cir) {
+		ItemBehavior behavior = kjs$getItemBehavior();
+		if (behavior != null && behavior.craftingRemainingItem != null) {
+			cir.setReturnValue(behavior.craftingRemainingItem.apply(itemStack));
+		}
+	}
+
+	@Inject(method = "hasCraftingRemainingItem", at = @At("HEAD"), cancellable = true)
+	private void hasCraftingRemainingItem(ItemStack stack, CallbackInfoReturnable<Boolean> cir) {
+		ItemBehavior behavior = kjs$getItemBehavior();
+		if (behavior != null && behavior.craftingRemainingItem != null) {
+			var returnStack = behavior.craftingRemainingItem.apply(stack);
+			cir.setReturnValue(returnStack != null && !returnStack.isEmpty());
+		}
+	}
+
+	@Inject(method = "getEntityLifespan", at = @At("HEAD"), cancellable = true)
+	private void getEntityLifespan(ItemStack itemStack, Level level, CallbackInfoReturnable<Integer> cir) {
+		ItemBehavior behavior = kjs$getItemBehavior();
+		if (behavior != null && behavior.getEntityLifespan != null) {
+			cir.setReturnValue(behavior.getEntityLifespan.applyAsInt(itemStack, level));
+		}
+	}
+
+	@Inject(method = "canDisableShield", at = @At("HEAD"), cancellable = true)
+	private void canDisableShield(ItemStack stack, ItemStack shield, LivingEntity entity, LivingEntity attacker, CallbackInfoReturnable<Boolean> cir) {
+		ItemBehavior behavior = kjs$getItemBehavior();
+		if (behavior != null && behavior.canDisableShield != null) {
+			cir.setReturnValue(behavior.canDisableShield.test(stack, shield, attacker));
+		}
+	}
+
+	@Inject(method = "canElytraFly", at = @At("HEAD"), cancellable = true)
+	private void canElytraFly(ItemStack stack, LivingEntity entity, CallbackInfoReturnable<Boolean> cir) {
+		ItemBehavior behavior = kjs$getItemBehavior();
+		if (behavior != null && behavior.canElytraFly != null) {
+			cir.setReturnValue(behavior.canElytraFly.test(stack, entity));
+		}
+	}
+
+	@Inject(method = "elytraFlightTick", at = @At("HEAD"), cancellable = true)
+	private void elytraFlightTick(ItemStack stack, LivingEntity entity, int flightTicks, CallbackInfoReturnable<Boolean> cir) {
+		ItemBehavior behavior = kjs$getItemBehavior();
+		if (behavior != null && behavior.elytraFlightTick != null) {
+			cir.setReturnValue(behavior.elytraFlightTick.flightTick(stack, entity, flightTicks));
+		}
+	}
+
+	@Inject(method = "canWalkOnPowderedSnow", at = @At("HEAD"), cancellable = true)
+	private void canWalkOnPowderedSnow(ItemStack stack, LivingEntity wearer, CallbackInfoReturnable<Boolean> cir) {
+		ItemBehavior behavior = kjs$getItemBehavior();
+		if (behavior != null && behavior.canWalkOnPowderedSnow != null) {
+			cir.setReturnValue(behavior.canWalkOnPowderedSnow.test(stack, wearer));
+		}
+	}
+
+	@Inject(method = "canPerformAction", at = @At("HEAD"), cancellable = true)
+	private void canPerformAction(ItemStack stack, ItemAbility itemAbility, CallbackInfoReturnable<Boolean> cir) {
+		ItemBehavior behavior = kjs$getItemBehavior();
+		if (behavior != null && behavior.canPerformAction != null) {
+			cir.setReturnValue(behavior.canPerformAction.test(stack, itemAbility));
+		}
+	}
+
+	@Inject(method = "canBeHurtBy", at = @At("HEAD"), cancellable = true)
+	private void canBeHurtBy(ItemStack stack, DamageSource source, CallbackInfoReturnable<Boolean> cir) {
+		ItemBehavior behavior = kjs$getItemBehavior();
+		if (behavior != null && behavior.canBeHurtBy != null) {
+			cir.setReturnValue(behavior.canBeHurtBy.test(stack, source));
+		}
+	}
+
+	@Inject(method = "applyEnchantments", at = @At("HEAD"), cancellable = true)
+	private void applyEnchantments(ItemStack stack, List<EnchantmentInstance> enchantments, CallbackInfoReturnable<ItemStack> cir) {
+		ItemBehavior behavior = kjs$getItemBehavior();
+		if (behavior != null && behavior.applyEnchantments != null) {
+			cir.setReturnValue(behavior.applyEnchantments.apply(stack, enchantments));
+		}
+	}
+}

--- a/src/main/java/dev/latvian/mods/kubejs/core/mixin/ItemMixin.java
+++ b/src/main/java/dev/latvian/mods/kubejs/core/mixin/ItemMixin.java
@@ -1,6 +1,7 @@
 package dev.latvian.mods.kubejs.core.mixin;
 
 import dev.latvian.mods.kubejs.core.ItemKJS;
+import dev.latvian.mods.kubejs.item.ItemBehavior;
 import dev.latvian.mods.kubejs.item.ItemBuilder;
 import dev.latvian.mods.kubejs.item.ItemStackKey;
 import dev.latvian.mods.rhino.util.HideFromJS;
@@ -49,7 +50,7 @@ public abstract class ItemMixin implements ItemKJS {
 	private Holder.Reference<Item> builtInRegistryHolder;
 
 	@Unique
-	private ItemBuilder kjs$itemBuilder;
+	private ItemBehavior kjs$behavior;
 
 	@Unique
 	private Map<String, Object> kjs$typeData;
@@ -68,8 +69,13 @@ public abstract class ItemMixin implements ItemKJS {
 
 	@Override
 	@Nullable
-	public ItemBuilder kjs$getItemBuilder() {
-		return kjs$itemBuilder;
+	public ItemBehavior kjs$getItemBehavior() {
+		return kjs$behavior;
+	}
+
+	@Override
+	public void kjs$setItemBehavior(ItemBehavior b) {
+		kjs$behavior = b;
 	}
 
 	@Override
@@ -96,11 +102,6 @@ public abstract class ItemMixin implements ItemKJS {
 	}
 
 	@Override
-	public void kjs$setItemBuilder(ItemBuilder b) {
-		kjs$itemBuilder = b;
-	}
-
-	@Override
 	public Map<String, Object> kjs$getTypeData() {
 		if (kjs$typeData == null) {
 			kjs$typeData = new HashMap<>();
@@ -124,69 +125,69 @@ public abstract class ItemMixin implements ItemKJS {
 
 	@Inject(method = "isFoil", at = @At("HEAD"), cancellable = true)
 	private void isFoil(ItemStack itemStack, CallbackInfoReturnable<Boolean> ci) {
-		if (kjs$itemBuilder != null && kjs$itemBuilder.glow) {
+		if (kjs$behavior != null && kjs$behavior.glow) {
 			ci.setReturnValue(true);
 		}
 	}
 
 	@Inject(method = "appendHoverText", at = @At("RETURN"))
 	private void appendHoverText(ItemStack stack, Item.TooltipContext context, List<Component> tooltip, TooltipFlag flagIn, CallbackInfo ci) {
-		if (kjs$itemBuilder != null && !kjs$itemBuilder.tooltip.isEmpty()) {
-			tooltip.addAll(kjs$itemBuilder.tooltip);
+		if (kjs$behavior != null && !kjs$behavior.tooltip.isEmpty()) {
+			tooltip.addAll(kjs$behavior.tooltip);
 		}
 	}
 
 	@Inject(method = "isBarVisible", at = @At("HEAD"), cancellable = true)
 	private void isBarVisible(ItemStack stack, CallbackInfoReturnable<Boolean> ci) {
-		if (kjs$itemBuilder != null && kjs$itemBuilder.barWidth != null && kjs$itemBuilder.barWidth.applyAsInt(stack) <= Item.MAX_BAR_WIDTH) {
+		if (kjs$behavior != null && kjs$behavior.barWidth != null && kjs$behavior.barWidth.applyAsInt(stack) <= Item.MAX_BAR_WIDTH) {
 			ci.setReturnValue(true);
 		}
 	}
 
 	@Inject(method = "getBarWidth", at = @At("HEAD"), cancellable = true)
 	private void getBarWidth(ItemStack stack, CallbackInfoReturnable<Integer> ci) {
-		if (kjs$itemBuilder != null && kjs$itemBuilder.barWidth != null) {
-			ci.setReturnValue(kjs$itemBuilder.barWidth.applyAsInt(stack));
+		if (kjs$behavior != null && kjs$behavior.barWidth != null) {
+			ci.setReturnValue(kjs$behavior.barWidth.applyAsInt(stack));
 		}
 	}
 
 	@Inject(method = "getBarColor", at = @At("HEAD"), cancellable = true)
 	private void getBarColor(ItemStack stack, CallbackInfoReturnable<Integer> ci) {
-		if (kjs$itemBuilder != null && kjs$itemBuilder.barColor != null) {
-			ci.setReturnValue(kjs$itemBuilder.barColor.apply(stack).kjs$getRGB());
+		if (kjs$behavior != null && kjs$behavior.barColor != null) {
+			ci.setReturnValue(kjs$behavior.barColor.apply(stack).kjs$getRGB());
 		}
 	}
 
 	@Inject(method = "getUseDuration", at = @At("HEAD"), cancellable = true)
 	private void getUseDuration(ItemStack itemStack, LivingEntity entity, CallbackInfoReturnable<Integer> cir) {
-		if (kjs$itemBuilder != null && kjs$itemBuilder.useDuration != null) {
-			cir.setReturnValue(kjs$itemBuilder.useDuration.applyAsInt(itemStack, entity));
+		if (kjs$behavior != null && kjs$behavior.useDuration != null) {
+			cir.setReturnValue(kjs$behavior.useDuration.applyAsInt(itemStack, entity));
 		}
 	}
 
 	@Inject(method = "getUseAnimation", at = @At("HEAD"), cancellable = true)
 	private void getUseAnimation(ItemStack itemStack, CallbackInfoReturnable<UseAnim> ci) {
-		if (kjs$itemBuilder != null && kjs$itemBuilder.anim != null) {
-			ci.setReturnValue(kjs$itemBuilder.anim);
+		if (kjs$behavior != null && kjs$behavior.anim != null) {
+			ci.setReturnValue(kjs$behavior.anim);
 		}
 	}
 
 	@Inject(method = "getName", at = @At("HEAD"), cancellable = true)
 	private void getName(ItemStack itemStack, CallbackInfoReturnable<Component> ci) {
-		if (kjs$itemBuilder != null && kjs$itemBuilder.nameGetter != null) {
-			ci.setReturnValue(kjs$itemBuilder.nameGetter.apply(itemStack));
+		if (kjs$behavior != null && kjs$behavior.nameGetter != null) {
+			ci.setReturnValue(kjs$behavior.nameGetter.apply(itemStack));
 		}
 
-		if (kjs$itemBuilder != null && kjs$itemBuilder.displayName != null && kjs$itemBuilder.formattedDisplayName) {
-			ci.setReturnValue(kjs$itemBuilder.displayName);
+		if (kjs$behavior != null && kjs$behavior.displayName != null && kjs$behavior.formattedDisplayName) {
+			ci.setReturnValue(kjs$behavior.displayName);
 		}
 	}
 
 	@Inject(method = "use", at = @At("HEAD"), cancellable = true)
 	private void use(Level level, Player player, InteractionHand interactionHand, CallbackInfoReturnable<InteractionResultHolder<ItemStack>> ci) {
-		if (kjs$itemBuilder != null && kjs$itemBuilder.use != null) {
+		if (kjs$behavior != null && kjs$behavior.use != null) {
 			ItemStack itemStack = player.getItemInHand(interactionHand);
-			if (kjs$itemBuilder.use.use(level, player, interactionHand)) {
+			if (kjs$behavior.use.use(level, player, interactionHand)) {
 				ci.setReturnValue(ItemUtils.startUsingInstantly(level, player, interactionHand));
 			} else {
 				ci.setReturnValue(InteractionResultHolder.fail(itemStack));
@@ -196,22 +197,22 @@ public abstract class ItemMixin implements ItemKJS {
 
 	@Inject(method = "finishUsingItem", at = @At("HEAD"), cancellable = true)
 	private void finishUsingItem(ItemStack itemStack, Level level, LivingEntity livingEntity, CallbackInfoReturnable<ItemStack> ci) {
-		if (kjs$itemBuilder != null && kjs$itemBuilder.finishUsing != null) {
-			ci.setReturnValue(kjs$itemBuilder.finishUsing.finishUsingItem(itemStack, level, livingEntity));
+		if (kjs$behavior != null && kjs$behavior.finishUsing != null) {
+			ci.setReturnValue(kjs$behavior.finishUsing.finishUsingItem(itemStack, level, livingEntity));
 		}
 	}
 
 	@Inject(method = "releaseUsing", at = @At("HEAD"))
 	private void releaseUsing(ItemStack itemStack, Level level, LivingEntity livingEntity, int i, CallbackInfo ci) {
-		if (kjs$itemBuilder != null && kjs$itemBuilder.releaseUsing != null) {
-			kjs$itemBuilder.releaseUsing.releaseUsing(itemStack, level, livingEntity, i);
+		if (kjs$behavior != null && kjs$behavior.releaseUsing != null) {
+			kjs$behavior.releaseUsing.releaseUsing(itemStack, level, livingEntity, i);
 		}
 	}
 
 	@Inject(method = "hurtEnemy", at = @At("HEAD"), cancellable = true)
 	private void hurtEnemy(ItemStack itemStack, LivingEntity livingEntity, LivingEntity livingEntity2, CallbackInfoReturnable<Boolean> cir) {
-		if (kjs$itemBuilder != null && kjs$itemBuilder.hurtEnemy != null) {
-			cir.setReturnValue(kjs$itemBuilder.hurtEnemy.test(new ItemBuilder.HurtEnemyContext(itemStack, livingEntity, livingEntity2)));
+		if (kjs$behavior != null && kjs$behavior.hurtEnemy != null) {
+			cir.setReturnValue(kjs$behavior.hurtEnemy.test(new ItemBuilder.HurtEnemyContext(itemStack, livingEntity, livingEntity2)));
 		}
 	}
 

--- a/src/main/java/dev/latvian/mods/kubejs/core/mixin/ItemMixin.java
+++ b/src/main/java/dev/latvian/mods/kubejs/core/mixin/ItemMixin.java
@@ -2,7 +2,6 @@ package dev.latvian.mods.kubejs.core.mixin;
 
 import dev.latvian.mods.kubejs.core.ItemKJS;
 import dev.latvian.mods.kubejs.item.ItemBehavior;
-import dev.latvian.mods.kubejs.item.ItemBuilder;
 import dev.latvian.mods.kubejs.item.ItemStackKey;
 import dev.latvian.mods.rhino.util.HideFromJS;
 import dev.latvian.mods.rhino.util.RemapPrefixForJS;
@@ -22,6 +21,7 @@ import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.UseAnim;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.level.Level;
+import net.neoforged.neoforge.common.extensions.IItemExtension;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -212,7 +212,7 @@ public abstract class ItemMixin implements ItemKJS {
 	@Inject(method = "hurtEnemy", at = @At("HEAD"), cancellable = true)
 	private void hurtEnemy(ItemStack itemStack, LivingEntity livingEntity, LivingEntity livingEntity2, CallbackInfoReturnable<Boolean> cir) {
 		if (kjs$behavior != null && kjs$behavior.hurtEnemy != null) {
-			cir.setReturnValue(kjs$behavior.hurtEnemy.test(new ItemBuilder.HurtEnemyContext(itemStack, livingEntity, livingEntity2)));
+			cir.setReturnValue(kjs$behavior.hurtEnemy.test(new ItemBehavior.HurtEnemyContext(itemStack, livingEntity, livingEntity2)));
 		}
 	}
 

--- a/src/main/java/dev/latvian/mods/kubejs/item/ItemBehavior.java
+++ b/src/main/java/dev/latvian/mods/kubejs/item/ItemBehavior.java
@@ -1,0 +1,44 @@
+package dev.latvian.mods.kubejs.item;
+
+import dev.latvian.mods.kubejs.color.KubeColor;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.UseAnim;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.ToIntBiFunction;
+import java.util.function.ToIntFunction;
+
+public class ItemBehavior {
+	public transient boolean glow = false;
+	public transient final List<Component> tooltip = new ArrayList<>();
+	@Nullable
+	public transient Function<ItemStack, KubeColor> barColor;
+	@Nullable
+	public transient ToIntFunction<ItemStack> barWidth;
+	@Nullable
+	public transient ItemBuilder.NameCallback nameGetter;
+	@Nullable
+	public transient UseAnim anim;
+	@Nullable
+	public transient ToIntBiFunction<ItemStack, LivingEntity> useDuration;
+	@Nullable
+	public transient ItemBuilder.UseCallback use;
+	@Nullable
+	public transient ItemBuilder.FinishUsingCallback finishUsing;
+	@Nullable
+	public transient ItemBuilder.ReleaseUsingCallback releaseUsing;
+	@Nullable
+	public transient Predicate<ItemBuilder.HurtEnemyContext> hurtEnemy;
+	@Nullable
+	public transient Consumer<FoodEatenKubeEvent> foodEaten;
+	@Nullable
+	public transient Component displayName;
+	public transient boolean formattedDisplayName = false;
+}

--- a/src/main/java/dev/latvian/mods/kubejs/item/ItemBehavior.java
+++ b/src/main/java/dev/latvian/mods/kubejs/item/ItemBehavior.java
@@ -2,43 +2,121 @@ package dev.latvian.mods.kubejs.item;
 
 import dev.latvian.mods.kubejs.color.KubeColor;
 import net.minecraft.network.chat.Component;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.UseAnim;
+import net.minecraft.world.item.enchantment.EnchantmentInstance;
+import net.minecraft.world.level.Level;
+import net.neoforged.neoforge.common.ItemAbility;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.ToIntBiFunction;
 import java.util.function.ToIntFunction;
+import java.util.function.UnaryOperator;
 
 public class ItemBehavior {
+	@Nullable
+	public transient Component displayName;
+	public transient boolean formattedDisplayName = false;
 	public transient boolean glow = false;
 	public transient final List<Component> tooltip = new ArrayList<>();
+
 	@Nullable
 	public transient Function<ItemStack, KubeColor> barColor;
 	@Nullable
 	public transient ToIntFunction<ItemStack> barWidth;
 	@Nullable
-	public transient ItemBuilder.NameCallback nameGetter;
+	public transient ItemBehavior.NameCallback nameGetter;
 	@Nullable
 	public transient UseAnim anim;
 	@Nullable
 	public transient ToIntBiFunction<ItemStack, LivingEntity> useDuration;
 	@Nullable
-	public transient ItemBuilder.UseCallback use;
+	public transient ItemBehavior.UseCallback use;
 	@Nullable
-	public transient ItemBuilder.FinishUsingCallback finishUsing;
+	public transient ItemBehavior.FinishUsingCallback finishUsing;
 	@Nullable
-	public transient ItemBuilder.ReleaseUsingCallback releaseUsing;
+	public transient ItemBehavior.ReleaseUsingCallback releaseUsing;
 	@Nullable
-	public transient Predicate<ItemBuilder.HurtEnemyContext> hurtEnemy;
+	public transient Predicate<HurtEnemyContext> hurtEnemy;
 	@Nullable
 	public transient Consumer<FoodEatenKubeEvent> foodEaten;
+
+	// IItemExtension methods
+	// @Nullable // This is somehow bugged
+	// public transient BiPredicate<ItemStack, Player> onDroppedByPlayer;
 	@Nullable
-	public transient Component displayName;
-	public transient boolean formattedDisplayName = false;
+	public transient Predicate<ItemStack> isPiglinCurrency;
+	@Nullable
+	public transient ItemBehavior.EndermanMaskTest isEnderMask;
+	@Nullable
+	public transient BiPredicate<ItemStack, LivingEntity> makesPiglinsNeutral;
+	@Nullable
+	public transient UnaryOperator<ItemStack> craftingRemainingItem;
+	@Nullable
+	public transient ToIntBiFunction<ItemStack, Level> getEntityLifespan;
+	@Nullable
+	public transient ItemBehavior.DisableShieldTest canDisableShield;
+	@Nullable
+	public transient BiPredicate<ItemStack, LivingEntity> canElytraFly;
+	@Nullable
+	public transient ItemBehavior.ElytraFlightTickCallback elytraFlightTick;
+	@Nullable
+	public transient BiPredicate<ItemStack, LivingEntity> canWalkOnPowderedSnow;
+	@Nullable
+	public transient BiPredicate<ItemStack, ItemAbility> canPerformAction;
+	@Nullable
+	public transient BiPredicate<ItemStack, DamageSource> canBeHurtBy;
+	@Nullable
+	public transient BiFunction<ItemStack, List<EnchantmentInstance>, ItemStack> applyEnchantments;
+
+
+	@FunctionalInterface
+	public interface UseCallback {
+		boolean use(Level level, Player player, InteractionHand interactionHand);
+	}
+
+	@FunctionalInterface
+	public interface FinishUsingCallback {
+		ItemStack finishUsingItem(ItemStack itemStack, Level level, LivingEntity livingEntity);
+	}
+
+	@FunctionalInterface
+	public interface ReleaseUsingCallback {
+		void releaseUsing(ItemStack itemStack, Level level, LivingEntity user, int tick);
+	}
+
+	@FunctionalInterface
+	public interface NameCallback {
+		Component apply(ItemStack itemStack);
+	}
+
+	@FunctionalInterface
+	public interface EndermanMaskTest {
+		boolean test(ItemStack stack, Player player, LivingEntity endermanEntity);
+	}
+
+	@FunctionalInterface
+	public interface DisableShieldTest {
+		boolean test(ItemStack stack, ItemStack shield, LivingEntity attacker);
+	}
+
+	@FunctionalInterface
+	public interface ElytraFlightTickCallback {
+		boolean flightTick(ItemStack stack, LivingEntity wearer, int flightTicks);
+	}
+
+
+	public record HurtEnemyContext(ItemStack getItem, LivingEntity getTarget, LivingEntity getAttacker) {
+	}
 }

--- a/src/main/java/dev/latvian/mods/kubejs/item/ItemBehaviorFunctions.java
+++ b/src/main/java/dev/latvian/mods/kubejs/item/ItemBehaviorFunctions.java
@@ -1,0 +1,320 @@
+package dev.latvian.mods.kubejs.item;
+
+import dev.latvian.mods.kubejs.color.KubeColor;
+import dev.latvian.mods.kubejs.typings.Info;
+import dev.latvian.mods.rhino.util.HideFromJS;
+import dev.latvian.mods.rhino.util.ReturnsSelf;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.damagesource.DamageType;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.UseAnim;
+import net.minecraft.world.item.enchantment.EnchantmentInstance;
+import net.minecraft.world.level.Level;
+import net.neoforged.neoforge.common.ItemAbility;
+
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.ToIntBiFunction;
+import java.util.function.ToIntFunction;
+import java.util.function.UnaryOperator;
+
+@ReturnsSelf
+public interface ItemBehaviorFunctions {
+	@HideFromJS
+	ItemBehavior kjs$getOrCreateBehavior();
+
+	@HideFromJS // Used only in item builders
+	default ItemBehaviorFunctions displayName(Component component, boolean formattedDisplayName) {
+		ItemBehavior behavior = kjs$getOrCreateBehavior();
+		behavior.displayName = component;
+		behavior.formattedDisplayName = formattedDisplayName;
+		return this;
+	}
+
+	@Info("Makes the item glow like enchanted, even if it's not enchanted.")
+	default ItemBehaviorFunctions glow(boolean glow) {
+		kjs$getOrCreateBehavior().glow = glow;
+		return this;
+	}
+
+	@Info("Adds a tooltip to the item.")
+	default ItemBehaviorFunctions tooltip(Component component) {
+		kjs$getOrCreateBehavior().tooltip.add(component);
+		return this;
+	}
+
+	@Info("Determines the color of the item's durability bar. Defaulted to vanilla behavior.")
+	default ItemBehaviorFunctions barColor(Function<ItemStack, KubeColor> barColor) {
+		kjs$getOrCreateBehavior().barColor = barColor;
+		return this;
+	}
+
+	@Info("""
+		Determines the width of the item's durability bar. Defaulted to vanilla behavior.
+				
+		The function should return a value between 0 and 13 (max width of the bar).
+		""")
+	default ItemBehaviorFunctions barWidth(ToIntFunction<ItemStack> barWidth) {
+		kjs$getOrCreateBehavior().barWidth = barWidth;
+		return this;
+	}
+
+	@Info("""
+		Sets the item's name dynamically.
+		""")
+	default ItemBehaviorFunctions name(ItemBehavior.NameCallback name) {
+		kjs$getOrCreateBehavior().nameGetter = name;
+		return this;
+	}
+
+	@Info("Determines the animation of the item when used, e.g. eating food.")
+	default ItemBehaviorFunctions useAnimation(UseAnim anim) {
+		kjs$getOrCreateBehavior().anim = anim;
+		return this;
+	}
+
+	@Info("""
+		The duration when the item is used.
+				
+		For example, when eating food, this is the time it takes to eat the food.
+		This can change the eating speed, or be used for other things (like making a custom bow).
+		""")
+	default ItemBehaviorFunctions useDuration(ToIntBiFunction<ItemStack, LivingEntity> useDuration) {
+		kjs$getOrCreateBehavior().useDuration = useDuration;
+		return this;
+	}
+
+	@Info("""
+		Determines if player will start using the item.
+				
+		For example, when eating food, returning true will make the player start eating the food.
+		""")
+	default ItemBehaviorFunctions use(ItemBehavior.UseCallback use) {
+		kjs$getOrCreateBehavior().use = use;
+		return this;
+	}
+
+	@Info("""
+		When players finish using the item.
+				
+		This is called only when `useDuration` ticks have passed.
+				
+		For example, when eating food, this is called when the player has finished eating the food, so hunger is restored.
+		""")
+	default ItemBehaviorFunctions finishUsing(ItemBehavior.FinishUsingCallback finishUsing) {
+		kjs$getOrCreateBehavior().finishUsing = finishUsing;
+		return this;
+	}
+
+	@Info("""
+		When players did not finish using the item but released the right mouse button halfway through.
+				
+		An example is the bow, where the arrow is shot when the player releases the right mouse button.
+				
+		To ensure the bow won't finish using, Minecraft sets the `useDuration` to a very high number (1h).
+		""")
+	default ItemBehaviorFunctions releaseUsing(ItemBehavior.ReleaseUsingCallback releaseUsing) {
+		kjs$getOrCreateBehavior().releaseUsing = releaseUsing;
+		return this;
+	}
+
+	@Info("""
+		Gets called when the item is used to hurt an entity.
+				
+		For example, when using a sword to hit a mob, this is called.
+		""")
+	default ItemBehaviorFunctions hurtEnemy(Predicate<ItemBehavior.HurtEnemyContext> hurtEnemy) {
+		kjs$getOrCreateBehavior().hurtEnemy = hurtEnemy;
+		return this;
+	}
+
+	@HideFromJS // Used only in item builders
+	default ItemBehaviorFunctions foodEaten(Consumer<FoodEatenKubeEvent> foodEaten) {
+		kjs$getOrCreateBehavior().foodEaten = foodEaten;
+		return this;
+	}
+
+	@Info("""
+		Determines if piglins will give an item or something in exchange for the item.
+		""")
+	default ItemBehaviorFunctions isPiglinCurrency(Predicate<ItemStack> isPiglinCurrency) {
+		kjs$getOrCreateBehavior().isPiglinCurrency = isPiglinCurrency;
+		return this;
+	}
+
+	default ItemBehaviorFunctions isPiglinCurrency(boolean isPiglinCurrency) {
+		return isPiglinCurrency(stack -> isPiglinCurrency);
+	}
+
+	@Info("""
+		Whether this item can be used to hide player head for enderman
+		""")
+	default ItemBehaviorFunctions isEnderMask(ItemBehavior.EndermanMaskTest isEnderMask) {
+		kjs$getOrCreateBehavior().isEnderMask = isEnderMask;
+		return this;
+	}
+
+	default ItemBehaviorFunctions isEnderMask(boolean isEnderMask) {
+		return isEnderMask((stack, player, enderman) -> isEnderMask);
+	}
+
+	@Info("""
+		Determines if piglins will be neutral to the wearer of the item and will not attack on sight.
+				
+		However, this does not prevent piglins from being hostile due to other actions, or make piglins
+		stop being hostile if they are already hostile.
+		""")
+	default ItemBehaviorFunctions makesPiglinsNeutral(BiPredicate<ItemStack, LivingEntity> makesPiglinsNeutral) {
+		kjs$getOrCreateBehavior().makesPiglinsNeutral = makesPiglinsNeutral;
+		return this;
+	}
+
+	default ItemBehaviorFunctions makesPiglinsNeutral(boolean makesPiglinsNeutral) {
+		return makesPiglinsNeutral((stack, wearer) -> makesPiglinsNeutral);
+	}
+
+	@Info("""
+		Returns the item that remains in the crafting grid (or furnace fuel) after crafting with this item programatically.
+				
+		Returning an empty stack or null will make the item be consumed as normal.
+				
+		An example would be durability-consuming items, e.g. hammers or wrenches.
+		""")
+	default ItemBehaviorFunctions craftingRemainingItem(UnaryOperator<ItemStack> craftingRemainingItem) {
+		kjs$getOrCreateBehavior().craftingRemainingItem = craftingRemainingItem;
+		return this;
+	}
+
+	@Info("""
+		Determines the lifespan in ticks of the item when it's dropped on the ground as an entity.
+				
+		Used for items like Fluix Seeds to prevent them from despawning.
+		""")
+	default ItemBehaviorFunctions getEntityLifespan(ToIntBiFunction<ItemStack, Level> getEntityLifespan) {
+		kjs$getOrCreateBehavior().getEntityLifespan = getEntityLifespan;
+		return this;
+	}
+
+	default ItemBehaviorFunctions getEntityLifespan(int lifespan) {
+		return getEntityLifespan((stack, level) -> lifespan);
+	}
+
+	@Info("""
+		Determines if the item can disable shield when attacking like axe does.
+		""")
+	default ItemBehaviorFunctions canDisableShield(ItemBehavior.DisableShieldTest canDisableShield) {
+		kjs$getOrCreateBehavior().canDisableShield = canDisableShield;
+		return this;
+	}
+
+	default ItemBehaviorFunctions canDisableShield(boolean canDisableShield) {
+		return canDisableShield((stack, shield, attacker) -> canDisableShield);
+	}
+
+	@Info("""
+		Determines if the item allows player to do elytra flying when equipped in the chest slot.
+		""")
+	default ItemBehaviorFunctions canElytraFly(BiPredicate<ItemStack, LivingEntity> canElytraFly) {
+		kjs$getOrCreateBehavior().canElytraFly = canElytraFly;
+		return this;
+	}
+
+	default ItemBehaviorFunctions canElytraFly(boolean canElytraFly) {
+		return canElytraFly((stack, entity) -> canElytraFly);
+	}
+
+	@Info("""
+		Called every tick when the player is flying with elytra with this item equipped in the chest slot.
+				
+		Returning false will stop the player from flying.
+		""")
+	default ItemBehaviorFunctions elytraFlightTick(ItemBehavior.ElytraFlightTickCallback elytraFlightTick) {
+		kjs$getOrCreateBehavior().elytraFlightTick = elytraFlightTick;
+		return this;
+	}
+
+	@Info("""
+		Determines if the player can walk on powdered snow with this item worn in the feet slot.
+		""")
+	default ItemBehaviorFunctions canWalkOnPowderedSnow(BiPredicate<ItemStack, LivingEntity> canWalkOnPowderedSnow) {
+		kjs$getOrCreateBehavior().canWalkOnPowderedSnow = canWalkOnPowderedSnow;
+		return this;
+	}
+
+	default ItemBehaviorFunctions canWalkOnPowderedSnow(boolean canWalkOnPowderedSnow) {
+		return canWalkOnPowderedSnow((stack, wearer) -> canWalkOnPowderedSnow);
+	}
+
+	@Info("""
+		Determines if the item can perform corresponding action. E.g. shearing sheep, stripping logs, etc.
+		""")
+	default ItemBehaviorFunctions canPerformAction(BiPredicate<ItemStack, ItemAbility> canPerformAction) {
+		kjs$getOrCreateBehavior().canPerformAction = canPerformAction;
+		return this;
+	}
+
+	@Info("""
+		Determines if the item entity will be destroyed by the damage source.
+				
+		For example, netherite items will not be destroyed by lava.
+		""")
+	default ItemBehaviorFunctions canBeHurtBy(BiPredicate<ItemStack, DamageSource> canBeHurtBy) {
+		kjs$getOrCreateBehavior().canBeHurtBy = canBeHurtBy;
+		return this;
+	}
+
+	@Info("""
+		Determines if the item entity will be destroyed by listed damages types.
+				
+		All other damages will be treated as normal. Passing [] will make the item immune to all damage.
+		"""
+	)
+	default ItemBehaviorFunctions onlyHurtBy(List<ResourceKey<DamageType>> damageTypes) {
+		return canBeHurtBy((stack, source) -> {
+			for (ResourceKey<DamageType> type : damageTypes) {
+				if (source.is(type)) {
+					return true;
+				}
+			}
+			return false;
+		});
+	}
+
+	@Info("""
+		Determines if the item entity will be immune to listed damages types.
+				
+		All other damages will be treated as normal. Passing [] will have no effect.
+		""")
+	default ItemBehaviorFunctions immuneTo(List<ResourceKey<DamageType>> damageTypes) {
+		if (damageTypes.isEmpty()) {
+			return this;
+		}
+
+		return canBeHurtBy((stack, source) -> {
+			for (ResourceKey<DamageType> type : damageTypes) {
+				if (source.is(type)) {
+					return false;
+				}
+			}
+			return true;
+		});
+	}
+
+	@Info("""
+		Returns the enchanted item stack after applying enchantments to the item.
+				
+		For example, books will be transformed into enchanted books by using this.
+		""")
+	default ItemBehaviorFunctions applyEnchantments(BiFunction<ItemStack, List<EnchantmentInstance>, ItemStack> applyEnchantments) {
+		kjs$getOrCreateBehavior().applyEnchantments = applyEnchantments;
+		return this;
+	}
+}

--- a/src/main/java/dev/latvian/mods/kubejs/item/ItemBuilder.java
+++ b/src/main/java/dev/latvian/mods/kubejs/item/ItemBuilder.java
@@ -31,10 +31,8 @@ import net.minecraft.world.item.component.Tool;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -56,22 +54,11 @@ public class ItemBuilder extends ModelledBuilderBase<Item> {
 	public transient Function<ItemStack, Collection<ItemStack>> subtypes;
 	public transient Rarity rarity;
 	public transient boolean fireResistant;
-	public transient boolean glow;
-	public transient final List<Component> tooltip;
 	@Nullable
 	public transient ItemTintFunction tint;
 	public transient FoodBuilder foodBuilder;
-	public transient Function<ItemStack, KubeColor> barColor;
-	public transient ToIntFunction<ItemStack> barWidth;
-	public transient NameCallback nameGetter;
-
-	public transient UseAnim anim;
-	public transient ToIntBiFunction<ItemStack, LivingEntity> useDuration;
-	public transient UseCallback use;
-	public transient FinishUsingCallback finishUsing;
-	public transient ReleaseUsingCallback releaseUsing;
-	public transient Predicate<HurtEnemyContext> hurtEnemy;
 	public transient JukeboxPlayable jukeboxPlayable;
+	public transient final ItemBehavior behavior = new ItemBehavior();
 
 	public transient Tool tool;
 	public transient ItemAttributeModifiers itemAttributeModifiers;
@@ -87,16 +74,8 @@ public class ItemBuilder extends ModelledBuilderBase<Item> {
 		this.containerItem = null;
 		this.subtypes = null;
 		this.rarity = null;
-		this.glow = false;
-		this.tooltip = new ArrayList<>();
 		this.foodBuilder = null;
-		this.anim = null;
-		this.useDuration = null;
-		this.use = null;
-		this.finishUsing = null;
-		this.releaseUsing = null;
 		this.fireResistant = false;
-		this.hurtEnemy = null;
 
 		this.tool = null;
 		this.itemAttributeModifiers = null;
@@ -110,7 +89,9 @@ public class ItemBuilder extends ModelledBuilderBase<Item> {
 
 	@Override
 	public Item transformObject(Item obj) {
-		obj.kjs$setItemBuilder(this);
+		behavior.displayName = displayName;
+		behavior.formattedDisplayName = formattedDisplayName;
+		obj.kjs$setItemBehavior(behavior);
 		return obj;
 	}
 
@@ -192,13 +173,13 @@ public class ItemBuilder extends ModelledBuilderBase<Item> {
 
 	@Info("Makes the item glow like enchanted, even if it's not enchanted.")
 	public ItemBuilder glow(boolean v) {
-		glow = v;
+		behavior.glow = v;
 		return this;
 	}
 
 	@Info("Adds a tooltip to the item.")
 	public ItemBuilder tooltip(Component text) {
-		tooltip.add(text);
+		behavior.tooltip.add(text);
 		return this;
 	}
 
@@ -226,7 +207,7 @@ public class ItemBuilder extends ModelledBuilderBase<Item> {
 
 	@Info("Determines the color of the item's durability bar. Defaulted to vanilla behavior.")
 	public ItemBuilder barColor(Function<ItemStack, KubeColor> barColor) {
-		this.barColor = barColor;
+		behavior.barColor = barColor;
 		return this;
 	}
 
@@ -236,7 +217,7 @@ public class ItemBuilder extends ModelledBuilderBase<Item> {
 		The function should return a value between 0 and 13 (max width of the bar).
 		""")
 	public ItemBuilder barWidth(ToIntFunction<ItemStack> barWidth) {
-		this.barWidth = barWidth;
+		behavior.barWidth = barWidth;
 		return this;
 	}
 
@@ -244,7 +225,7 @@ public class ItemBuilder extends ModelledBuilderBase<Item> {
 		Sets the item's name dynamically.
 		""")
 	public ItemBuilder name(NameCallback name) {
-		this.nameGetter = name;
+		behavior.nameGetter = name;
 		return this;
 	}
 
@@ -280,7 +261,7 @@ public class ItemBuilder extends ModelledBuilderBase<Item> {
 
 	@Info("Determines the animation of the item when used, e.g. eating food.")
 	public ItemBuilder useAnimation(UseAnim animation) {
-		this.anim = animation;
+		behavior.anim = animation;
 		return this;
 	}
 
@@ -291,7 +272,7 @@ public class ItemBuilder extends ModelledBuilderBase<Item> {
 		This can change the eating speed, or be used for other things (like making a custom bow).
 		""")
 	public ItemBuilder useDuration(ToIntBiFunction<ItemStack, LivingEntity> useDuration) {
-		this.useDuration = useDuration;
+		behavior.useDuration = useDuration;
 		return this;
 	}
 
@@ -301,7 +282,7 @@ public class ItemBuilder extends ModelledBuilderBase<Item> {
 		For example, when eating food, returning true will make the player start eating the food.
 		""")
 	public ItemBuilder use(UseCallback use) {
-		this.use = use;
+		behavior.use = use;
 		return this;
 	}
 
@@ -313,7 +294,7 @@ public class ItemBuilder extends ModelledBuilderBase<Item> {
 		For example, when eating food, this is called when the player has finished eating the food, so hunger is restored.
 		""")
 	public ItemBuilder finishUsing(FinishUsingCallback finishUsing) {
-		this.finishUsing = finishUsing;
+		behavior.finishUsing = finishUsing;
 		return this;
 	}
 
@@ -325,7 +306,7 @@ public class ItemBuilder extends ModelledBuilderBase<Item> {
 		To ensure the bow won't finish using, Minecraft sets the `useDuration` to a very high number (1h).
 		""")
 	public ItemBuilder releaseUsing(ReleaseUsingCallback releaseUsing) {
-		this.releaseUsing = releaseUsing;
+		behavior.releaseUsing = releaseUsing;
 		return this;
 	}
 
@@ -335,7 +316,7 @@ public class ItemBuilder extends ModelledBuilderBase<Item> {
 		For example, when using a sword to hit a mob, this is called.
 		""")
 	public ItemBuilder hurtEnemy(Predicate<HurtEnemyContext> context) {
-		this.hurtEnemy = context;
+		behavior.hurtEnemy = context;
 		return this;
 	}
 

--- a/src/main/java/dev/latvian/mods/kubejs/item/ItemBuilder.java
+++ b/src/main/java/dev/latvian/mods/kubejs/item/ItemBuilder.java
@@ -1,6 +1,5 @@
 package dev.latvian.mods.kubejs.item;
 
-import dev.latvian.mods.kubejs.color.KubeColor;
 import dev.latvian.mods.kubejs.component.DataComponentWrapper;
 import dev.latvian.mods.kubejs.generator.KubeAssetGenerator;
 import dev.latvian.mods.kubejs.plugin.builtin.wrapper.ItemWrapper;
@@ -15,9 +14,6 @@ import net.minecraft.core.component.DataComponents;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.InteractionHand;
-import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.EitherHolder;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
@@ -25,10 +21,8 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.item.JukeboxPlayable;
 import net.minecraft.world.item.JukeboxSong;
 import net.minecraft.world.item.Rarity;
-import net.minecraft.world.item.UseAnim;
 import net.minecraft.world.item.component.ItemAttributeModifiers;
 import net.minecraft.world.item.component.Tool;
-import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
@@ -36,15 +30,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.Predicate;
-import java.util.function.ToIntBiFunction;
-import java.util.function.ToIntFunction;
 
 @SuppressWarnings({"unused", "UnusedReturnValue"})
 @ReturnsSelf
-public class ItemBuilder extends ModelledBuilderBase<Item> {
-	public record HurtEnemyContext(ItemStack getItem, LivingEntity getTarget, LivingEntity getAttacker) {
-	}
+public class ItemBuilder extends ModelledBuilderBase<Item> implements ItemBehaviorFunctions {
 
 	public transient Map<Object, Object> components;
 	public transient int maxStackSize;
@@ -89,8 +78,7 @@ public class ItemBuilder extends ModelledBuilderBase<Item> {
 
 	@Override
 	public Item transformObject(Item obj) {
-		behavior.displayName = displayName;
-		behavior.formattedDisplayName = formattedDisplayName;
+		displayName(displayName, formattedDisplayName);
 		obj.kjs$setItemBehavior(behavior);
 		return obj;
 	}
@@ -157,7 +145,7 @@ public class ItemBuilder extends ModelledBuilderBase<Item> {
 
 	@Info("""
 		Adds subtypes to the item. The function should return a collection of item stacks, each with a different subtype.
-		
+				
 		Each subtype will appear as a separate item in JEI and the creative inventory.
 		""")
 	public ItemBuilder subtypes(Function<ItemStack, Collection<ItemStack>> fn) {
@@ -168,18 +156,6 @@ public class ItemBuilder extends ModelledBuilderBase<Item> {
 	@Info("Sets the item's rarity.")
 	public ItemBuilder rarity(Rarity v) {
 		rarity = v;
-		return this;
-	}
-
-	@Info("Makes the item glow like enchanted, even if it's not enchanted.")
-	public ItemBuilder glow(boolean v) {
-		behavior.glow = v;
-		return this;
-	}
-
-	@Info("Adds a tooltip to the item.")
-	public ItemBuilder tooltip(Component text) {
-		behavior.tooltip.add(text);
 		return this;
 	}
 
@@ -205,30 +181,6 @@ public class ItemBuilder extends ModelledBuilderBase<Item> {
 		return this;
 	}
 
-	@Info("Determines the color of the item's durability bar. Defaulted to vanilla behavior.")
-	public ItemBuilder barColor(Function<ItemStack, KubeColor> barColor) {
-		behavior.barColor = barColor;
-		return this;
-	}
-
-	@Info("""
-		Determines the width of the item's durability bar. Defaulted to vanilla behavior.
-		
-		The function should return a value between 0 and 13 (max width of the bar).
-		""")
-	public ItemBuilder barWidth(ToIntFunction<ItemStack> barWidth) {
-		behavior.barWidth = barWidth;
-		return this;
-	}
-
-	@Info("""
-		Sets the item's name dynamically.
-		""")
-	public ItemBuilder name(NameCallback name) {
-		behavior.nameGetter = name;
-		return this;
-	}
-
 	@Info("""
 		Set the food properties of the item.
 		""")
@@ -238,6 +190,7 @@ public class ItemBuilder extends ModelledBuilderBase<Item> {
 		}
 
 		b.accept(foodBuilder);
+		foodEaten(foodBuilder.eaten);
 		return this;
 	}
 
@@ -259,65 +212,9 @@ public class ItemBuilder extends ModelledBuilderBase<Item> {
 		return fireResistant(true);
 	}
 
-	@Info("Determines the animation of the item when used, e.g. eating food.")
-	public ItemBuilder useAnimation(UseAnim animation) {
-		behavior.anim = animation;
-		return this;
-	}
-
-	@Info("""
-		The duration when the item is used.
-		
-		For example, when eating food, this is the time it takes to eat the food.
-		This can change the eating speed, or be used for other things (like making a custom bow).
-		""")
-	public ItemBuilder useDuration(ToIntBiFunction<ItemStack, LivingEntity> useDuration) {
-		behavior.useDuration = useDuration;
-		return this;
-	}
-
-	@Info("""
-		Determines if player will start using the item.
-		
-		For example, when eating food, returning true will make the player start eating the food.
-		""")
-	public ItemBuilder use(UseCallback use) {
-		behavior.use = use;
-		return this;
-	}
-
-	@Info("""
-		When players finish using the item.
-		
-		This is called only when `useDuration` ticks have passed.
-		
-		For example, when eating food, this is called when the player has finished eating the food, so hunger is restored.
-		""")
-	public ItemBuilder finishUsing(FinishUsingCallback finishUsing) {
-		behavior.finishUsing = finishUsing;
-		return this;
-	}
-
-	@Info("""
-		When players did not finish using the item but released the right mouse button halfway through.
-		
-		An example is the bow, where the arrow is shot when the player releases the right mouse button.
-		
-		To ensure the bow won't finish using, Minecraft sets the `useDuration` to a very high number (1h).
-		""")
-	public ItemBuilder releaseUsing(ReleaseUsingCallback releaseUsing) {
-		behavior.releaseUsing = releaseUsing;
-		return this;
-	}
-
-	@Info("""
-		Gets called when the item is used to hurt an entity.
-		
-		For example, when using a sword to hit a mob, this is called.
-		""")
-	public ItemBuilder hurtEnemy(Predicate<HurtEnemyContext> context) {
-		behavior.hurtEnemy = context;
-		return this;
+	@Override
+	public ItemBehavior kjs$getOrCreateBehavior() {
+		return behavior;
 	}
 
 	public ItemBuilder jukeboxPlayable(ResourceKey<JukeboxSong> song, boolean showInTooltip) {
@@ -332,26 +229,6 @@ public class ItemBuilder extends ModelledBuilderBase<Item> {
 	public ItemBuilder disableRepair() {
 		this.canRepair = false;
 		return this;
-	}
-
-	@FunctionalInterface
-	public interface UseCallback {
-		boolean use(Level level, Player player, InteractionHand interactionHand);
-	}
-
-	@FunctionalInterface
-	public interface FinishUsingCallback {
-		ItemStack finishUsingItem(ItemStack itemStack, Level level, LivingEntity livingEntity);
-	}
-
-	@FunctionalInterface
-	public interface ReleaseUsingCallback {
-		void releaseUsing(ItemStack itemStack, Level level, LivingEntity user, int tick);
-	}
-
-	@FunctionalInterface
-	public interface NameCallback {
-		Component apply(ItemStack itemStack);
 	}
 
 	public Item.Properties createItemProperties() {

--- a/src/main/java/dev/latvian/mods/kubejs/item/ItemModificationKubeEvent.java
+++ b/src/main/java/dev/latvian/mods/kubejs/item/ItemModificationKubeEvent.java
@@ -3,6 +3,7 @@ package dev.latvian.mods.kubejs.item;
 import dev.latvian.mods.kubejs.color.KubeColor;
 import dev.latvian.mods.kubejs.component.ItemComponentFunctions;
 import dev.latvian.mods.kubejs.core.DiggerItemKJS;
+import dev.latvian.mods.kubejs.core.ItemKJS;
 import dev.latvian.mods.kubejs.event.KubeEvent;
 import dev.latvian.mods.kubejs.typings.Info;
 import dev.latvian.mods.kubejs.util.TickDuration;
@@ -12,7 +13,6 @@ import it.unimi.dsi.fastutil.objects.Reference2IntOpenHashMap;
 import net.minecraft.Util;
 import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.core.component.DataComponentType;
-import net.minecraft.core.component.DataComponents;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
@@ -38,7 +38,7 @@ import static net.minecraft.world.item.Item.BASE_ATTACK_DAMAGE_ID;
 public class ItemModificationKubeEvent implements KubeEvent {
 	@Info("""
 		Modifies items matching the given ingredient.
-		
+				
 		**NOTE**: tag ingredients are not supported at this time.
 		""")
 	public void modify(ItemPredicate in, Consumer<ItemModifications> c) {
@@ -46,7 +46,7 @@ public class ItemModificationKubeEvent implements KubeEvent {
 	}
 
 	@RemapPrefixForJS("kjs$")
-	public record ItemModifications(Item item) implements ItemComponentFunctions {
+	public record ItemModifications(Item item) implements ItemComponentFunctions, ItemBehaviorFunctions {
 		@HideFromJS
 		public static final Reference2IntOpenHashMap<Item> BURN_TIME_OVERRIDES = new Reference2IntOpenHashMap<>();
 
@@ -108,100 +108,14 @@ public class ItemModificationKubeEvent implements KubeEvent {
 			item.kjs$setCanRepair(false);
 		}
 
-		@Info("Makes the item glow like enchanted, even if it's not enchanted.")
-		public void glow(boolean v) {
-			getOrCreateBehavior().glow = v;
-		}
-
-		@Info("Adds a tooltip line to the item.")
-		public void tooltip(Component text) {
-			getOrCreateBehavior().tooltip.add(text);
-		}
-
-		@Info("Determines the color of the item's durability bar. Defaulted to vanilla behavior.")
-		public void barColor(Function<ItemStack, KubeColor> barColor) {
-			getOrCreateBehavior().barColor = barColor;
-		}
-
-		@Info("""
-			Determines the width of the item's durability bar. Defaulted to vanilla behavior.
-			
-			The function should return a value between 0 and 13 (max width of the bar).
-			""")
-		public void barWidth(ToIntFunction<ItemStack> barWidth) {
-			getOrCreateBehavior().barWidth = barWidth;
-		}
-
-		@Info("Sets the item's name dynamically.")
-		public void name(ItemBuilder.NameCallback nameGetter) {
-			getOrCreateBehavior().nameGetter = nameGetter;
-		}
-
-		@Info("Determines the animation of the item when used, e.g. eating food.")
-		public void useAnimation(UseAnim anim) {
-			getOrCreateBehavior().anim = anim;
-		}
-
-		@Info("""
-			The duration when the item is used.
-			
-			For example, when eating food, this is the time it takes to eat the food.
-			This can change the eating speed, or be used for other things (like making a custom bow).
-			""")
-		public void useDuration(ToIntBiFunction<ItemStack, LivingEntity> useDuration) {
-			getOrCreateBehavior().useDuration = useDuration;
-		}
-
-		@Info("""
-			Determines if the player will start using the item.
-			
-			For example, when eating food, returning true will make the player start eating the food.
-			""")
-		public void use(ItemBuilder.UseCallback use) {
-			getOrCreateBehavior().use = use;
-		}
-
-		@Info("""
-			Called when the player finishes using the item.
-			
-			This is called only when `useDuration` ticks have passed.
-			
-			For example, when eating food, this is called when the player has finished eating the food.
-			""")
-		public void finishUsing(ItemBuilder.FinishUsingCallback finishUsing) {
-			getOrCreateBehavior().finishUsing = finishUsing;
-		}
-
-		@Info("""
-			Called when the player released the right mouse button before finishing using the item.
-			
-			An example is the bow, where the arrow is shot when the player releases the right mouse button.
-			""")
-		public void releaseUsing(ItemBuilder.ReleaseUsingCallback releaseUsing) {
-			getOrCreateBehavior().releaseUsing = releaseUsing;
-		}
-
-		@Info("""
-			Called when the item is used to hurt an entity.
-			
-			For example, when using a sword to hit a mob, this is called.
-			""")
-		public void hurtEnemy(Predicate<ItemBuilder.HurtEnemyContext> hurtEnemy) {
-			getOrCreateBehavior().hurtEnemy = hurtEnemy;
-		}
-
-		@Info("Called when the player finishes eating food.")
-		public void foodEaten(Consumer<FoodEatenKubeEvent> foodEaten) {
-			getOrCreateBehavior().foodEaten = foodEaten;
-		}
-
-		private ItemBehavior getOrCreateBehavior() {
-			var b = item.kjs$getItemBehavior();
-			if (b == null) {
-				b = new ItemBehavior();
-				item.kjs$setItemBehavior(b);
+		@Override
+		public ItemBehavior kjs$getOrCreateBehavior() {
+			var behavior = item.kjs$getItemBehavior();
+			if (behavior == null) {
+				behavior = new ItemBehavior();
+				item.kjs$setItemBehavior(behavior);
 			}
-			return b;
+			return behavior;
 		}
 	}
 }

--- a/src/main/java/dev/latvian/mods/kubejs/item/ItemModificationKubeEvent.java
+++ b/src/main/java/dev/latvian/mods/kubejs/item/ItemModificationKubeEvent.java
@@ -1,5 +1,6 @@
 package dev.latvian.mods.kubejs.item;
 
+import dev.latvian.mods.kubejs.color.KubeColor;
 import dev.latvian.mods.kubejs.component.ItemComponentFunctions;
 import dev.latvian.mods.kubejs.core.DiggerItemKJS;
 import dev.latvian.mods.kubejs.event.KubeEvent;
@@ -12,14 +13,22 @@ import net.minecraft.Util;
 import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.core.component.DataComponentType;
 import net.minecraft.core.component.DataComponents;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TieredItem;
+import net.minecraft.world.item.UseAnim;
 import net.minecraft.world.item.component.ItemAttributeModifiers;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.ToIntBiFunction;
+import java.util.function.ToIntFunction;
 
 import static net.minecraft.world.item.Item.BASE_ATTACK_DAMAGE_ID;
 
@@ -97,6 +106,102 @@ public class ItemModificationKubeEvent implements KubeEvent {
 
 		public void disableRepair() {
 			item.kjs$setCanRepair(false);
+		}
+
+		@Info("Makes the item glow like enchanted, even if it's not enchanted.")
+		public void glow(boolean v) {
+			getOrCreateBehavior().glow = v;
+		}
+
+		@Info("Adds a tooltip line to the item.")
+		public void tooltip(Component text) {
+			getOrCreateBehavior().tooltip.add(text);
+		}
+
+		@Info("Determines the color of the item's durability bar. Defaulted to vanilla behavior.")
+		public void barColor(Function<ItemStack, KubeColor> barColor) {
+			getOrCreateBehavior().barColor = barColor;
+		}
+
+		@Info("""
+			Determines the width of the item's durability bar. Defaulted to vanilla behavior.
+			
+			The function should return a value between 0 and 13 (max width of the bar).
+			""")
+		public void barWidth(ToIntFunction<ItemStack> barWidth) {
+			getOrCreateBehavior().barWidth = barWidth;
+		}
+
+		@Info("Sets the item's name dynamically.")
+		public void name(ItemBuilder.NameCallback nameGetter) {
+			getOrCreateBehavior().nameGetter = nameGetter;
+		}
+
+		@Info("Determines the animation of the item when used, e.g. eating food.")
+		public void useAnimation(UseAnim anim) {
+			getOrCreateBehavior().anim = anim;
+		}
+
+		@Info("""
+			The duration when the item is used.
+			
+			For example, when eating food, this is the time it takes to eat the food.
+			This can change the eating speed, or be used for other things (like making a custom bow).
+			""")
+		public void useDuration(ToIntBiFunction<ItemStack, LivingEntity> useDuration) {
+			getOrCreateBehavior().useDuration = useDuration;
+		}
+
+		@Info("""
+			Determines if the player will start using the item.
+			
+			For example, when eating food, returning true will make the player start eating the food.
+			""")
+		public void use(ItemBuilder.UseCallback use) {
+			getOrCreateBehavior().use = use;
+		}
+
+		@Info("""
+			Called when the player finishes using the item.
+			
+			This is called only when `useDuration` ticks have passed.
+			
+			For example, when eating food, this is called when the player has finished eating the food.
+			""")
+		public void finishUsing(ItemBuilder.FinishUsingCallback finishUsing) {
+			getOrCreateBehavior().finishUsing = finishUsing;
+		}
+
+		@Info("""
+			Called when the player released the right mouse button before finishing using the item.
+			
+			An example is the bow, where the arrow is shot when the player releases the right mouse button.
+			""")
+		public void releaseUsing(ItemBuilder.ReleaseUsingCallback releaseUsing) {
+			getOrCreateBehavior().releaseUsing = releaseUsing;
+		}
+
+		@Info("""
+			Called when the item is used to hurt an entity.
+			
+			For example, when using a sword to hit a mob, this is called.
+			""")
+		public void hurtEnemy(Predicate<ItemBuilder.HurtEnemyContext> hurtEnemy) {
+			getOrCreateBehavior().hurtEnemy = hurtEnemy;
+		}
+
+		@Info("Called when the player finishes eating food.")
+		public void foodEaten(Consumer<FoodEatenKubeEvent> foodEaten) {
+			getOrCreateBehavior().foodEaten = foodEaten;
+		}
+
+		private ItemBehavior getOrCreateBehavior() {
+			var b = item.kjs$getItemBehavior();
+			if (b == null) {
+				b = new ItemBehavior();
+				item.kjs$setItemBehavior(b);
+			}
+			return b;
 		}
 	}
 }

--- a/src/main/resources/kubejs.mixins.json
+++ b/src/main/resources/kubejs.mixins.json
@@ -37,6 +37,7 @@
 		"HolderMixin",
 		"IBlockStateExtensionMixin",
 		"ICustomIngredientMixin",
+		"IItemExtensionMixin",
 		"IItemHandlerMixin",
 		"IngredientMixin",
 		"IntersectionIngredientMixin",


### PR DESCRIPTION
<!-- These comments won't appear in the final PR, so you can just leave them here -->

### Description <!-- A brief description of the bug this fixes, the feature this adds, or provide a link to the issue this closes -->

Separated the callbacks from `ItemBuilder` as a standalone class `ItemBehavior`, which allows the `ItemModificationKubeEvent` to modify the item's behavior (not registered by KubeJS) via the `ItemMixin`.

Also, since KubeJS has only supported Neoforge for quite some time, many methods from `IItemExtension` were patched by mixin to further extend the modifications of item behavior.

#### Example Script <!-- Please provide an example script showing that the bug is fixed, or how the feature is used, if applicable -->

Modifies the diamond boot to make players walk on snow while wearing it.
```js
// startup_script
ItemEvents.modification(event => {
    event.modify('minecraft:diamond_boots', item => {
        item.canWalkOnPowderedSnow(true)
    })
})
```

<img width="323" height="304" alt="image" src="https://github.com/user-attachments/assets/7eed4637-3d79-47eb-b9cc-c2445f4b1741" />


#### Other details <!-- Any other important information, like if this is likely to break addons -->

- The `IItemExtensionMixin` has a priority of `999`, so it applies earlier than defaults, while `1001` applies later than defaults. There are a few mods that share the same inject point, so using `1001` will prevent the mixin from working.
