### PR TITLE
Fix ConsoleJS and ScriptType initialization cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # changelog
 
 ## Unreleased
+
 - Fix `Client` binding not being available from startup/client scripts (#1145)
+- Fixed circular initialization between ConsoleJS and ScriptType before script consoles are ready (#1147)
 
 ## [8.0.2] - 2026-06-12
 

--- a/src/main/java/dev/latvian/mods/kubejs/KubeJS.java
+++ b/src/main/java/dev/latvian/mods/kubejs/KubeJS.java
@@ -15,7 +15,6 @@ import dev.latvian.mods.kubejs.plugin.KubeJSPlugins;
 import dev.latvian.mods.kubejs.plugin.builtin.event.StartupEvents;
 import dev.latvian.mods.kubejs.recipe.KubeJSRecipeSerializers;
 import dev.latvian.mods.kubejs.registry.RegistryType;
-import dev.latvian.mods.kubejs.script.ConsoleJS;
 import dev.latvian.mods.kubejs.script.KubeJSBackgroundThread;
 import dev.latvian.mods.kubejs.script.PlatformWrapper;
 import dev.latvian.mods.kubejs.script.ScriptManager;
@@ -109,8 +108,8 @@ public class KubeJS {
 
 		if (!datagen) {
 			new KubeJSBackgroundThread().start();
-			ConsoleJS.STARTUP.startCapturingErrors();
-			ConsoleJS.CLIENT.startCapturingErrors();
+			ScriptType.STARTUP.console.startCapturingErrors();
+			ScriptType.CLIENT.console.startCapturingErrors();
 		}
 
 		LOGGER.info("Loading vanilla registries...");

--- a/src/main/java/dev/latvian/mods/kubejs/script/ConsoleJS.java
+++ b/src/main/java/dev/latvian/mods/kubejs/script/ConsoleJS.java
@@ -68,9 +68,9 @@ import java.util.stream.Collectors;
 /// @see JavaWrapper#createConsole(KubeJSContext, String)
 @NullUnmarked
 public class ConsoleJS {
-	public static final ConsoleJS STARTUP = ScriptType.STARTUP.console;
-	public static final ConsoleJS SERVER = ScriptType.SERVER.console;
-	public static final ConsoleJS CLIENT = ScriptType.CLIENT.console;
+	public static ConsoleJS STARTUP;
+	public static ConsoleJS SERVER;
+	public static ConsoleJS CLIENT;
 
 	public static ConsoleJS getCurrent(@Nullable Context cx) {
 		if (cx instanceof KubeJSContext kcx) {

--- a/src/main/java/dev/latvian/mods/kubejs/script/ScriptType.java
+++ b/src/main/java/dev/latvian/mods/kubejs/script/ScriptType.java
@@ -32,6 +32,12 @@ public enum ScriptType implements ScriptTypePredicate, ScriptTypeHolder {
 	SERVER("server", "KubeJS Server", KubeJSPaths.SERVER_SCRIPTS),
 	CLIENT("client", "KubeJS Client", KubeJSPaths.CLIENT_SCRIPTS);
 
+	static {
+		ConsoleJS.STARTUP = STARTUP.console;
+		ConsoleJS.SERVER = SERVER.console;
+		ConsoleJS.CLIENT = CLIENT.console;
+	}
+
 	public static final ScriptType[] VALUES = values();
 
 	public final String name;


### PR DESCRIPTION
This fixes a circular initialization bug between `ConsoleJS` and `ScriptType` before script consoles are ready. Minimal reproduction of this bug would be registering a KubeJS event group with `EventGroup.server()`, which initializes `ScriptType` while `ConsoleJS` is still constructing its instances, causing a startup crash.