### PR TITLE
Convert EntityArrayList to have a type that extends Entity

### DIFF
--- a/src/main/java/dev/latvian/mods/kubejs/core/EntityCollectionKJS.java
+++ b/src/main/java/dev/latvian/mods/kubejs/core/EntityCollectionKJS.java
@@ -27,20 +27,20 @@ public interface EntityCollectionKJS {
 		return list;
 	}
 
-	default EntityArrayList kjs$getPlayers() {
-		return new EntityArrayList(kjs$getMcPlayers());
+	default EntityArrayList<? extends Player> kjs$getPlayers() {
+		return new EntityArrayList<>(kjs$getMcPlayers());
 	}
 
-	default EntityArrayList kjs$getEntities() {
-		return new EntityArrayList(kjs$getMcEntities());
+	default EntityArrayList<? extends Entity> kjs$getEntities() {
+		return new EntityArrayList<>(kjs$getMcEntities());
 	}
 
-	default EntityArrayList kjs$getEntitiesWithin(AABB aabb) {
+	default EntityArrayList<? extends Entity> kjs$getEntitiesWithin(AABB aabb) {
 		if (aabb == null || aabb == AABB.INFINITE) {
 			return kjs$getEntities();
 		}
 
-		var list = new EntityArrayList(10);
+		var list = new EntityArrayList<>(10);
 
 		for (var entity : kjs$getMcEntities()) {
 			if (entity.getBoundingBox().intersects(aabb)) {

--- a/src/main/java/dev/latvian/mods/kubejs/core/EntityGetterKJS.java
+++ b/src/main/java/dev/latvian/mods/kubejs/core/EntityGetterKJS.java
@@ -21,8 +21,8 @@ public interface EntityGetterKJS extends EntityCollectionKJS {
 	}
 
 	@Override
-	default EntityArrayList kjs$getPlayers() {
-		return new EntityArrayList(kjs$self().players());
+	default EntityArrayList<? extends Player> kjs$getPlayers() {
+		return new EntityArrayList<>(kjs$self().players());
 	}
 
 	@Override
@@ -31,7 +31,7 @@ public interface EntityGetterKJS extends EntityCollectionKJS {
 	}
 
 	@Override
-	default EntityArrayList kjs$getEntitiesWithin(AABB aabb) {
-		return new EntityArrayList(kjs$self().getEntities(null, aabb));
+	default EntityArrayList<? extends Entity> kjs$getEntitiesWithin(AABB aabb) {
+		return new EntityArrayList<>(kjs$self().getEntities(null, aabb));
 	}
 }

--- a/src/main/java/dev/latvian/mods/kubejs/core/EntityKJS.java
+++ b/src/main/java/dev/latvian/mods/kubejs/core/EntityKJS.java
@@ -341,8 +341,8 @@ public interface EntityKJS extends WithPersistentData, MessageSenderKJS, ScriptT
 	}
 
 	@Info("Gets a list of all passengers of the entity.")
-	default EntityArrayList kjs$getPassengers() {
-		return new EntityArrayList(kjs$self().getPassengers());
+	default EntityArrayList<? extends Entity> kjs$getPassengers() {
+		return new EntityArrayList<>(kjs$self().getPassengers());
 	}
 
 	@Deprecated

--- a/src/main/java/dev/latvian/mods/kubejs/core/EntityKJS.java
+++ b/src/main/java/dev/latvian/mods/kubejs/core/EntityKJS.java
@@ -526,7 +526,7 @@ public interface EntityKJS extends WithPersistentData, MessageSenderKJS, ScriptT
 	}
 
 	@Nullable
-	default Entity kjs$rayTraceEntity(double distance, @Nullable Predicate<Entity> filter) {
+	default Entity kjs$rayTraceEntity(double distance, @Nullable Predicate<? super Entity> filter) {
 		double d0 = Double.MAX_VALUE;
 		Entity entity = null;
 

--- a/src/main/java/dev/latvian/mods/kubejs/core/MinecraftServerKJS.java
+++ b/src/main/java/dev/latvian/mods/kubejs/core/MinecraftServerKJS.java
@@ -119,8 +119,8 @@ public interface MinecraftServerKJS extends WithAttachedData<MinecraftServer>, W
 	}
 
 	@Override
-	default EntityArrayList kjs$getPlayers() {
-		return new EntityArrayList(kjs$self().getPlayerList().getPlayers());
+	default EntityArrayList<ServerPlayer> kjs$getPlayers() {
+		return new EntityArrayList<>(kjs$self().getPlayerList().getPlayers());
 	}
 
 	@Override

--- a/src/main/java/dev/latvian/mods/kubejs/level/ExplosionKubeEvent.java
+++ b/src/main/java/dev/latvian/mods/kubejs/level/ExplosionKubeEvent.java
@@ -83,8 +83,8 @@ public abstract class ExplosionKubeEvent implements KubeLevelEvent {
 		}
 
 		@Info("Gets a list of all entities affected by the explosion.")
-		public EntityArrayList getAffectedEntities() {
-			return new EntityArrayList(affectedEntities);
+		public EntityArrayList<? extends Entity> getAffectedEntities() {
+			return new EntityArrayList<>(affectedEntities);
 		}
 
 		@Info("Remove an entity from the list of affected entities.")

--- a/src/main/java/dev/latvian/mods/kubejs/level/LevelBlock.java
+++ b/src/main/java/dev/latvian/mods/kubejs/level/LevelBlock.java
@@ -330,8 +330,8 @@ public interface LevelBlock extends BlockProviderKJS {
 		Block.popResourceFromFace(getLevel(), getPos(), dir, item);
 	}
 
-	default EntityArrayList getPlayersInRadius(double radius) {
-		var list = new EntityArrayList(1);
+	default EntityArrayList<? extends Player> getPlayersInRadius(double radius) {
+		var list = new EntityArrayList<Player>(1);
 
 		double cx = getCenterX();
 		double cy = getCenterY();
@@ -346,7 +346,7 @@ public interface LevelBlock extends BlockProviderKJS {
 		return list;
 	}
 
-	default EntityArrayList getPlayersInRadius() {
+	default EntityArrayList<? extends Player> getPlayersInRadius() {
 		return getPlayersInRadius(8D);
 	}
 

--- a/src/main/java/dev/latvian/mods/kubejs/player/EntityArrayList.java
+++ b/src/main/java/dev/latvian/mods/kubejs/player/EntityArrayList.java
@@ -126,7 +126,7 @@ public class EntityArrayList<T extends Entity> extends ArrayList<T> implements M
 		@Param(name = "filter", value = "The predicate - a function that takes an argument of `Entity` and returns a boolean.")
 	})
 	// FIXME: Inaccessible from JS due to order of operations in Rhino, this method is used by other filter methods
-	public EntityArrayList<T> filter(Predicate<Entity> filter) {
+	public EntityArrayList<T> filter(Predicate<? super Entity> filter) {
 		if (isEmpty()) {
 			return this;
 		}
@@ -148,7 +148,7 @@ public class EntityArrayList<T extends Entity> extends ArrayList<T> implements M
 		""", params = {
 		@Param(name = "filterList", value = "The list of predicates - functions that take one argument of `Entity` and return boolean values.")
 	})
-	public EntityArrayList<T> filterList(List<Predicate<Entity>> filterList) {
+	public EntityArrayList<T> filterList(List<? extends Predicate<Entity>> filterList) {
 		if (isEmpty() || filterList.isEmpty()) {
 			return this;
 		}

--- a/src/main/java/dev/latvian/mods/kubejs/player/EntityArrayList.java
+++ b/src/main/java/dev/latvian/mods/kubejs/player/EntityArrayList.java
@@ -24,20 +24,20 @@ import java.util.List;
 import java.util.function.Predicate;
 
 @RemapPrefixForJS("kjs$")
-public class EntityArrayList extends ArrayList<Entity> implements MessageSenderKJS, DataSenderKJS {
-	public static final Predicate<Entity> ALWAYS_TRUE_PREDICATE = entity -> true;
+public class EntityArrayList<T extends Entity> extends ArrayList<T> implements MessageSenderKJS, DataSenderKJS {
+	public static final Predicate<Entity> ALWAYS_TRUE_PREDICATE = _ -> true;
 
 	public EntityArrayList(int size) {
 		super(size);
 	}
 
-	public EntityArrayList(Iterable<? extends Entity> entities) {
-		this(entities instanceof Collection c ? c.size() : 4);
+	public EntityArrayList(Iterable<T> entities) {
+		this(entities instanceof Collection<T> c ? c.size() : 4);
 		addAllIterable(entities);
 	}
 
-	public void addAllIterable(Iterable<? extends Entity> entities) {
-		if (entities instanceof Collection c) {
+	public void addAllIterable(Iterable<T> entities) {
+		if (entities instanceof Collection<T> c) {
 			addAll(c);
 		} else {
 			for (var entity : entities) {
@@ -126,12 +126,12 @@ public class EntityArrayList extends ArrayList<Entity> implements MessageSenderK
 		@Param(name = "filter", value = "The predicate - a function that takes an argument of `Entity` and returns a boolean.")
 	})
 	// FIXME: Inaccessible from JS due to order of operations in Rhino, this method is used by other filter methods
-	public EntityArrayList filter(Predicate<Entity> filter) {
+	public EntityArrayList<T> filter(Predicate<Entity> filter) {
 		if (isEmpty()) {
 			return this;
 		}
 
-		var list = new EntityArrayList(size() / 4);
+		var list = new EntityArrayList<T>(size() / 4);
 
 		for (var entity : this) {
 			if (filter.test(entity)) {
@@ -148,12 +148,12 @@ public class EntityArrayList extends ArrayList<Entity> implements MessageSenderK
 		""", params = {
 		@Param(name = "filterList", value = "The list of predicates - functions that take one argument of `Entity` and return boolean values.")
 	})
-	public EntityArrayList filterList(List<Predicate<Entity>> filterList) {
+	public EntityArrayList<T> filterList(List<Predicate<Entity>> filterList) {
 		if (isEmpty() || filterList.isEmpty()) {
 			return this;
 		}
 
-		var list = new EntityArrayList(size());
+		var list = new EntityArrayList<T>(size());
 
 		for (var entity : this) {
 			for (var filter : filterList) {
@@ -169,7 +169,7 @@ public class EntityArrayList extends ArrayList<Entity> implements MessageSenderK
 	@Info(value = "Filters the entity list based on the provided `EntitySelector`.", params = {
 		@Param(name = "selector", value = "The entity selector. It may be a string representing the entity selector as seen in commands, such as `'@e[distance=..25]'`")
 	})
-	public EntityArrayList filterSelector(EntitySelector selector) {
+	public EntityArrayList<T> filterSelector(EntitySelector selector) {
 		return filterList(selector.contextFreePredicates);
 	}
 
@@ -182,8 +182,8 @@ public class EntityArrayList extends ArrayList<Entity> implements MessageSenderK
 		@Param(name = "z", value = "The `z` coordinate of the point."),
 		@Param(name = "distance", value = "The maximum distance of entities from the point.")
 	})
-	public EntityArrayList filterDistance(double x, double y, double z, double distance) {
-		var list = new EntityArrayList(size());
+	public EntityArrayList<T> filterDistance(double x, double y, double z, double distance) {
+		var list = new EntityArrayList<T>(size());
 
 		for (var entity : this) {
 			if (entity.distanceToSqr(x, y, z) <= distance * distance) {
@@ -201,24 +201,24 @@ public class EntityArrayList extends ArrayList<Entity> implements MessageSenderK
 		@Param(name = "pos", value = "The `BlockPos` - that is the center of the block at specified position. It can be a 3-element array of integers, such as `[64, 25, 39]`."),
 		@Param(name = "distance", value = "The maximum distance of entities from the point.")
 	})
-	public EntityArrayList filterDistance(BlockPos pos, double distance) {
+	public EntityArrayList<T> filterDistance(BlockPos pos, double distance) {
 		return filterDistance(pos.getX() + 0.5D, pos.getY() + 0.5D, pos.getZ() + 0.5D, distance);
 	}
 
 	@Info("Results in an entity list containing only players.")
-	public EntityArrayList filterPlayers() {
+	public EntityArrayList<T> filterPlayers() {
 		return filter(e -> e instanceof Player);
 	}
 
 	@Info("Results in an entity list containing only item entities.")
-	public EntityArrayList filterItems() {
+	public EntityArrayList<T> filterItems() {
 		return filter(e -> e instanceof ItemEntity);
 	}
 
 	@Info(value = "Filters the entity list based on the type of the entity. Only entities whose type is equal to the provided one will end up in the resulting list.", params = {
 		@Param(name = "type", value = "The entity type. It may be a string representing an entity ID, like `'minecraft:creeper'`.")
 	})
-	public EntityArrayList filterType(EntityType<?> type) {
+	public EntityArrayList<T> filterType(EntityType<?> type) {
 		return filter(e -> e.getType() == type);
 	}
 
@@ -239,9 +239,8 @@ public class EntityArrayList extends ArrayList<Entity> implements MessageSenderK
 	}
 
 	@Override
-	@Nullable
 	@Info("Gets the first entity on the list, or `null` if the list is empty.")
-	public Entity getFirst() {
+	public @Nullable T getFirst() {
 		return isEmpty() ? null : get(0);
 	}
 }


### PR DESCRIPTION
As @KonSola5 has pointed out, `EntityArrayList` should be `EntityArrayList<T extends Entity>` due to the loss of classes that extend `Entity` and lose precision on what is exactly contained within the list (before, `Player` would convert to the basic `Entity` for example).

This PR changes `EntityArrayList` to have a type, fixing that issue.