### PR TITLE
Fix BlockItemBuilder translation key resolution/duplicate key

### DIFF
--- a/src/main/java/dev/latvian/mods/kubejs/block/BlockItemBuilder.java
+++ b/src/main/java/dev/latvian/mods/kubejs/block/BlockItemBuilder.java
@@ -1,5 +1,6 @@
 package dev.latvian.mods.kubejs.block;
 
+import dev.latvian.mods.kubejs.client.LangKubeEvent;
 import dev.latvian.mods.kubejs.generator.KubeAssetGenerator;
 import dev.latvian.mods.kubejs.item.ItemBuilder;
 import net.minecraft.resources.Identifier;
@@ -16,7 +17,10 @@ public class BlockItemBuilder extends ItemBuilder {
 
 	@Override
 	public Item createObject() {
-		return new BlockItem(blockBuilder.get(), createItemProperties());
+		return new BlockItem(blockBuilder.get(),
+			createItemProperties()
+				.overrideDescription(blockBuilder.getBuilderTranslationKey())
+		);
 	}
 
 	@Override
@@ -26,5 +30,13 @@ public class BlockItemBuilder extends ItemBuilder {
 
 	@Override
 	public void generateAssets(KubeAssetGenerator generator) {
+	}
+
+	@Override
+	public void generateLang(LangKubeEvent lang) {
+		// To allow subclasses like SeedItemBuilder to still generate normally
+		if (getClass() != BlockItemBuilder.class) {
+			super.generateLang(lang);
+		}
 	}
 }


### PR DESCRIPTION
This fix sets block item properties to resolve to `block.modid.id` instead of `item.modid.id` by setting the item description to the block builder's translation key. This also fixes the very niche edge case of a generic BlockItem key being generated while an Item key is already being created, resulting in a duplicate key that overwrites the previous key in `LangKubeEvent#add`.