### PR TITLE
Fix `Client` binding not being available from startup/client scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Readd error handling during the recipe event (#1142)
 - Fix BlockItemBuilder translation key resolution/duplicate key (#1143)
 - Reimplement basic JEI integration. EMI and REI at the time of writing are not released for 26.1 yet and will follow later.
+- Fix `Client` binding not being available from startup/client scripts (#1145)
 
 ## [8.0.1] - 2026-06-08
 

--- a/src/main/java/dev/latvian/mods/kubejs/block/BlockItemBuilder.java
+++ b/src/main/java/dev/latvian/mods/kubejs/block/BlockItemBuilder.java
@@ -1,5 +1,6 @@
 package dev.latvian.mods.kubejs.block;
 
+import dev.latvian.mods.kubejs.client.LangKubeEvent;
 import dev.latvian.mods.kubejs.generator.KubeAssetGenerator;
 import dev.latvian.mods.kubejs.item.ItemBuilder;
 import net.minecraft.resources.Identifier;
@@ -16,7 +17,10 @@ public class BlockItemBuilder extends ItemBuilder {
 
 	@Override
 	public Item createObject() {
-		return new BlockItem(blockBuilder.get(), createItemProperties());
+		return new BlockItem(blockBuilder.get(),
+			createItemProperties()
+				.overrideDescription(blockBuilder.getBuilderTranslationKey())
+		);
 	}
 
 	@Override
@@ -26,5 +30,13 @@ public class BlockItemBuilder extends ItemBuilder {
 
 	@Override
 	public void generateAssets(KubeAssetGenerator generator) {
+	}
+
+	@Override
+	public void generateLang(LangKubeEvent lang) {
+		// To allow subclasses like SeedItemBuilder to still generate normally
+		if (getClass() != BlockItemBuilder.class) {
+			super.generateLang(lang);
+		}
 	}
 }

--- a/src/main/java/dev/latvian/mods/kubejs/client/KubeJSClientEventHandler.java
+++ b/src/main/java/dev/latvian/mods/kubejs/client/KubeJSClientEventHandler.java
@@ -97,6 +97,9 @@ public class KubeJSClientEventHandler {
 	}
 
 	private static void setupClient0() {
+		KubeJS.getStartupScriptManager().addClientRuntimeBindings();
+		KubeJS.getClientScriptManager().addClientRuntimeBindings();
+
 		if (!PlatformWrapper.isGeneratingData() && Minecraft.getInstance() != null && WebServerProperties.get().enabled) {
 			LocalWebServer.start(Minecraft.getInstance(), true);
 		}

--- a/src/main/java/dev/latvian/mods/kubejs/plugin/KubeJSPlugin.java
+++ b/src/main/java/dev/latvian/mods/kubejs/plugin/KubeJSPlugin.java
@@ -93,6 +93,12 @@ public interface KubeJSPlugin {
 	default void registerBindings(BindingRegistry bindings) {
 	}
 
+	/// Add client runtime bindings that require Minecraft's physical client instance to exist.
+	/// Use this for client objects, such as font, screen, or window instance,
+	/// that are null during mod loading and [#registerBindings] execution.
+	default void registerClientRuntimeBindings(BindingRegistry bindings) {
+	}
+
 	/// Register JS-to-Java type wrappers so Rhino can automatically convert script values
 	/// (e.g. a string `"minecraft:stone"`) into the expected Java type (e.g. a [Block]).
 	default void registerTypeWrappers(TypeWrapperRegistry registry) {

--- a/src/main/java/dev/latvian/mods/kubejs/plugin/builtin/BuiltinKubeJSClientPlugin.java
+++ b/src/main/java/dev/latvian/mods/kubejs/plugin/builtin/BuiltinKubeJSClientPlugin.java
@@ -29,10 +29,6 @@ public class BuiltinKubeJSClientPlugin implements KubeJSPlugin {
 
 	@Override
 	public void registerBindings(BindingRegistry bindings) {
-		var mc = Minecraft.getInstance();
-
-		bindings.add("Client", mc);
-
 		if (bindings.type().isClient()) {
 			var se = ScheduledClientEvent.EVENTS;
 			bindings.add("setTimeout", new ScheduledEvents.TimeoutJSFunction(se, false, false));
@@ -41,6 +37,11 @@ public class BuiltinKubeJSClientPlugin implements KubeJSPlugin {
 			bindings.add("clearInterval", new ScheduledEvents.TimeoutJSFunction(se, true, true));
 		}
 		bindings.add("GLFWInput", GLFWInputWrapper.MAP.get());
+	}
+
+	@Override
+	public void registerClientRuntimeBindings(BindingRegistry bindings) {
+		bindings.add("Client", Minecraft.getInstance());
 	}
 
 	@Override

--- a/src/main/java/dev/latvian/mods/kubejs/script/ScriptManager.java
+++ b/src/main/java/dev/latvian/mods/kubejs/script/ScriptManager.java
@@ -83,6 +83,17 @@ public class ScriptManager {
 		KubeJSPlugins.forEachPlugin(this, KubeJSPlugin::afterScriptsLoaded);
 	}
 
+	public void addClientRuntimeBindings() {
+		if (contextFactory != null) {
+			var cx = (KubeJSContext) contextFactory.enter();
+			var bindings = new BindingRegistry(cx, cx.topLevelScope);
+
+			for (var plugin : KubeJSPlugins.getAll()) {
+				plugin.registerClientRuntimeBindings(bindings);
+			}
+		}
+	}
+
 	public void collectScripts(ScriptPack pack, Path dir, String path) {
 		if (!path.isEmpty() && !path.endsWith("/")) {
 			path += "/";


### PR DESCRIPTION
This adds a new `KubeJSPlugin` override for registering client runtime variables that rely on `Minecraft#getInstance` being initialized. This lets addon makers register client-side instance bindings without implementing their own lifecycle workaround; they can override `registerClientRuntimeBindings` in their plugin class, which is called from `KubeJSClientEventHandler#setupClient0` after Minecraft instance exists and before KubeJS client events are posted.
This restores the binding of `Client` for startup/client context and retains the ability to bind client instanced aliases if an addon modder so desires.