### PR TITLE
Fix creative tab modification not firing correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix `Client` binding not being available from startup/client scripts (#1145)
 - Fixed circular initialization between ConsoleJS and ScriptType before script consoles are ready (#1147)
+- Fixed creative tab modification not firing correctly (#1149)
 
 ## [8.0.2] - 2026-06-12
 

--- a/src/main/java/dev/latvian/mods/kubejs/KubeJSModEventHandler.java
+++ b/src/main/java/dev/latvian/mods/kubejs/KubeJSModEventHandler.java
@@ -62,7 +62,7 @@ public class KubeJSModEventHandler {
 
 	@SubscribeEvent(priority = EventPriority.LOW)
 	public static void creativeTab(BuildCreativeModeTabContentsEvent event) {
-		var tabId = event.getTabKey().registry();
+		var tabId = event.getTabKey().identifier();
 
 		if (StartupEvents.MODIFY_CREATIVE_TAB.hasListeners(tabId)) {
 			StartupEvents.MODIFY_CREATIVE_TAB.post(ScriptType.STARTUP, tabId, new CreativeTabKubeEvent(event.getTab(), event.hasPermissions(), new CreativeTabCallbackForge(event)));


### PR DESCRIPTION
This fixes the bug encountered in #1146 

Using `event.getTabKey().registry();` defaults to `minecraft:creative_mode_tab`, therefore attempting to modify a specific tab (like `minecraft:building_blocks`) would not be correctly fired. 

This PR fixes that issue by changing it from `.registry()` to `.identifier()`

