### PR TITLE
Better fix for Client binding timing bug via Lazy init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Fix `Client` binding not being available from startup/client scripts (#1145)
+- Fix `Client` binding not being available from startup/client scripts (#1152)
 - Fixed circular initialization between ConsoleJS and ScriptType before script consoles are ready (#1147)
 
 ## [8.0.2] - 2026-06-12

--- a/src/main/java/dev/latvian/mods/kubejs/client/KubeJSClientEventHandler.java
+++ b/src/main/java/dev/latvian/mods/kubejs/client/KubeJSClientEventHandler.java
@@ -97,9 +97,6 @@ public class KubeJSClientEventHandler {
 	}
 
 	private static void setupClient0() {
-		KubeJS.getStartupScriptManager().addClientRuntimeBindings();
-		KubeJS.getClientScriptManager().addClientRuntimeBindings();
-
 		if (!PlatformWrapper.isGeneratingData() && Minecraft.getInstance() != null && WebServerProperties.get().enabled) {
 			LocalWebServer.start(Minecraft.getInstance(), true);
 		}

--- a/src/main/java/dev/latvian/mods/kubejs/plugin/KubeJSPlugin.java
+++ b/src/main/java/dev/latvian/mods/kubejs/plugin/KubeJSPlugin.java
@@ -93,12 +93,6 @@ public interface KubeJSPlugin {
 	default void registerBindings(BindingRegistry bindings) {
 	}
 
-	/// Add client runtime bindings that require Minecraft's physical client instance to exist.
-	/// Use this for client objects, such as font, screen, or window instance,
-	/// that are null during mod loading and [#registerBindings] execution.
-	default void registerClientRuntimeBindings(BindingRegistry bindings) {
-	}
-
 	/// Register JS-to-Java type wrappers so Rhino can automatically convert script values
 	/// (e.g. a string `"minecraft:stone"`) into the expected Java type (e.g. a [Block]).
 	default void registerTypeWrappers(TypeWrapperRegistry registry) {

--- a/src/main/java/dev/latvian/mods/kubejs/plugin/builtin/BuiltinKubeJSClientPlugin.java
+++ b/src/main/java/dev/latvian/mods/kubejs/plugin/builtin/BuiltinKubeJSClientPlugin.java
@@ -29,6 +29,10 @@ public class BuiltinKubeJSClientPlugin implements KubeJSPlugin {
 
 	@Override
 	public void registerBindings(BindingRegistry bindings) {
+		if (bindings.type().isStartup() || bindings.type().isClient()) {
+			bindings.addLazy("Client", Minecraft::getInstance);
+		}
+
 		if (bindings.type().isClient()) {
 			var se = ScheduledClientEvent.EVENTS;
 			bindings.add("setTimeout", new ScheduledEvents.TimeoutJSFunction(se, false, false));
@@ -37,11 +41,6 @@ public class BuiltinKubeJSClientPlugin implements KubeJSPlugin {
 			bindings.add("clearInterval", new ScheduledEvents.TimeoutJSFunction(se, true, true));
 		}
 		bindings.add("GLFWInput", GLFWInputWrapper.MAP.get());
-	}
-
-	@Override
-	public void registerClientRuntimeBindings(BindingRegistry bindings) {
-		bindings.add("Client", Minecraft.getInstance());
 	}
 
 	@Override

--- a/src/main/java/dev/latvian/mods/kubejs/script/BindingRegistry.java
+++ b/src/main/java/dev/latvian/mods/kubejs/script/BindingRegistry.java
@@ -1,6 +1,11 @@
 package dev.latvian.mods.kubejs.script;
 
+import dev.latvian.mods.rhino.BaseFunction;
+import dev.latvian.mods.rhino.Context;
 import dev.latvian.mods.rhino.Scriptable;
+import dev.latvian.mods.rhino.ScriptableObject;
+
+import java.util.function.Supplier;
 
 public record BindingRegistry(KubeJSContext context, Scriptable scope) {
 	public ScriptType type() {
@@ -10,6 +15,34 @@ public record BindingRegistry(KubeJSContext context, Scriptable scope) {
 	public void add(String name, Object value) {
 		if (value != null) {
 			context.addToScope(scope, name, value);
+		}
+	}
+
+	public void addLazy(String name, Supplier<?> supplier) {
+		var descriptor = context.newObject(scope);
+		descriptor.put(context, "get", descriptor, new BaseFunction(scope, ScriptableObject.getFunctionPrototype(scope, context)) {
+			private Object value;
+
+			@Override
+			public Object call(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+				if (value == null) {
+					var supplied = supplier.get();
+
+					if (supplied != null) {
+						value = supplied;
+					}
+
+					return supplied;
+				}
+
+				return value;
+			}
+		});
+		descriptor.put(context, "enumerable", descriptor, true);
+		descriptor.put(context, "configurable", descriptor, true);
+
+		if (scope instanceof ScriptableObject object && descriptor instanceof ScriptableObject descriptorObject) {
+			object.defineOwnProperty(context, name, descriptorObject);
 		}
 	}
 }

--- a/src/main/java/dev/latvian/mods/kubejs/script/BindingRegistry.java
+++ b/src/main/java/dev/latvian/mods/kubejs/script/BindingRegistry.java
@@ -1,7 +1,9 @@
 package dev.latvian.mods.kubejs.script;
 
+import dev.latvian.mods.kubejs.util.Lazy;
 import dev.latvian.mods.rhino.BaseFunction;
 import dev.latvian.mods.rhino.Context;
+import dev.latvian.mods.rhino.NativeJavaClass;
 import dev.latvian.mods.rhino.Scriptable;
 import dev.latvian.mods.rhino.ScriptableObject;
 
@@ -12,37 +14,48 @@ public record BindingRegistry(KubeJSContext context, Scriptable scope) {
 		return context.getType();
 	}
 
+	/// Adds a value to the script scope when it is not null.
 	public void add(String name, Object value) {
 		if (value != null) {
 			context.addToScope(scope, name, value);
 		}
 	}
 
+	/// Adds a property with a getter that lazily resolves the supplied value when read.
+	/// Null results are not cached, allowing a later read to resolve the value again.
 	public void addLazy(String name, Supplier<?> supplier) {
-		var descriptor = context.newObject(scope);
-		descriptor.put(context, "get", descriptor, new BaseFunction(scope, ScriptableObject.getFunctionPrototype(scope, context)) {
-			private Object value;
+		var lazy = Lazy.of(() -> {
+			var value = supplier.get();
 
-			@Override
-			public Object call(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
-				if (value == null) {
-					var supplied = supplier.get();
+			if (value == null) {
+				return null;
+			}
 
-					if (supplied != null) {
-						value = supplied;
+			return value instanceof Class<?> c ? new NativeJavaClass(context, BindingRegistry.this.scope, c) : context.javaToJS(value, BindingRegistry.this.scope);
+		});
+
+		if (scope instanceof ScriptableObject object) {
+			var getter = new BaseFunction(scope, ScriptableObject.getFunctionPrototype(scope, context)) {
+				@Override
+				public Object call(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+					var value = lazy.get();
+
+					if (value == null) {
+						// Avoid caching early null values forever, e.g., Minecraft#getInstance before client init
+						lazy.forget();
+						return null;
 					}
 
-					return supplied;
+					// Hand it over to add() as a normal global once the lazy getter is no longer needed
+					object.delete(context, name);
+					add(name, value);
+					return value;
 				}
+			};
 
-				return value;
-			}
-		});
-		descriptor.put(context, "enumerable", descriptor, true);
-		descriptor.put(context, "configurable", descriptor, true);
-
-		if (scope instanceof ScriptableObject object && descriptor instanceof ScriptableObject descriptorObject) {
-			object.defineOwnProperty(context, name, descriptorObject);
+			// Allow scripters to reference the binding before the value exists via the temporary getter
+			object.setGetterOrSetter(context, name, 0, getter, false);
+			object.setAttributes(context, name, ScriptableObject.EMPTY);
 		}
 	}
 }

--- a/src/main/java/dev/latvian/mods/kubejs/script/ScriptManager.java
+++ b/src/main/java/dev/latvian/mods/kubejs/script/ScriptManager.java
@@ -83,17 +83,6 @@ public class ScriptManager {
 		KubeJSPlugins.forEachPlugin(this, KubeJSPlugin::afterScriptsLoaded);
 	}
 
-	public void addClientRuntimeBindings() {
-		if (contextFactory != null) {
-			var cx = (KubeJSContext) contextFactory.enter();
-			var bindings = new BindingRegistry(cx, cx.topLevelScope);
-
-			for (var plugin : KubeJSPlugins.getAll()) {
-				plugin.registerClientRuntimeBindings(bindings);
-			}
-		}
-	}
-
 	public void collectScripts(ScriptPack pack, Path dir, String path) {
 		if (!path.isEmpty() && !path.endsWith("/")) {
 			path += "/";


### PR DESCRIPTION
This reverts #1145 in favor of a more robust lazy initialization of the Client binding, initializing a lazy reference and storing it on the first call it isn't null. The issue with the previous fix was that it added the binding later from client setup, but that could target a different Rhino context/scope than the one startup scripts were loaded with, so existing startup event callbacks still couldn't resolve `Client`. 

This keeps `Client` registered in the original script scope while avoiding the early `Minecraft.getInstance()` null timing issue.