### PR TITLE
Update NeoForge to a stable version and fix breaking change

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,8 +13,8 @@ modrinth_id=umyGl7zF
 minecraft_version=26.1.2
 supported_versions=26.1.2
 
-neoforgeVersion=26.1.2.29-beta
-neoforgeVersions=[26.1.2.29-beta,)
+neoforgeVersion=26.1.2.71
+neoforgeVersions=[26.1.2.71,)
 rhinoVersion=2101.2.7-build.81
 tinyServerVersion=1.0.0-build.45
 gifLibVersion=1.7

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/dev/latvian/mods/kubejs/entity/AfterLivingEntityHurtKubeEvent.java
+++ b/src/main/java/dev/latvian/mods/kubejs/entity/AfterLivingEntityHurtKubeEvent.java
@@ -28,6 +28,6 @@ public class AfterLivingEntityHurtKubeEvent implements KubeLivingEntityEvent {
 
 	@Info("The amount of damage.")
 	public float getDamage() {
-		return event.getNewDamage();
+		return event.getHealthDamage();
 	}
 }


### PR DESCRIPTION
In Neoforge version `26.1.2.71`, which is now the first stable version, a breaking change was introduced to `LivingDamageEvent` (https://github.com/neoforged/NeoForge/pull/3101). 

This PR updates Neo to the stable version and fixes the breaking change