### PR TITLE
Update Neo to first stable version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,8 +13,8 @@ modrinth_id=umyGl7zF
 minecraft_version=26.1.2
 supported_versions=26.1.2
 
-neoforgeVersion=26.1.2.29-beta
-neoforgeVersions=[26.1.2.29-beta,)
+neoforgeVersion=26.1.2.71
+neoforgeVersions=[26.1.2.71,)
 rhinoVersion=2101.2.7-build.81
 tinyServerVersion=1.0.0-build.45
 gifLibVersion=1.7


### PR DESCRIPTION
NeoForge has announced that NF version `26.1.2.71` is the first stable version, so update to that