### PR TITLE
Fix item and block-item tinting asset generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Builders now generate the required model data for item and block-item tinting (#1156)
 - Fix `Client` binding not being available from startup/client scripts (#1152)
 - Fixed circular initialization between ConsoleJS and ScriptType before script consoles are ready (#1147)
 - Fixed creative tab modification not firing correctly (#1149)

--- a/src/main/java/dev/latvian/mods/kubejs/block/BlockBuilder.java
+++ b/src/main/java/dev/latvian/mods/kubejs/block/BlockBuilder.java
@@ -235,17 +235,17 @@ public abstract class BlockBuilder extends ModelledBuilderBase<Block> {
 		generateBlockModels(generator);
 
 		if (itemBuilder != null) {
-			int maxTintIndex = -1;
-
-			if (itemBuilder.tint != null) {
-				maxTintIndex = itemBuilder.tint.getMaxTintIndex();
-			}
+			int maxTintIndex = itemBuilder.tint == null ? -1 : itemBuilder.tint.getMaxTintIndex();
 
 			if (tint != null) {
 				maxTintIndex = Math.max(maxTintIndex, tint.getMaxTintIndex());
 			}
 
-			generator.itemModel(itemBuilder.id, this::generateItemModel, KubeAssetGenerator.createItemTintSources(maxTintIndex));
+			if (itemBuilder.hasCustomModel()) {
+				itemBuilder.generateItemModels(generator, maxTintIndex);
+			} else {
+				generator.itemModel(itemBuilder.id, this::generateItemModel, KubeAssetGenerator.createItemTintSources(maxTintIndex));
+			}
 		}
 	}
 
@@ -296,16 +296,6 @@ public abstract class BlockBuilder extends ModelledBuilderBase<Block> {
 	}
 
 	protected void generateItemModel(ModelGenerator m) {
-		var hasCustomModel = itemBuilder != null &&
-			(itemBuilder.modelGenerator != null ||
-				itemBuilder.parentModel != null ||
-				!itemBuilder.textures.isEmpty() ||
-				!itemBuilder.baseTexture.equals(itemBuilder.id.withPath(ID.ITEM).toString()));
-		if (hasCustomModel) {
-			itemBuilder.generateItemModel(m);
-			return;
-		}
-
 		m.parent(id.withPath(ID.BLOCK));
 	}
 

--- a/src/main/java/dev/latvian/mods/kubejs/block/BlockBuilder.java
+++ b/src/main/java/dev/latvian/mods/kubejs/block/BlockBuilder.java
@@ -235,16 +235,10 @@ public abstract class BlockBuilder extends ModelledBuilderBase<Block> {
 		generateBlockModels(generator);
 
 		if (itemBuilder != null) {
-			int maxTintIndex = itemBuilder.tint == null ? -1 : itemBuilder.tint.getMaxTintIndex();
-
-			if (tint != null) {
-				maxTintIndex = Math.max(maxTintIndex, tint.getMaxTintIndex());
-			}
-
 			if (itemBuilder.hasCustomModel()) {
-				itemBuilder.generateItemModels(generator, maxTintIndex);
+				itemBuilder.generateItemModels(generator);
 			} else {
-				generator.itemModel(itemBuilder.id, this::generateItemModel, KubeAssetGenerator.createItemTintSources(maxTintIndex));
+				generator.itemModel(itemBuilder.id, this::generateItemModel, KubeAssetGenerator.createItemTintSources(itemBuilder.getMaxTintIndex()));
 			}
 		}
 	}

--- a/src/main/java/dev/latvian/mods/kubejs/block/BlockBuilder.java
+++ b/src/main/java/dev/latvian/mods/kubejs/block/BlockBuilder.java
@@ -235,7 +235,17 @@ public abstract class BlockBuilder extends ModelledBuilderBase<Block> {
 		generateBlockModels(generator);
 
 		if (itemBuilder != null) {
-			generator.itemModel(itemBuilder.id, this::generateItemModel);
+			int maxTintIndex = -1;
+
+			if (itemBuilder.tint != null) {
+				maxTintIndex = itemBuilder.tint.getMaxTintIndex();
+			}
+
+			if (tint != null) {
+				maxTintIndex = Math.max(maxTintIndex, tint.getMaxTintIndex());
+			}
+
+			generator.itemModel(itemBuilder.id, this::generateItemModel, KubeAssetGenerator.createItemTintSources(maxTintIndex));
 		}
 	}
 
@@ -286,6 +296,16 @@ public abstract class BlockBuilder extends ModelledBuilderBase<Block> {
 	}
 
 	protected void generateItemModel(ModelGenerator m) {
+		var hasCustomModel = itemBuilder != null &&
+			(itemBuilder.modelGenerator != null ||
+				itemBuilder.parentModel != null ||
+				!itemBuilder.textures.isEmpty() ||
+				!itemBuilder.baseTexture.equals(itemBuilder.id.withPath(ID.ITEM).toString()));
+		if (hasCustomModel) {
+			itemBuilder.generateItemModel(m);
+			return;
+		}
+
 		m.parent(id.withPath(ID.BLOCK));
 	}
 

--- a/src/main/java/dev/latvian/mods/kubejs/block/BlockTintFunction.java
+++ b/src/main/java/dev/latvian/mods/kubejs/block/BlockTintFunction.java
@@ -30,6 +30,10 @@ public interface BlockTintFunction {
 	@Nullable
 	KubeColor getColor(BlockState state, @Nullable BlockAndTintGetter level, @Nullable BlockPos pos, int index);
 
+	default int getMaxTintIndex() {
+		return 0;
+	}
+
 	record Fixed(KubeColor color) implements BlockTintFunction {
 		@Override
 		public KubeColor getColor(BlockState state, @Nullable BlockAndTintGetter level, @Nullable BlockPos pos, int index) {
@@ -44,6 +48,17 @@ public interface BlockTintFunction {
 		public @Nullable KubeColor getColor(BlockState state, @Nullable BlockAndTintGetter level, @Nullable BlockPos pos, int index) {
 			var f = map.get(index);
 			return f == null ? null : f.getColor(state, level, pos, index);
+		}
+
+		@Override
+		public int getMaxTintIndex() {
+			int maxIndex = 0;
+
+			for (var entry : map.int2ObjectEntrySet()) {
+				maxIndex = Math.max(maxIndex, entry.getIntKey());
+			}
+
+			return maxIndex;
 		}
 	}
 

--- a/src/main/java/dev/latvian/mods/kubejs/client/ItemTintFunctionWrapper.java
+++ b/src/main/java/dev/latvian/mods/kubejs/client/ItemTintFunctionWrapper.java
@@ -23,11 +23,7 @@ public record ItemTintFunctionWrapper(int index) implements ItemTintSource {
 		var builder = item.kjs$getItemBuilder();
 
 		if (builder != null) {
-			var c = builder.tint == null ? null : builder.tint.getColor(stack, index);
-
-			if (c == null) {
-				c = ItemTintFunction.BLOCK.getColor(stack, index);
-			}
+			var c = builder.tint == null ? ItemTintFunction.BLOCK.getColor(stack, index) : builder.tint.getColor(stack, index);
 
 			if (c != null) {
 				return c.kjs$getARGB();

--- a/src/main/java/dev/latvian/mods/kubejs/client/ItemTintFunctionWrapper.java
+++ b/src/main/java/dev/latvian/mods/kubejs/client/ItemTintFunctionWrapper.java
@@ -3,6 +3,7 @@ package dev.latvian.mods.kubejs.client;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import dev.latvian.mods.kubejs.item.ItemTintFunction;
 import net.minecraft.client.color.item.ItemTintSource;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.world.entity.LivingEntity;
@@ -21,9 +22,16 @@ public record ItemTintFunctionWrapper(int index) implements ItemTintSource {
 		var item = stack.getItem();
 		var builder = item.kjs$getItemBuilder();
 
-		if (builder != null && builder.tint != null) {
-			var c = builder.tint.getColor(stack, index);
-			return c == null ? 0xFFFFFFFF : c.kjs$getARGB();
+		if (builder != null) {
+			var c = builder.tint == null ? null : builder.tint.getColor(stack, index);
+
+			if (c == null) {
+				c = ItemTintFunction.BLOCK.getColor(stack, index);
+			}
+
+			if (c != null) {
+				return c.kjs$getARGB();
+			}
 		}
 
 		return 0xFFFFFFFF;

--- a/src/main/java/dev/latvian/mods/kubejs/client/KubeJSClientEventHandler.java
+++ b/src/main/java/dev/latvian/mods/kubejs/client/KubeJSClientEventHandler.java
@@ -115,14 +115,7 @@ public class KubeJSClientEventHandler {
 				var tintSources = new ArrayList<@Nullable BlockTintSource>();
 
 				if (b.tint instanceof BlockTintFunction.Mapped mapped) {
-					int maxIndex = 0;
-					for (var entry : mapped.map.int2ObjectEntrySet()) {
-						int key = entry.getIntKey();
-						if (key > maxIndex) {
-							maxIndex = key;
-						}
-					}
-					for (int i = 0; i <= maxIndex; i++) {
+					for (int i = 0; i <= mapped.getMaxTintIndex(); i++) {
 						var func = mapped.map.get(i);
 						tintSources.add(func == null ? null : new BlockTintFunctionWrapper(func, i));
 					}

--- a/src/main/java/dev/latvian/mods/kubejs/fluid/FluidBucketItemBuilder.java
+++ b/src/main/java/dev/latvian/mods/kubejs/fluid/FluidBucketItemBuilder.java
@@ -20,7 +20,7 @@ public class FluidBucketItemBuilder extends ItemBuilder {
 
 	@Override
 	public void generateAssets(KubeAssetGenerator generator) {
-		if (modelGenerator != null || parentModel != null || !textures.isEmpty()) {
+		if (hasCustomModel()) {
 			super.generateAssets(generator);
 		}
 	}

--- a/src/main/java/dev/latvian/mods/kubejs/fluid/FluidBuilder.java
+++ b/src/main/java/dev/latvian/mods/kubejs/fluid/FluidBuilder.java
@@ -215,10 +215,6 @@ public class FluidBuilder extends BuilderBase<FlowingFluid> {
 				m.texture("bucket_fluid", fluidPath.toString());
 			});
 
-			var modelRef = new JsonObject();
-			modelRef.addProperty("type", "minecraft:model");
-			modelRef.addProperty("model", bucketItem.id.withPath(ID.ITEM).toString());
-
 			var tints = new JsonArray();
 
 			var baseTint = new JsonObject();
@@ -237,11 +233,7 @@ public class FluidBuilder extends BuilderBase<FlowingFluid> {
 			fluidTint.addProperty("value", tintColor != null ? tintColor.kjs$getARGB() : -1);
 			tints.add(fluidTint);
 
-			modelRef.add("tints", tints);
-
-			var def = new JsonObject();
-			def.add("model", modelRef);
-			generator.json(bucketItem.id.withPath(ID.ITEM_DEFINITION), def);
+			generator.itemDefinition(bucketItem.id, bucketItem.id.withPath(ID.ITEM), tints);
 		}
 	}
 }

--- a/src/main/java/dev/latvian/mods/kubejs/generator/KubeAssetGenerator.java
+++ b/src/main/java/dev/latvian/mods/kubejs/generator/KubeAssetGenerator.java
@@ -1,5 +1,6 @@
 package dev.latvian.mods.kubejs.generator;
 
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import dev.latvian.mods.kubejs.client.LoadedTexture;
 import dev.latvian.mods.kubejs.client.ModelGenerator;
@@ -13,6 +14,7 @@ import dev.latvian.mods.kubejs.script.data.GeneratedData;
 import dev.latvian.mods.kubejs.util.ID;
 import net.minecraft.resources.Identifier;
 import net.minecraft.util.Util;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Map;
 import java.util.function.Consumer;
@@ -43,15 +45,44 @@ public interface KubeAssetGenerator extends KubeResourceGenerator {
 	}
 
 	default void itemModel(Identifier id, Consumer<ModelGenerator> consumer) {
+		itemModel(id, consumer, null);
+	}
+
+	default void itemModel(Identifier id, Consumer<ModelGenerator> consumer, @Nullable JsonArray tints) {
 		var gen = Util.make(new ModelGenerator(), consumer);
 		json(id.withPath(ID.ITEM_MODEL), gen.toJson());
+		itemDefinition(id, id.withPath(ID.ITEM), tints);
+	}
 
+	default void itemDefinition(Identifier id, Identifier model, @Nullable JsonArray tints) {
 		var modelRef = new JsonObject();
 		modelRef.addProperty("type", "minecraft:model");
-		modelRef.addProperty("model", id.withPath(ID.ITEM).toString());
+		modelRef.addProperty("model", model.toString());
+
+		if (tints != null) {
+			modelRef.add("tints", tints);
+		}
+
 		var def = new JsonObject();
 		def.add("model", modelRef);
 		json(id.withPath(ID.ITEM_DEFINITION), def);
+	}
+
+	static @Nullable JsonArray createItemTintSources(int maxTintIndex) {
+		if (maxTintIndex < 0) {
+			return null;
+		}
+
+		var tints = new JsonArray();
+
+		for (int i = 0; i <= maxTintIndex; i++) {
+			var tintSource = new JsonObject();
+			tintSource.addProperty("type", "kubejs:tint");
+			tintSource.addProperty("index", i);
+			tints.add(tintSource);
+		}
+
+		return tints;
 	}
 
 	default void defaultItemModel(Identifier id) {

--- a/src/main/java/dev/latvian/mods/kubejs/item/ItemBuilder.java
+++ b/src/main/java/dev/latvian/mods/kubejs/item/ItemBuilder.java
@@ -1,6 +1,5 @@
 package dev.latvian.mods.kubejs.item;
 
-import dev.latvian.mods.kubejs.client.ModelGenerator;
 import dev.latvian.mods.kubejs.color.KubeColor;
 import dev.latvian.mods.kubejs.component.DataComponentWrapper;
 import dev.latvian.mods.kubejs.generator.KubeAssetGenerator;
@@ -117,27 +116,33 @@ public class ItemBuilder extends ModelledBuilderBase<Item> {
 
 	@Override
 	public void generateAssets(KubeAssetGenerator generator) {
-		generateItemModels(generator);
-	}
-
-	protected void generateItemModels(KubeAssetGenerator generator) {
-		generator.itemModel(id, this::generateItemModel, KubeAssetGenerator.createItemTintSources(tint == null ? -1 : tint.getMaxTintIndex()));
+		generateItemModels(generator, tint == null ? -1 : tint.getMaxTintIndex());
 	}
 
 	@HideFromJS
-	public void generateItemModel(ModelGenerator model) {
-		if (modelGenerator != null) {
-			modelGenerator.accept(model);
-			return;
-		}
+	public void generateItemModels(KubeAssetGenerator generator, int maxTintIndex) {
+		generator.itemModel(id, model -> {
+			if (modelGenerator != null) {
+				modelGenerator.accept(model);
+				return;
+			}
 
-		model.parent(parentModel != null ? parentModel : KubeAssetGenerator.GENERATED_ITEM_MODEL);
+			model.parent(parentModel != null ? parentModel : KubeAssetGenerator.GENERATED_ITEM_MODEL);
 
-		if (textures.isEmpty()) {
-			model.texture("layer0", baseTexture);
-		} else {
-			model.textures(textures);
-		}
+			if (textures.isEmpty()) {
+				model.texture("layer0", baseTexture);
+			} else {
+				model.textures(textures);
+			}
+		}, KubeAssetGenerator.createItemTintSources(maxTintIndex));
+	}
+
+	@HideFromJS
+	public boolean hasCustomModel() {
+		return modelGenerator != null ||
+			parentModel != null ||
+			!textures.isEmpty() ||
+			!baseTexture.equals(id.withPath(ID.ITEM).toString());
 	}
 
 	public <T> ItemBuilder component(DataComponentType<T> type, T value) {

--- a/src/main/java/dev/latvian/mods/kubejs/item/ItemBuilder.java
+++ b/src/main/java/dev/latvian/mods/kubejs/item/ItemBuilder.java
@@ -1,5 +1,6 @@
 package dev.latvian.mods.kubejs.item;
 
+import dev.latvian.mods.kubejs.client.ModelGenerator;
 import dev.latvian.mods.kubejs.color.KubeColor;
 import dev.latvian.mods.kubejs.component.DataComponentWrapper;
 import dev.latvian.mods.kubejs.generator.KubeAssetGenerator;
@@ -9,6 +10,7 @@ import dev.latvian.mods.kubejs.script.ConsoleJS;
 import dev.latvian.mods.kubejs.typings.Info;
 import dev.latvian.mods.kubejs.util.ID;
 import dev.latvian.mods.kubejs.util.TickDuration;
+import dev.latvian.mods.rhino.util.HideFromJS;
 import dev.latvian.mods.rhino.util.ReturnsSelf;
 import net.minecraft.core.component.DataComponentType;
 import net.minecraft.core.component.DataComponents;
@@ -119,20 +121,23 @@ public class ItemBuilder extends ModelledBuilderBase<Item> {
 	}
 
 	protected void generateItemModels(KubeAssetGenerator generator) {
-		generator.itemModel(id, m -> {
-			if (modelGenerator != null) {
-				modelGenerator.accept(m);
-				return;
-			}
+		generator.itemModel(id, this::generateItemModel, KubeAssetGenerator.createItemTintSources(tint == null ? -1 : tint.getMaxTintIndex()));
+	}
 
-			m.parent(parentModel != null ? parentModel : KubeAssetGenerator.GENERATED_ITEM_MODEL);
+	@HideFromJS
+	public void generateItemModel(ModelGenerator model) {
+		if (modelGenerator != null) {
+			modelGenerator.accept(model);
+			return;
+		}
 
-			if (textures.isEmpty()) {
-				m.texture("layer0", baseTexture);
-			} else {
-				m.textures(textures);
-			}
-		});
+		model.parent(parentModel != null ? parentModel : KubeAssetGenerator.GENERATED_ITEM_MODEL);
+
+		if (textures.isEmpty()) {
+			model.texture("layer0", baseTexture);
+		} else {
+			model.textures(textures);
+		}
 	}
 
 	public <T> ItemBuilder component(DataComponentType<T> type, T value) {

--- a/src/main/java/dev/latvian/mods/kubejs/item/ItemBuilder.java
+++ b/src/main/java/dev/latvian/mods/kubejs/item/ItemBuilder.java
@@ -1,5 +1,6 @@
 package dev.latvian.mods.kubejs.item;
 
+import dev.latvian.mods.kubejs.block.BlockItemBuilder;
 import dev.latvian.mods.kubejs.color.KubeColor;
 import dev.latvian.mods.kubejs.component.DataComponentWrapper;
 import dev.latvian.mods.kubejs.generator.KubeAssetGenerator;
@@ -116,11 +117,11 @@ public class ItemBuilder extends ModelledBuilderBase<Item> {
 
 	@Override
 	public void generateAssets(KubeAssetGenerator generator) {
-		generateItemModels(generator, tint == null ? -1 : tint.getMaxTintIndex());
+		generateItemModels(generator);
 	}
 
 	@HideFromJS
-	public void generateItemModels(KubeAssetGenerator generator, int maxTintIndex) {
+	public void generateItemModels(KubeAssetGenerator generator) {
 		generator.itemModel(id, model -> {
 			if (modelGenerator != null) {
 				modelGenerator.accept(model);
@@ -134,7 +135,7 @@ public class ItemBuilder extends ModelledBuilderBase<Item> {
 			} else {
 				model.textures(textures);
 			}
-		}, KubeAssetGenerator.createItemTintSources(maxTintIndex));
+		}, KubeAssetGenerator.createItemTintSources(getMaxTintIndex()));
 	}
 
 	@HideFromJS
@@ -143,6 +144,17 @@ public class ItemBuilder extends ModelledBuilderBase<Item> {
 			parentModel != null ||
 			!textures.isEmpty() ||
 			!baseTexture.equals(id.withPath(ID.ITEM).toString());
+	}
+
+	@HideFromJS
+	public int getMaxTintIndex() {
+		int maxTintIndex = tint == null ? -1 : tint.getMaxTintIndex();
+
+		if (this instanceof BlockItemBuilder blockItemBuilder && blockItemBuilder.blockBuilder.tint != null) {
+			maxTintIndex = Math.max(maxTintIndex, blockItemBuilder.blockBuilder.tint.getMaxTintIndex());
+		}
+
+		return maxTintIndex;
 	}
 
 	public <T> ItemBuilder component(DataComponentType<T> type, T value) {

--- a/src/main/java/dev/latvian/mods/kubejs/item/ItemTintFunction.java
+++ b/src/main/java/dev/latvian/mods/kubejs/item/ItemTintFunction.java
@@ -23,6 +23,10 @@ public interface ItemTintFunction {
 
 	@Nullable KubeColor getColor(ItemStack stack, int index);
 
+	default int getMaxTintIndex() {
+		return 0;
+	}
+
 	record Fixed(KubeColor color) implements ItemTintFunction {
 		@Override
 		public KubeColor getColor(ItemStack stack, int index) {
@@ -38,6 +42,17 @@ public interface ItemTintFunction {
 		public KubeColor getColor(ItemStack stack, int index) {
 			var f = map.get(index);
 			return f == null ? null : f.getColor(stack, index);
+		}
+
+		@Override
+		public int getMaxTintIndex() {
+			int maxIndex = 0;
+
+			for (var entry : map.int2ObjectEntrySet()) {
+				maxIndex = Math.max(maxIndex, entry.getIntKey());
+			}
+
+			return maxIndex;
 		}
 	}
 


### PR DESCRIPTION
This fixes `ItemBuilder#color` and block-item `color()` by generating the newly required `tints` sources in the item definition assets.
We also properly account for models with multiple tint overlays. This is done by computing the highest tint index used by the item or inherited block tint, then generating enough tint entries for the model.